### PR TITLE
Fix CORE-5174

### DIFF
--- a/src/jrd/tra.cpp
+++ b/src/jrd/tra.cpp
@@ -3560,8 +3560,8 @@ void jrd_tra::rollbackToSavepoint(thread_db* tdbb, SLONG number)
  **************************************/
 {
 	// merge all but one folowing savepoints into one
-	while(tra_save_point && tra_save_point->sav_next &&
-		  tra_save_point->sav_next->sav_number >= number)
+	while(tra_save_point && tra_save_point->sav_number > number &&
+		  tra_save_point->sav_next && tra_save_point->sav_next->sav_number >= number)
 	{
 		rollforwardSavepoint(tdbb);
 	}


### PR DESCRIPTION
Take into account possible reverse of savepoint number sequence in short chains.
Example: 
For savepoints sequence "12 -> 14 -> 7 -> 1" request to rollback savepoints up to 12, must result in "14 -> 7 -> 1", not "7 -> 1" as it might happen before this fix.
