### PR TITLE
CORE-782

### DIFF
--- a/src/common/config/config.cpp
+++ b/src/common/config/config.cpp
@@ -195,7 +195,8 @@ const Config::ConfigEntry Config::entries[MAX_CONFIG_KEY] =
 	{TYPE_BOOLEAN,		"RemoteAccess",				(ConfigValue) true},
 	{TYPE_BOOLEAN,		"IPv6V6Only",				(ConfigValue) false},
 	{TYPE_BOOLEAN,		"WireCompression",			(ConfigValue) false},
-	{TYPE_BOOLEAN,		"AllowEncryptedSecurityDatabase", (ConfigValue) false}
+	{TYPE_BOOLEAN,		"AllowEncryptedSecurityDatabase", (ConfigValue) false},
+	{TYPE_INTEGER,		"LogLevel",					(ConfigValue) 1 }
 };
 
 /******************************************************************************
@@ -795,4 +796,9 @@ bool Config::getWireCompression() const
 bool Config::getCryptSecurityDatabase() const
 {
 	return get<bool>(KEY_ENCRYPT_SECURITY_DATABASE);
+}
+
+int Config::getLogLevel()
+{
+	return (int)getDefaultConfig()->values[KEY_LOG_LEVEL];
 }

--- a/src/common/config/config.h
+++ b/src/common/config/config.h
@@ -141,6 +141,7 @@ public:
 		KEY_IPV6_V6ONLY,
 		KEY_WIRE_COMPRESSION,
 		KEY_ENCRYPT_SECURITY_DATABASE,
+		KEY_LOG_LEVEL,
 		MAX_CONFIG_KEY		// keep it last
 	};
 
@@ -346,6 +347,8 @@ public:
 	bool getWireCompression() const;
 
 	bool getCryptSecurityDatabase() const;
+
+	static int getLogLevel();
 };
 
 // Implementation of interface to access master configuration file

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -1039,8 +1039,11 @@ Firebird::PathName getPrefix(unsigned int prefType, const char* name)
 #endif
 			break;
 
-		case Firebird::IConfigManager::DIR_CONF:
 		case Firebird::IConfigManager::DIR_LOG:
+			s = "logs";
+			break;
+			
+		case Firebird::IConfigManager::DIR_CONF:
 		case Firebird::IConfigManager::DIR_GUARD:
 		case Firebird::IConfigManager::DIR_SECDB:
 			s = "";


### PR DESCRIPTION
 Does not include an error or status code as this would change the parameters of gds__log

Removed old changes due to controversy, this method still includes LogLevel but uses an enum flags to define how/what data is stored.  Includes 3 enum's for original (exactly how it currenctly works), flag for daily log files, flag for machine readable log files. 

Requires the introduction of a "logs" folder in the setup/installer.