### PR TITLE
Do not enforce -std=c+11 on Linux.

### DIFF
--- a/builds/posix/prefix.linux
+++ b/builds/posix/prefix.linux
@@ -28,5 +28,3 @@ DEV_FLAGS=-p $(COMMON_FLAGS) $(WARN_FLAGS)
 
 # This file must be compiled with SSE4.2 support
 %/CRC32C.o: COMMON_FLAGS += -msse4
-
-CXXFLAGS := $(CXXFLAGS) -std=c++11

--- a/builds/posix/prefix.linux_amd64
+++ b/builds/posix/prefix.linux_amd64
@@ -28,5 +28,3 @@ DEV_FLAGS=$(COMMON_FLAGS) $(WARN_FLAGS) -fmax-errors=8
 
 # This file must be compiled with SSE4.2 support
 %/CRC32C.o: COMMON_FLAGS += -msse4
-
-CXXFLAGS := $(CXXFLAGS) -std=c++11


### PR DESCRIPTION
Commit 52d9a05a0f3d ("Backport from master: Optimized hash function for
lock manager and hash join") adds "-std=c++11" to CXXFLAGS on Linux
unconditionally. This doesn't seem to be necessary (looks rather like an
omission) and breaks the build on distributions with old gcc versions
(e.g. SLES 11 SP4).