### PR TITLE
Fix 32-bit gcc build

### DIFF
--- a/src/common/DecFloat.cpp
+++ b/src/common/DecFloat.cpp
@@ -238,6 +238,18 @@ Decimal64 Decimal64::set(int value, DecimalStatus decSt, int scale)
 	return *this;
 }
 
+Decimal64 Decimal64::set(long value, DecimalStatus decSt, int scale)
+{
+#if SIZEOF_LONG > 4
+	return set((SINT64)value, decSt, scale);
+#else
+	decDoubleFromInt32(&dec, value);
+	setScale(decSt, -scale);
+
+	return *this;
+#endif
+}
+
 Decimal64 Decimal64::set(SINT64 value, DecimalStatus decSt, int scale)
 {
 	{
@@ -462,6 +474,18 @@ Decimal128 Decimal128::set(int value, DecimalStatus decSt, int scale)
 	setScale(decSt, -scale);
 
 	return *this;
+}
+
+Decimal128 Decimal128::set(long value, DecimalStatus decSt, int scale)
+{
+#if SIZEOF_LONG > 4
+	return set((SINT64)value, decSt, scale);
+#else
+	decQuadFromInt32(&dec, value);
+	setScale(decSt, -scale);
+
+	return *this;
+#endif
 }
 
 Decimal128 Decimal128::set(SINT64 value, DecimalStatus decSt, int scale)

--- a/src/common/DecFloat.h
+++ b/src/common/DecFloat.h
@@ -69,6 +69,7 @@ class Decimal64
 
 public:
 	Decimal64 set(int value, DecimalStatus decSt, int scale);
+	Decimal64 set(long value, DecimalStatus decSt, int scale);
 	Decimal64 set(SINT64 value, DecimalStatus decSt, int scale);
 	Decimal64 set(const char* value, DecimalStatus decSt);
 	Decimal64 set(double value, DecimalStatus decSt);
@@ -111,6 +112,7 @@ class Decimal128
 public:
 	Decimal128 set(Decimal64 d64);
 	Decimal128 set(int value, DecimalStatus decSt, int scale);
+	Decimal128 set(long value, DecimalStatus decSt, int scale);
 	Decimal128 set(SINT64 value, DecimalStatus decSt, int scale);
 	Decimal128 set(const char* value, DecimalStatus decSt);
 	Decimal128 set(double value, DecimalStatus decSt);


### PR DESCRIPTION
Resolves ambiguity in dtype_long case of CVT_get_dec64() and CVT_get_dec128().