### PR TITLE
Don't assume the temporary dir path when building

### DIFF
--- a/src/misc/writeBuildNum.sh
+++ b/src/misc/writeBuildNum.sh
@@ -94,10 +94,11 @@ eof
 
 createMakeVersion() {
 
+TmpDir="${TMPDIR:-/tmp}"
 OdsH="${Root}/src/jrd/ods.h"
-Mini="/tmp/miniods.h"
-TestCpp="/tmp/test.cpp"
-AOut="/tmp/a.out"
+Mini="${TmpDir}/miniods.h"
+TestCpp="${TmpDir}/test.cpp"
+AOut="${TmpDir}/a.out"
 
 grep ODS_VERSION $OdsH | grep -v ENCODE_ODS >$Mini
 


### PR DESCRIPTION
Instead of just assuming /tmp, check TMPDIR, and fall back to /tmp
on systems that aren't POSIX-compliant.

(Building Firebird failed for me on a machine that overrides TMPDIR.)