### PR TITLE
Fixed CORE-5233: Fix unaligned memory access in MET_format

### DIFF
--- a/src/jrd/met.epp
+++ b/src/jrd/met.epp
@@ -1480,16 +1480,21 @@ Format* MET_format(thread_db* tdbb, jrd_rel* relation, USHORT number)
 		count = p[0] | (p[1] << 8);
 		p += 2;
 
+		UCharBuffer tmpArray;
 		while (count-- > 0)
 		{
 			USHORT offset = p[0] | (p[1] << 8);
 			p += 2;
 
-			const Ods::Descriptor* odsDflDesc = (Ods::Descriptor*) p;
-			p = (UCHAR*) (odsDflDesc + 1);
+			Ods::Descriptor odsDflDesc;
+			memcpy(&odsDflDesc, p, sizeof(odsDflDesc));
+			p += sizeof(Ods::Descriptor);
 
-			dsc desc = *odsDflDesc;
-			desc.dsc_address = const_cast<UCHAR*>(p);
+			dsc desc = odsDflDesc;
+
+			tmpArray.getBuffer(desc.dsc_length);
+			desc.dsc_address = tmpArray.begin();
+			memcpy(desc.dsc_address, p, desc.dsc_length);
 			EVL_make_value(tdbb, &desc, &format->fmt_defaults[offset], relation->rel_pool);
 
 			p += desc.dsc_length;


### PR DESCRIPTION
This works around the issue by copying into temporary correctly-aligned data structures. It would be nice if this wasn't needed and the data was guaranteed to be correctly aligned, but I don't know if that is possible to do, as it seems this is stored on disk.
