### PR TITLE
Fix building with GCC-6

### DIFF
--- a/src/common/classes/alloc.h
+++ b/src/common/classes/alloc.h
@@ -498,9 +498,13 @@ using Firebird::MemoryPool;
 
 inline static MemoryPool* getDefaultMemoryPool() { return Firebird::MemoryPool::processMemoryPool; }
 
+#if (( ! __GNUC__ ) || ( __GNUC__ < 6 ))
+
 // Global versions of operators new and delete
 void* operator new(size_t s) THROW_BAD_ALLOC;
 void* operator new[](size_t s) THROW_BAD_ALLOC;
+
+#endif
 
 void operator delete(void* mem) throw();
 void operator delete[](void* mem) throw();

--- a/src/dudley/exe.epp
+++ b/src/dudley/exe.epp
@@ -2884,9 +2884,9 @@ static USHORT get_prot_mask( const TEXT * relation, TEXT * field)
 		blr_parameter, 0, 0, 0,
 		blr_parameter, 0, 1, 0,
 		blr_parameter, 1, 0, 0,
-		blr_end,
-		blr_end,
-		blr_end,
+		static_cast<SCHAR>(blr_end),
+		static_cast<SCHAR>(blr_end),
+		static_cast<SCHAR>(blr_end),
 		blr_eoc
 	};
 	static FB_API_HANDLE req_handle;


### PR DESCRIPTION
From [cppreference](http://en.cppreference.com/w/cpp/memory/new/operator_new), with regards to the replaceable, global versions of `operator new`:

>  The versions (1-4) are implicitly declared in each translation unit even if the <new> header is not included. Versions (1-8) are replaceable: a user-provided non-member function with the same signature defined anywhere in the program, in any source file, replaces the default version. Its declaration does not need to be visible.

With GCC-5/C++98, such an unnecessary declaration would be ignored but GCC-6/C++14 seems to treat it as a violation of [ODR](https://en.wikipedia.org/wiki/One_Definition_Rule).  Deleting the declaration in `src/common/classes/alloc.h` (while leaving the definition in `src/common/classes/alloc.cpp`) solves the issue.

Furthermore, compiling also fails with:

``
../temp/std/dudley/exe.cpp:6516:2: error: narrowing conversion of ‘255u’ from ‘unsigned char’ to ‘SCHAR {aka char}’ inside { } [-Wnarrowing]
``

The symbol `blr_end` can be explicitly cast to `SCHAR` to fix the issue.