### PR TITLE
Add platform support for m68k

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1008,10 +1008,11 @@ AC_CHECK_MEMBER([struct dirent.d_type],
 dnl EKU: try to determine the alignment of long and double
 dnl      replaces FB_ALIGNMENT and FB_DOUBLE_ALIGN in src/jrd/common.h
 AC_MSG_CHECKING(alignment of long)
-AC_RUN_IFELSE([AC_LANG_SOURCE([[main () {
+AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <semaphore.h>
+main () {
   struct s {
     char a;
-    long long b;
+    union { long long x; sem_t y; } b;
   };
   exit((int)&((struct s*)0)->b);
 }]])],[ac_cv_c_alignment=$ac_status],[ac_cv_c_alignment=$ac_status],[])

--- a/configure.ac
+++ b/configure.ac
@@ -361,6 +361,17 @@ dnl CPU_TYPE=ppc64
    SHRLIB_EXT=so
    ;;
 
+  m68k*-*-linux*)
+   MAKEFILE_PREFIX=linux_generic
+   INSTALL_PREFIX=linux
+   PLATFORM=LINUX
+   AC_DEFINE(LINUX, 1, [Define this if OS is Linux])
+   AC_DEFINE(M68K, 1, [Define this if CPU is M68k])
+   LOCK_MANAGER_FLG=Y
+   EDITLINE_FLG=Y
+   SHRLIB_EXT=so
+   ;;
+
   *-*-linux* | *-*-gnu*)
     MAKEFILE_PREFIX=linux_generic
     INSTALL_PREFIX=linux

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -195,6 +195,10 @@
 #define FB_CPU CpuPowerPc64
 #endif /* PPC64 */
 
+#ifdef M68K
+#define FB_CPU CpuM68k
+#endif /* M68K */
+
 #endif /* LINUX */
 
 

--- a/src/jrd/inf_pub.h
+++ b/src/jrd/inf_pub.h
@@ -241,6 +241,7 @@ enum  info_db_implementations
 	isc_info_db_impl_linux_arm64 = 84,
 	isc_info_db_impl_linux_ppc64el = 85,
 	isc_info_db_impl_linux_ppc64 = 86,
+	isc_info_db_impl_linux_m68k = 87,
 
 
 	isc_info_db_impl_last_value   // Leave this LAST!


### PR DESCRIPTION
Hello!

As discussed in #39, here's my patch for adding Linux/m68k support for the B3_0_Release branch.

One thing I'm a bit unsure about is the fact that I have defined isc_info_db_impl_linux_m68k in the 2.5 branch as 86 while it's now 87 in the 3.0 and master branch since these had support added for ppc64 which took the 86. Will this create any problems except that maybe databases created on Linux/m68k Firebird 2.5 would not work on Linux/m68k Firebird 3.0 - which we wouldn't care about really.

Thanks,
Adrian
