### PR TITLE
Postfix for #24 that fixes CORE-5271

### DIFF
--- a/src/common/os/posix/path_utils.cpp
+++ b/src/common/os/posix/path_utils.cpp
@@ -136,6 +136,12 @@ void PathUtils::concatPath(Firebird::PathName& result,
 		const Firebird::PathName& first,
 		const Firebird::PathName& second)
 {
+	if (first.length() == 0)
+	{
+		result = second;
+		return;
+	}
+
 	result = first;
 
 	// First path used to be from trusted sources like getRootDirectory, etc.

--- a/src/common/os/win32/path_utils.cpp
+++ b/src/common/os/win32/path_utils.cpp
@@ -108,6 +108,12 @@ void PathUtils::concatPath(Firebird::PathName& result,
 		const Firebird::PathName& first,
 		const Firebird::PathName& second)
 {
+	if (first.length() == 0)
+	{
+		result = second;
+		return;
+	}
+
 	result = first;
 
 	// First path used to be from trusted sources like getRootDirectory, etc.


### PR DESCRIPTION
It is hard to imagine a sane code that append non-empty path to an empty one.
