### PR TITLE
Fix android include paths related to c++11 

### DIFF
--- a/builds/posix/make.android.arm64
+++ b/builds/posix/make.android.arm64
@@ -36,7 +36,10 @@ STRIP:=$(CROSS_PREFIX)strip
 
 COMMON_FLAGS=-ggdb -DFB_SEND_FLAGS=MSG_NOSIGNAL -DLINUX -DANDROID -DARM64 -pipe -MMD -fPIC -fmessage-length=0 \
 			 -I$(ROOT)/extern/libtommath --sysroot=$(CROSS_PLATFORM) \
-			 -I$(CROSS_PLATFORM)/usr/include -I$(ROOT)/gen/cross
+			 -I$(CROSS_PLATFORM)/usr/include -I$(ROOT)/gen/cross \
+			 -I$(NDK)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include \
+			 -I$(NDK)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/arm64-v8a/include
+
 
 OPTIMIZE_FLAGS=-fno-omit-frame-pointer
 WARN_FLAGS=-Wall -Wno-switch -Wno-parentheses -Wno-unknown-pragmas -Wno-unused-variable

--- a/builds/posix/make.android.arme
+++ b/builds/posix/make.android.arme
@@ -20,7 +20,7 @@ HOST_TAG64:=linux-x86
 endif
 NDK_TOOLCHAIN_VERSION:=$(shell echo $(TOOLCHAIN_DIR) | awk -F - '{print $$NF;}')
 
-CROSS_PLATFORM:=$(NDK)/platforms/android-14/arch-arm
+CROSS_PLATFORM:=$(NDK)/platforms/android-24/arch-arm
 CROSS_PREFIX:=$(NDK)/toolchains/$(TOOLCHAIN_DIR)/prebuilt/$(HOST_TAG64)/bin/arm-linux-androideabi-
 
 CXX:=$(CROSS_PREFIX)g++
@@ -36,7 +36,10 @@ STRIP:=$(CROSS_PREFIX)strip
 
 COMMON_FLAGS=-ggdb -DFB_SEND_FLAGS=MSG_NOSIGNAL -DLINUX -DANDROID -DARM -pipe -MMD -fPIC -fmessage-length=0 \
 			 -I$(ROOT)/extern/libtommath --sysroot=$(CROSS_PLATFORM) \
-			 -I$(CROSS_PLATFORM)/usr/include -I$(ROOT)/gen/cross
+			 -I$(CROSS_PLATFORM)/usr/include -I$(ROOT)/gen/cross \
+			 -I$(NDK)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include \
+			 -I$(NDK)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/armeabi/include
+
 
 OPTIMIZE_FLAGS=-fno-omit-frame-pointer
 WARN_FLAGS=-Wall -Wno-switch -Wno-parentheses -Wno-unknown-pragmas -Wno-unused-variable

--- a/builds/posix/make.android.x86
+++ b/builds/posix/make.android.x86
@@ -44,7 +44,10 @@ STRIP:=$(CROSS_PREFIX)strip
 
 COMMON_FLAGS=-ggdb -DFB_SEND_FLAGS=MSG_NOSIGNAL -DLINUX -DANDROID -pipe -MMD -fPIC -fmessage-length=0 \
 			 -I$(ROOT)/extern/libtommath --sysroot=$(CROSS_PLATFORM) \
-			 -I$(CROSS_PLATFORM)/usr/include -I$(ROOT)/gen/cross
+			 -I$(CROSS_PLATFORM)/usr/include -I$(ROOT)/gen/cross \
+			 -I$(NDK)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include \
+			 -I$(NDK)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/x86/include
+
 
 OPTIMIZE_FLAGS=-fno-omit-frame-pointer
 WARN_FLAGS=-Wall -Wno-switch -Wno-parentheses -Wno-unknown-pragmas -Wno-unused-variable

--- a/builds/posix/make.android.x86_64
+++ b/builds/posix/make.android.x86_64
@@ -36,7 +36,9 @@ STRIP:=$(CROSS_PREFIX)strip
 
 COMMON_FLAGS=-ggdb -DFB_SEND_FLAGS=MSG_NOSIGNAL -DLINUX -DANDROID -DAMD64 -pipe -MMD -fPIC -fmessage-length=0 \
 			 -I$(ROOT)/extern/libtommath --sysroot=$(CROSS_PLATFORM) \
-			 -I$(CROSS_PLATFORM)/usr/include -I$(ROOT)/gen/cross
+			 -I$(CROSS_PLATFORM)/usr/include -I$(ROOT)/gen/cross \
+			 -I$(NDK)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include \
+			 -I$(NDK)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/x86_64/include
 
 OPTIMIZE_FLAGS=-fno-omit-frame-pointer
 WARN_FLAGS=-Wall -Wno-switch -Wno-parentheses -Wno-unknown-pragmas -Wno-unused-variable

--- a/src/include/cross/android.arme
+++ b/src/include/cross/android.arme
@@ -479,7 +479,8 @@
 #define HAVE_SYS_STAT_H 1
 
 /* Define to 1 if you have the <sys/timeb.h> header file. */
-#define HAVE_SYS_TIMEB_H 1
+/* Deprecated in android-24 */
+#undef HAVE_SYS_TIMEB_H
 
 /* Define to 1 if you have the <sys/types.h> header file. */
 #define HAVE_SYS_TYPES_H 1


### PR DESCRIPTION
This one fixed ::posix_fadvise' has not been declared for arm32

(Had to upgrade android platform to 24)

Also include paths needed to be updated to include the c++11 headers

