### PR TITLE
Fixed: gbak can overwrite database if it is excecuted with arguments where path to backup corresponds to path to this database

### DIFF
--- a/builds/posix/make.shared.variables
+++ b/builds/posix/make.shared.variables
@@ -81,9 +81,10 @@ AllObjects += $(GFIX_Objects)
 
 # gbak
 Svc_GBAK_Objects:= $(call dirObjects,burp)
-GBAK_Objects:= $(Svc_GBAK_Objects) $(call dirObjects,burp/main)
+GBAK_Own_Objects:= $(Svc_GBAK_Objects) $(call dirObjects,burp/main)
+GBAK_Objects:= $(GBAK_Own_Objects) $(call makeObjects,jrd,ods.cpp)
 
-AllObjects += $(GBAK_Objects)
+AllObjects += $(GBAK_Own_Objects)
 
 # gsec
 Svc_GSEC_Objects:= $(call dirObjects,utilities/gsec)

--- a/builds/win32/msvc14/burp.vcxproj
+++ b/builds/win32/msvc14/burp.vcxproj
@@ -150,6 +150,7 @@
     <ClCompile Include="..\..\..\gen\burp\backup.cpp" />
     <ClCompile Include="..\..\..\gen\burp\OdsDetection.cpp" />
     <ClCompile Include="..\..\..\gen\burp\restore.cpp" />
+    <ClCompile Include="..\..\..\src\jrd\ods.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\..\src\burp\backup.epp" />

--- a/builds/win32/msvc14/burp.vcxproj.filters
+++ b/builds/win32/msvc14/burp.vcxproj.filters
@@ -16,6 +16,9 @@
       <UniqueIdentifier>{eb4b34e6-bff2-4f4f-acff-eda9621d223b}</UniqueIdentifier>
       <Extensions>h;hpp;hxx;hm;inl</Extensions>
     </Filter>
+    <Filter Include="JRD files">
+      <UniqueIdentifier>{406ca6e9-9417-41b1-a3d7-8d1cde81fe48}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\src\burp\burp.cpp">
@@ -38,6 +41,9 @@
     </ClCompile>
     <ClCompile Include="..\..\..\gen\burp\restore.cpp">
       <Filter>BURP files\Generated files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\jrd\ods.cpp">
+      <Filter>JRD files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Example:
`gbak -user SYSDBA -password * -b dbalias db.fdb`
where dbalias refers to db.fdb

Solution:
If the output file exists, then its header is checked. The existing file isn't overwritten if it is similar to database.