### PR TITLE
Fixed deletion of existing backup file when backup is unsuccessful

### DIFF
--- a/src/burp/burp.cpp
+++ b/src/burp/burp.cpp
@@ -1304,11 +1304,12 @@ int gbak(Firebird::UtilSvc* uSvc)
 			if (file->fil_fd != INVALID_HANDLE_VALUE)
 			{
 				close_platf(file->fil_fd);
-			}
-			if (exit_code != FINI_OK &&
-				(tdgbl->action->act_action == ACT_backup_split || tdgbl->action->act_action == ACT_backup))
-			{
-				unlink_platf(tdgbl->toSystem(file->fil_name).c_str());
+				
+				if (exit_code != FINI_OK &&
+					(tdgbl->action->act_action == ACT_backup_split || tdgbl->action->act_action == ACT_backup))
+				{
+					unlink_platf(tdgbl->toSystem(file->fil_name).c_str());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Without these changes the existing backup file can be deleted even if it wasn't overwritten. For example, it happens when gbak is interrupted if its options are set incorrectly.
