### PR TITLE
mk/4.0/gcc6

### DIFF
--- a/src/common/classes/alloc.h
+++ b/src/common/classes/alloc.h
@@ -331,6 +331,16 @@ inline void operator delete[](void* mem, Firebird::MemoryPool& pool ALLOC_PARAMS
 	MemoryPool::globalFree(mem);
 }
 
+#if __cplusplus >= 201402L
+inline void operator delete(void* mem, std::size_t s ALLOC_PARAMS) throw()
+{
+	MemoryPool::globalFree(mem);
+}
+inline void operator delete[](void* mem, std::size_t s ALLOC_PARAMS) throw()
+{
+	MemoryPool::globalFree(mem);
+}
+#endif
 #ifdef DEBUG_GDS_ALLOC
 
 #ifdef __clang__

--- a/src/gpre/sqe.cpp
+++ b/src/gpre/sqe.cpp
@@ -1733,11 +1733,11 @@ static gpre_ctx* par_alias_list( gpre_req* request, gpre_nod* alias_list)
 			}
 		}
 
-		if (!context)
-		{
-			fb_utils::snprintf(error_string, sizeof(error_string),
-				"there is no alias or table named %s at this scope level",
-				(TEXT*) *arg);
+	if (!context)
+	{
+		fb_utils::snprintf(error_string, sizeof(error_string),
+			"there is no alias or table named %s at this scope level",
+			(TEXT*) *arg);
 		PAR_error(error_string);
 	}
 


### PR DESCRIPTION
First patch allows to build with gcc6 in C++14 mode without -fno-sized-deallocation option. Second fixes a misleading indentation gcc6 warns about.
