### PR TITLE
Add platform support for m68k

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -354,6 +354,17 @@ dnl CPU_TYPE=ppc64
    SHRLIB_EXT=so
    ;;
 
+  m68k*-*-linux*)
+   MAKEFILE_PREFIX=linux_generic
+   INSTALL_PREFIX=linux
+   PLATFORM=LINUX
+   AC_DEFINE(LINUX, 1, [Define this if OS is Linux])
+   AC_DEFINE(M68K, 1, [Define this if CPU is M68k])
+   LOCK_MANAGER_FLG=Y
+   EDITLINE_FLG=Y
+   SHRLIB_EXT=so
+   ;;
+
   *-*-linux* | *-*-gnu*)
     MAKEFILE_PREFIX=linux_generic
     INSTALL_PREFIX=linux

--- a/configure.in
+++ b/configure.in
@@ -967,10 +967,11 @@ AC_CHECK_MEMBER([struct dirent.d_type],
 dnl EKU: try to determine the alignment of long and double
 dnl      replaces FB_ALIGNMENT and FB_DOUBLE_ALIGN in src/jrd/common.h
 AC_MSG_CHECKING(alignment of long)
-AC_TRY_RUN([main () {
+AC_TRY_RUN([#include <semaphore.h>
+main () {
   struct s {
     char a;
-    long long b;
+    union { long long x; sem_t y; } b;
   };
   exit((int)&((struct s*)0)->b);
 }], ac_cv_c_alignment=$ac_status, ac_cv_c_alignment=$ac_status)

--- a/src/jrd/common.h
+++ b/src/jrd/common.h
@@ -200,7 +200,9 @@
 #define IMPLEMENTATION  isc_info_db_impl_linux_ppc64el	/* 85  */
 #endif /* PPC64EL */
 
-
+#ifdef M68K
+#define IMPLEMENTATION  isc_info_db_impl_linux_m68k	/* 86  */
+#endif /* M68K */
 
 #endif /* LINUX */
 

--- a/src/jrd/inf_pub.h
+++ b/src/jrd/inf_pub.h
@@ -217,6 +217,7 @@ enum  info_db_implementations
 	isc_info_db_impl_linux_alpha = 83,
 	isc_info_db_impl_linux_arm64 = 84,
 	isc_info_db_impl_linux_ppc64el = 85,
+	isc_info_db_impl_linux_m68k = 86,
 
 	isc_info_db_impl_last_value   // Leave this LAST!
 };

--- a/src/jrd/pag.cpp
+++ b/src/jrd/pag.cpp
@@ -165,10 +165,10 @@ static const int CLASS_LINUX_HPPA = 40;		// LINUX/HPPA
 static const int CLASS_LINUX_ALPHA = 41;	// LINUX/ALPHA
 static const int CLASS_LINUX_ARM64 = 42;	// LINUX/ARM64
 static const int CLASS_LINUX_PPC64EL = 43;	// LINUX/PowerPc64EL
-
+static const int CLASS_LINUX_M68K = 44;		// LINUX/M68K
 
 static const int CLASS_MAX10 = CLASS_LINUX_AMD64;	// This should not be changed, no new ports with ODS10
-static const int CLASS_MAX = CLASS_LINUX_PPC64EL;
+static const int CLASS_MAX = CLASS_LINUX_M68K;
 
 // ARCHITECTURE COMPATIBILITY CLASSES
 
@@ -269,8 +269,8 @@ static const ArchitectureType archMatrix[CLASS_MAX + 1] =
 	archBigEndian,    // CLASS_LINUX_HPPA
 	archLittleEndian, // CLASS_LINUX_ALPHA
 	archLittleEndian, // CLASS_LINUX_ARM64
-	archLittleEndian  // CLASS_LINUX_PPC64EL
-
+	archLittleEndian, // CLASS_LINUX_PPC64EL
+	archBigEndian     // CLASS_LINUX_M68K
 };
 
 #ifdef __sun
@@ -338,6 +338,8 @@ const SSHORT CLASS		= CLASS_LINUX_ALPHA;
 const SSHORT CLASS		= CLASS_LINUX_ARM64;
 #elif defined(PPC64EL)
 const SSHORT CLASS		= CLASS_LINUX_PPC64EL;
+#elif defined(M68K)
+const SSHORT CLASS		= CLASS_LINUX_M68K;
 #else
 #error no support on other hardware for Linux
 #endif

--- a/src/jrd/utl.cpp
+++ b/src/jrd/utl.cpp
@@ -229,8 +229,8 @@ static const TEXT* const impl_implementation[] =
 	"Firebird/linux HPPA",			// 82
 	"Firebird/linux ALPHA",			// 83
 	"Firebird/linux ARM64",			// 84
-	"Firebird/linux PPC64EL"		// 85
-
+	"Firebird/linux PPC64EL",		// 85
+	"Firebird/linux M68K"			// 86
 };
 
 


### PR DESCRIPTION
Hello!

This pull request adds generic Linux/m68k platform support to Firebird 2.5. The first patch by me just adds the necessary platform definitions for Linux/m68k while the second patch by Michael Karcher fixes the alignment of 'sem_t' on m68k which is different to the alignment of 'long long' which resulted in the futex system call failing with "The futex facility returned an unexpected error code.Aborted".

See Debian bug report 828141 [1] for more details.

These two patches currently address Firebird 2.5 only since this is the currently used version of Firebird in Debian unstable. We have 3.0 in Debian experimental, but I haven't found the time yet to test Firebird 3.0 on Linux/m68k. However, I am planning to do this within the next days so that I can provide patches against the 3.0 branch and hopefully also master.

Thanks,
Adrian

> [1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=828141
