### PR TITLE
Allow to enforce IPv4 or IPv6 in URL-like connection string.

### DIFF
--- a/doc/README.IPv6
+++ b/doc/README.IPv6
@@ -22,6 +22,19 @@ If a domain name is used in connection string, all addresses (IPv4 and IPv6)
 are tried in the order returned by resolver until a connection is established.
 Only if all attempts fail, the client fails to connect.
 
+New URL-style connection string format (see README.connection_strings) allows
+to restrict name lookup to only IPv4 or IPv6 addresses:
+
+  connect 'inet://server.example.org/test';
+  connect 'inet4://server.example.org/test';
+  connect 'inet6://server.example.org/test';
+
+First example tries all addresses, second only IPv4 ones, third only IPv6
+ones. This can be used to avoid connection delays on systems where name lookup
+returns IPv6 addresses for some host names but attempts to connect to them
+time out rather than failing immediatelly (as reported, this can happen even
+for name "localhost" on some systems).
+
 
 Server
 ------

--- a/doc/README.connection_strings
+++ b/doc/README.connection_strings
@@ -107,6 +107,13 @@ Examples:
     inet://myserver:fb_db/mydb
     inet://localhost:fb_db/mydb
 
+  The "inet" protocol can be replaced by "inet4" or "inet6" to restrict client
+  to IPv4 or IPv6 addresses corresponding to supplied name ("inet" protocol
+  tries all addresses in the order determined by OS):
+
+    inet4://myserver/mydb
+    inet6://myserver/mydb
+
   Connect via named pipes:
 
     wnet://myserver/C:\db\mydb.fdb

--- a/src/remote/client/interface.cpp
+++ b/src/remote/client/interface.cpp
@@ -92,6 +92,8 @@
 
 
 const char* const PROTOCOL_INET = "inet";
+const char* const PROTOCOL_INET4 = "inet4";
+const char* const PROTOCOL_INET6 = "inet6";
 const char* const PROTOCOL_WNET = "wnet";
 const char* const PROTOCOL_XNET = "xnet";
 
@@ -5419,6 +5421,7 @@ static rem_port* analyze(ClntAuthBlock& cBlock, PathName& attach_name, unsigned 
  **************************************/
 
 	rem_port* port = NULL;
+	int inet_af = AF_UNSPEC;
 
 	cBlock.loadClnt(pb, &parSet);
 	authenticateStep0(cBlock);
@@ -5443,7 +5446,12 @@ static rem_port* analyze(ClntAuthBlock& cBlock, PathName& attach_name, unsigned 
 	else
 #endif
 
-	if (ISC_analyze_protocol(PROTOCOL_INET, attach_name, node_name, INET_SEPARATOR) ||
+	if (ISC_analyze_protocol(PROTOCOL_INET4, attach_name, node_name, INET_SEPARATOR))
+		inet_af = AF_INET;
+	else if (ISC_analyze_protocol(PROTOCOL_INET6, attach_name, node_name, INET_SEPARATOR))
+		inet_af = AF_INET6;
+	if (inet_af != AF_UNSPEC ||
+		ISC_analyze_protocol(PROTOCOL_INET, attach_name, node_name, INET_SEPARATOR) ||
 		ISC_analyze_tcp(attach_name, node_name))
 	{
 		if (node_name.isEmpty())
@@ -5455,7 +5463,7 @@ static rem_port* analyze(ClntAuthBlock& cBlock, PathName& attach_name, unsigned 
 		}
 
 		port = INET_analyze(&cBlock, attach_name, node_name.c_str(), flags & ANALYZE_UV, pb,
-			cBlock.getConfig(), ref_db_name);
+			cBlock.getConfig(), ref_db_name, inet_af);
 	}
 
 	// We have a local connection string. If it's a file on a network share,

--- a/src/remote/inet_proto.h
+++ b/src/remote/inet_proto.h
@@ -34,9 +34,10 @@ namespace Firebird
 }
 
 rem_port*	INET_analyze(ClntAuthBlock*, const Firebird::PathName&, const TEXT*,
-						 bool, Firebird::ClumpletReader&, Firebird::RefPtr<Config>*, const Firebird::PathName*);
+						 bool, Firebird::ClumpletReader&, Firebird::RefPtr<Config>*,
+						 const Firebird::PathName*, int af = AF_UNSPEC);
 rem_port*	INET_connect(const TEXT*, struct packet*, USHORT, Firebird::ClumpletReader*,
-						 Firebird::RefPtr<Config>*);
+						 Firebird::RefPtr<Config>*, int af = AF_UNSPEC);
 rem_port*	INET_reconnect(SOCKET);
 rem_port*	INET_server(SOCKET);
 void		setStopMainThread(FPTR_INT func);


### PR DESCRIPTION
Extend the new (URL like) connection string format by protocols inet4 and inet6 which work exactly like inet except the resolver is asked for only IPv4 or only IPv6 addresses. As discussed on firebird-devel mailing list, this can be used as a workaround on systems where the resolver returns an IPv6 address for a name but an attempt to connect to it times out rather than failing quickly.
