### PR TITLE
Fix MSVC 15.0 detection (aka VS 2017)

### DIFF
--- a/src/common/os/win32/mod_loader.cpp
+++ b/src/common/os/win32/mod_loader.cpp
@@ -103,6 +103,8 @@ public:
 					"msvcr120.dll",
 #elif _MSC_VER == 1900
 					"vcruntime140.dll",
+#elif _MSC_VER == 1910
+					"vcruntime140.dll",
 #else
                     #error Specify CRT DLL name here !
 #endif


### PR DESCRIPTION
Without that diff, LibreOffice compilation was failing on MSVC 15.0 with: [1].

* [1] http://paste.openstack.org/show/599110/