### PR TITLE
have constant link order

### DIFF
--- a/builds/posix/make.shared.variables
+++ b/builds/posix/make.shared.variables
@@ -1,8 +1,8 @@
 # Helper functions
 doObjects= $(patsubst %.y,%.o,$(patsubst %.epp,%.o,$(patsubst %.c,%.o,$(1:.cpp=.o))))
 makeObjects= $(addprefix $(OBJ)/$(1)/,$(call doObjects,$2))
-dirFiles= $(notdir $(wildcard ../src/$(1)/*.cpp)) $(notdir $(wildcard ../src/$(1)/*.c)) \
-		  $(notdir $(wildcard ../src/$(1)/*.epp)) $(notdir $(wildcard ../src/$(1)/*.y))
+dirFiles= $(sort $(notdir $(wildcard ../src/$(1)/*.cpp)) $(notdir $(wildcard ../src/$(1)/*.c)) \
+		  $(notdir $(wildcard ../src/$(1)/*.epp)) $(notdir $(wildcard ../src/$(1)/*.y)))
 dirInPath= $(call makeObjects,$(1),$(call dirFiles,$(1)))
 
 dirMaster= $(call dirInPath,$(1))


### PR DESCRIPTION
to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.

Without this patch g++ would order functions in libEngine12.so and fbintl
depending on random order of files in the build system's filesystem.

partial fix for http://tracker.firebirdsql.org/browse/CORE-5548