### PR TITLE
fix gcc build with -std=c++11 on i386

### DIFF
--- a/src/common/common.h
+++ b/src/common/common.h
@@ -126,7 +126,7 @@
 #define FB_CPU CpuPowerPc
 #endif
 
-#ifdef i386
+#if defined(i386) || defined(__i386__)
 #define I386
 #define FB_CPU CpuIntel
 #endif /* i386 */
@@ -230,7 +230,7 @@
 #define powerpc
 #define FB_CPU CpuPowerPc
 #endif
-#ifdef i386
+#if defined(i386) || defined(__i386__)
 #define I386
 #define FB_CPU CpuIntel
 #endif

--- a/src/isql/InputDevices.cpp
+++ b/src/isql/InputDevices.cpp
@@ -23,7 +23,7 @@
 
 #include "firebird.h"
 #if defined(DARWIN) && !defined(IOS)
-#if defined(i386) || defined(__x86_64__)
+#if defined(i386) || defined(__i386__) || defined(__x86_64__)
 #include <architecture/i386/io.h>
 #else
 #include <io.h>

--- a/src/jrd/license.h
+++ b/src/jrd/license.h
@@ -79,7 +79,7 @@
 #define FB_PLATFORM	"S4"
 #endif // Solaris
 #endif // Sparc
-#ifdef i386
+#if defined(i386) || defined(__i386__)
 #define FB_PLATFORM     "SI"
 #endif // i386
 #ifdef AMD64
@@ -99,7 +99,7 @@
 #endif // aix
 
 #ifdef WIN_NT
-#ifdef i386
+#if defined(i386) || defined(__i386__)
 #define FB_PLATFORM	"WI"
 #else
 #define FB_PLATFORM	"NP"
@@ -119,7 +119,7 @@
 #endif
 
 #ifdef DARWIN
-#if defined(i386) || defined(__x86_64__)
+#if defined(i386) || defined(__i386__) || defined(__x86_64__)
 #define FB_PLATFORM		"UI"	// Darwin/Intel
 #endif
 #if defined(__ppc__) || defined(__ppc64__)

--- a/src/remote/remote_def.h
+++ b/src/remote/remote_def.h
@@ -45,7 +45,7 @@
 #if defined(__sun)
 #	ifdef sparc
 const P_ARCH ARCHITECTURE	= arch_sun4;
-#elif (defined i386 || defined AMD64)
+#elif (defined i386 || defined __i386__ || defined AMD64)
 const P_ARCH ARCHITECTURE	= arch_sunx86;
 #	else
 const P_ARCH ARCHITECTURE	= arch_sun;


### PR DESCRIPTION
After commit 2f3dc8bca8f4 ("Added -std=c++11 flag to Linux builds."),
i386 (32-bit) linux builds started to fail with "#error Define FB_CPU
for your platform". This is because gcc doesn't define "i386" macro with
-std=c++11, only "**i386**". While current gcc seems to define both
macros without -std=c++11, let's play it safe and check for both.
