### PR TITLE
If fakeroot available use it for creating linux install image

### DIFF
--- a/builds/install/arch-specific/linux/Makefile.in
+++ b/builds/install/arch-specific/linux/Makefile.in
@@ -86,7 +86,7 @@ $(DebugFile) :  buildImageDir
 	(cd $(GEN_ROOT)/$(DebugDir); tar -czf ../$(DebugFile) .)
 
 buildRoot:
-	(cd $(GEN_ROOT); ./install/makeInstallImage.sh)
+	command -v fakeroot > /dev/null 2> /dev/null && (cd $(GEN_ROOT); fakeroot ./install/makeInstallImage.sh) || (cd $(GEN_ROOT); ./install/makeInstallImage.sh)
 
 buildDebugInfo: buildRoot
 	mkdir -p $(GEN_ROOT)/$(DebugDir)


### PR DESCRIPTION
These changes allow to execute 'make dist' without need of root. 'make install' of course still need root.

This piece of code is same in 2.5/3.0 so it can be used there to.
