### PR TITLE
Excess conversion of sql statement to UTF8 is removed from fbtrace

### DIFF
--- a/src/utilities/ntrace/TracePluginImpl.cpp
+++ b/src/utilities/ntrace/TracePluginImpl.cpp
@@ -1482,24 +1482,18 @@ void TracePluginImpl::register_sql_statement(ITraceSQLStatement* statement)
 	if (!sql_length)
 		return;
 
-	if (config.include_filter.hasData() || config.exclude_filter.hasData())
+	if (config.include_filter.hasData())
 	{
-		const char* sqlUtf8 = statement->getTextUTF8();
-		FB_SIZE_T utf8_length = fb_strlen(sqlUtf8);
+		include_matcher->reset();
+		include_matcher->process((const UCHAR*)sql, sql_length);
+		need_statement = include_matcher->result();
+	}
 
-		if (config.include_filter.hasData())
-		{
-			include_matcher->reset();
-			include_matcher->process((const UCHAR*) sqlUtf8, utf8_length);
-			need_statement = include_matcher->result();
-		}
-
-		if (need_statement && config.exclude_filter.hasData())
-		{
-			exclude_matcher->reset();
-			exclude_matcher->process((const UCHAR*) sqlUtf8, utf8_length);
-			need_statement = !exclude_matcher->result();
-		}
+	if (need_statement && config.exclude_filter.hasData())
+	{
+		exclude_matcher->reset();
+		exclude_matcher->process((const UCHAR*)sql, sql_length);
+		need_statement = !exclude_matcher->result();
 	}
 
 	if (need_statement)


### PR DESCRIPTION
Сonversion is not necessary because statements already in UTF8. Also, this commit fixes exception in matcher when statement contains 2-byte characters. Excess conversion "damages" the statement in this case.