### PR TITLE
High precision datatype support - Numeric(34,x)

### DIFF
--- a/doc/sql.extensions/README.data_types
+++ b/doc/sql.extensions/README.data_types
@@ -185,3 +185,34 @@ DECFLOAT (FB 4.0)
 			as a literal, instead you can use the equivalent in scientific notation: 1.1E-1022.
 			Similarly 10<1022 zeroes>0 can be presented as 1.0E1024.
 
+
+Enhancement in precision of calculations with NUMERIC/DECIMAL (FB 4.0)
+--------------
+
+  Function:
+    Maximum precision of NUMERIC and DECIMAL data types is increased to 34 digits.
+
+  Author:
+    Alex Peshkoff <peshkoff@mail.ru>
+
+  Syntax rules:
+    NUMERIC ( P {, N} )
+    DECUMAL ( P {, N} )
+		where P is precision (P <= 34, was limited prior with 18 digits) and N is optional number
+		of digits after decimal separator (as before).
+
+  Storage:
+    128-bit, format according to IEEE 754.
+
+  Example(s):
+    1. DECLARE VARIABLE VAR1 DECIMAL(25);
+    2. CREATE TABLE TABLE1 (FIELD1 NUMERIC(34, 17));
+
+  Note(s):
+    Numerics with precision less than 19 digits use SMALLINT, INTEGER, BIGINT or DOUBLE PRECISION
+    as base datatype depending upon number of digits and dialect. When precision is between 19 and
+    34 digits DECFLOAT(34) is used for it. Actual precision is always increased to 34 digits. For
+    complex calculations such digits are casted (internally, in trivial way) to DECFLOAT(34) and
+    the result of various math (log, exp, etc.) and aggregate functions using high precision
+    numeric argument is DECFLOAT(34).
+

--- a/doc/sql.extensions/README.data_types
+++ b/doc/sql.extensions/README.data_types
@@ -197,7 +197,7 @@ Enhancement in precision of calculations with NUMERIC/DECIMAL (FB 4.0)
 
   Syntax rules:
     NUMERIC ( P {, N} )
-    DECUMAL ( P {, N} )
+    DECIMAL ( P {, N} )
 		where P is precision (P <= 34, was limited prior with 18 digits) and N is optional number
 		of digits after decimal separator (as before).
 
@@ -215,4 +215,3 @@ Enhancement in precision of calculations with NUMERIC/DECIMAL (FB 4.0)
     complex calculations such digits are casted (internally, in trivial way) to DECFLOAT(34) and
     the result of various math (log, exp, etc.) and aggregate functions using high precision
     numeric argument is DECFLOAT(34).
-

--- a/src/burp/canonical.cpp
+++ b/src/burp/canonical.cpp
@@ -163,6 +163,7 @@ ULONG CAN_encode_decode(burp_rel* relation, lstring* buffer, UCHAR* data, bool_t
 			break;
 
 		case dtype_dec128:
+		case dtype_dec_fixed:
 			if (!xdr_dec128(xdrs, (Firebird::Decimal128*) p))
 				return FALSE;
 			break;

--- a/src/common/DecFloat.cpp
+++ b/src/common/DecFloat.cpp
@@ -904,6 +904,8 @@ DecimalFixed DecimalFixed::add(DecimalStatus decSt, DecimalFixed op2) const
 	DecimalContext context(this, decSt);
 	DecimalFixed rc;
 	decQuadAdd(&rc.dec, &dec, &op2.dec, &context);
+	context.checkForExceptions();
+	decQuadQuantize(&rc.dec, &rc.dec, &c1.dec, &context);
 	return rc;
 }
 
@@ -912,6 +914,8 @@ DecimalFixed DecimalFixed::sub(DecimalStatus decSt, DecimalFixed op2) const
 	DecimalContext context(this, decSt);
 	DecimalFixed rc;
 	decQuadSubtract(&rc.dec, &dec, &op2.dec, &context);
+	context.checkForExceptions();
+	decQuadQuantize(&rc.dec, &rc.dec, &c1.dec, &context);
 	return rc;
 }
 
@@ -920,6 +924,8 @@ DecimalFixed DecimalFixed::mul(DecimalStatus decSt, DecimalFixed op2) const
 	DecimalContext context(this, decSt);
 	DecimalFixed rc;
 	decQuadMultiply(&rc.dec, &dec, &op2.dec, &context);
+	context.checkForExceptions();
+	decQuadQuantize(&rc.dec, &rc.dec, &c1.dec, &context);
 	return rc;
 }
 

--- a/src/common/DecFloat.cpp
+++ b/src/common/DecFloat.cpp
@@ -117,6 +117,7 @@ private:
 };
 
 CDecimal128 dmax(DBL_MAX, DecimalStatus(0)), dmin(-DBL_MAX, DecimalStatus(0));
+CDecimal128 dzup(DBL_MIN, DecimalStatus(0)), dzlw(-DBL_MIN, DecimalStatus(0));
 CDecimal128 i64max(MAX_SINT64, DecimalStatus(0)), i64min(MIN_SINT64, DecimalStatus(0));
 
 unsigned digits(const unsigned pMax, unsigned char* const coeff, int& exp)
@@ -588,6 +589,11 @@ double Decimal128::toDouble(DecimalStatus decSt) const
 
 	if (compare(decSt, dmin) < 0 || compare(decSt, dmax) > 0)
 		decContextSetStatus(&context, DEC_Overflow);
+	else if ((!decQuadIsZero(&dec)) && compare(decSt, dzlw) > 0 && compare(decSt, dzup) < 0)
+	{
+		decContextSetStatus(&context, DEC_Underflow);
+		return 0.0;
+	}
 	else
 	{
 		char s[IDecFloat34::STRING_SIZE];

--- a/src/common/DecFloat.cpp
+++ b/src/common/DecFloat.cpp
@@ -582,7 +582,7 @@ DecimalFixed DecimalFixed::set(SINT64 value)
 
 DecimalFixed DecimalFixed::set(const char* value, int scale, DecimalStatus decSt)
 {
-	{
+	{	// scope for 'context'
 		DecimalContext context(this, decSt);
 		decQuadFromString(&dec, value, &context);
 	}
@@ -595,7 +595,7 @@ DecimalFixed DecimalFixed::set(double value, int scale, DecimalStatus decSt)
 {
 	char s[50];
 	sprintf(s, "%18.016e", value);
-	{ //scope for 'context'
+	{	// scope for 'context'
 		DecimalContext context(this, decSt);
 		decQuadFromString(&dec, s, &context);
 	}

--- a/src/common/DecFloat.cpp
+++ b/src/common/DecFloat.cpp
@@ -116,10 +116,10 @@ private:
 	}
 };
 
-CDecimal128 dmax(DBL_MAX, DecimalStatus(0)), dmin(-DBL_MAX, DecimalStatus(0));
-CDecimal128 dzup(DBL_MIN, DecimalStatus(0)), dzlw(-DBL_MIN, DecimalStatus(0));
-CDecimal128 i64max(MAX_SINT64, DecimalStatus(0)), i64min(MIN_SINT64, DecimalStatus(0));
-CDecimal128 c1(1);
+const CDecimal128 dmax(DBL_MAX, DecimalStatus(0)), dmin(-DBL_MAX, DecimalStatus(0));
+const CDecimal128 dzup(DBL_MIN, DecimalStatus(0)), dzlw(-DBL_MIN, DecimalStatus(0));
+const CDecimal128 i64max(MAX_SINT64, DecimalStatus(0)), i64min(MIN_SINT64, DecimalStatus(0));
+const CDecimal128 c1(1);
 
 unsigned digits(const unsigned pMax, unsigned char* const coeff, int& exp)
 {

--- a/src/common/DecFloat.cpp
+++ b/src/common/DecFloat.cpp
@@ -695,7 +695,6 @@ double Decimal128Base::toDouble(DecimalStatus decSt) const
 	else
 	{
 		char s[IDecFloat34::STRING_SIZE];
-		memset(s, 0, sizeof(s));
 		decQuadToString(&dec, s);
 		return atof(s);
 	}

--- a/src/common/DecFloat.h
+++ b/src/common/DecFloat.h
@@ -65,6 +65,8 @@ struct DecimalBinding
 	SCHAR numScale;
 };
 
+class DecimalFixed;
+
 class Decimal64
 {
 	friend class Decimal128;
@@ -79,6 +81,7 @@ public:
 	Decimal64 set(SINT64 value, DecimalStatus decSt, int scale);
 	Decimal64 set(const char* value, DecimalStatus decSt);
 	Decimal64 set(double value, DecimalStatus decSt);
+	Decimal64 set(DecimalFixed value, DecimalStatus decSt, int scale);
 
 	UCHAR* getBytes();
 	Decimal64 abs() const;
@@ -154,13 +157,9 @@ public:
 	Decimal128 set(SINT64 value, DecimalStatus decSt, int scale);
 	Decimal128 set(const char* value, DecimalStatus decSt);
 	Decimal128 set(double value, DecimalStatus decSt);
+	Decimal128 set(DecimalFixed value, DecimalStatus decSt, int scale);
 
 	Decimal128 operator=(Decimal64 d64);
-	Decimal128 operator=(Decimal128Base d128b)
-	{
-		memcpy(&dec, &d128b.dec, sizeof(dec));
-		return *this;
-	}
 
 	void toString(DecimalStatus decSt, unsigned length, char* to) const;
 	void toString(string& to) const;
@@ -188,6 +187,12 @@ public:
 
 private:
 	void setScale(DecimalStatus decSt, int scale);
+
+	Decimal128 operator=(Decimal128Base d128b)
+	{
+		memcpy(&dec, &d128b.dec, sizeof(dec));
+		return *this;
+	}
 };
 
 class CDecimal128 : public Decimal128
@@ -220,7 +225,7 @@ public:
 #endif
 	DecimalFixed set(SLONG value);
 	DecimalFixed set(SINT64 value);
-	DecimalFixed set(const char* value, DecimalStatus decSt);
+	DecimalFixed set(const char* value, int scale, DecimalStatus decSt);
 	DecimalFixed set(double value, int scale, DecimalStatus decSt);
 
 	int toInteger(DecimalStatus decSt) const;
@@ -241,6 +246,8 @@ public:
 		memcpy(&dec, &d128b.dec, sizeof(dec));
 		return *this;
 	}
+
+	void exactInt(DecimalStatus decSt);	// makes it integer after conversions
 
 private:
 	Decimal128 scaled128(DecimalStatus decSt, int scale) const;

--- a/src/common/DecFloat.h
+++ b/src/common/DecFloat.h
@@ -32,6 +32,8 @@
 #include "firebird/Interface.h"
 #include "fb_exception.h"
 
+#include <string.h>
+
 #include "classes/fb_string.h"
 
 extern "C"
@@ -108,7 +110,34 @@ private:
 	void setScale(DecimalStatus decSt, int scale);
 };
 
-class Decimal128
+class Decimal128Base
+{
+	friend class Decimal128;
+	friend class DecimalFixed;
+
+public:
+	void toString(DecimalStatus decSt, unsigned length, char* to) const;
+	void toString(string& to) const;
+	double toDouble(DecimalStatus decSt) const;
+
+	UCHAR* getBytes();
+	int compare(DecimalStatus decSt, Decimal128Base tgt) const;
+	int sign() const;
+
+	void makeKey(ULONG* key) const;
+	void grabKey(ULONG* key);
+	static ULONG getIndexKeyLength();
+	ULONG makeIndexKey(vary* buf);
+
+#ifdef DEV_BUILD
+	int show();
+#endif
+
+private:
+	decQuad dec;
+};
+
+class Decimal128 : public Decimal128Base
 {
 	friend class Decimal64;
 
@@ -123,50 +152,39 @@ public:
 	Decimal128 set(double value, DecimalStatus decSt);
 
 	Decimal128 operator=(Decimal64 d64);
+	Decimal128 operator=(Decimal128Base d128b)
+	{
+		memcpy(&dec, &d128b.dec, sizeof(dec));
+		return *this;
+	}
 
 	int toInteger(DecimalStatus decSt, int scale) const;
-	void toString(DecimalStatus decSt, unsigned length, char* to) const;
-	void toString(string& to) const;
-	double toDouble(DecimalStatus decSt) const;
 	SINT64 toInt64(DecimalStatus decSt, int scale) const;
-	UCHAR* getBytes();
 	Decimal64 toDecimal64(DecimalStatus decSt) const;
-	Decimal128 abs() const;
 	Decimal128 ceil(DecimalStatus decSt) const;
 	Decimal128 floor(DecimalStatus decSt) const;
+	Decimal128 abs() const;
+	Decimal128 neg() const;
 	Decimal128 add(DecimalStatus decSt, Decimal128 op2) const;
 	Decimal128 sub(DecimalStatus decSt, Decimal128 op2) const;
 	Decimal128 mul(DecimalStatus decSt, Decimal128 op2) const;
 	Decimal128 div(DecimalStatus decSt, Decimal128 op2) const;
-	Decimal128 neg() const;
 	Decimal128 fma(DecimalStatus decSt, Decimal128 op2, Decimal128 op3) const;
+
 	Decimal128 sqrt(DecimalStatus decSt) const;
 	Decimal128 pow(DecimalStatus decSt, Decimal128 op2) const;
 	Decimal128 ln(DecimalStatus decSt) const;
 	Decimal128 log10(DecimalStatus decSt) const;
 
-	int compare(DecimalStatus decSt, Decimal128 tgt) const;
 	bool isInf() const;
 	bool isNan() const;
-	int sign() const;
-
-	void makeKey(ULONG* key) const;
-	void grabKey(ULONG* key);
-	static ULONG getIndexKeyLength();
-	ULONG makeIndexKey(vary* buf);
 
 	Decimal128 quantize(DecimalStatus decSt, Decimal128 op2) const;
 	Decimal128 normalize(DecimalStatus decSt) const;
 	short totalOrder(Decimal128 op2) const;
 	short decCompare(Decimal128 op2) const;
 
-#ifdef DEV_BUILD
-	int show();
-#endif
-
 private:
-	decQuad dec;
-
 	void setScale(DecimalStatus decSt, int scale);
 };
 
@@ -186,6 +204,33 @@ public:
 	CDecimal128(int value)
 	{
 		set(value, DecimalStatus(0), 0);
+	}
+};
+
+class DecimalFixed : public Decimal128Base
+{
+public:
+#if SIZEOF_LONG < 8
+	DecimalFixed set(int value);
+#endif
+	DecimalFixed set(SLONG value);
+	DecimalFixed set(SINT64 value);
+	DecimalFixed set(DecimalStatus decSt, const char* value);
+
+	int toInteger(DecimalStatus decSt) const;
+	SINT64 toInt64(DecimalStatus decSt) const;
+
+	DecimalFixed abs() const;
+	DecimalFixed neg() const;
+	DecimalFixed add(DecimalStatus decSt, DecimalFixed op2) const;
+	DecimalFixed sub(DecimalStatus decSt, DecimalFixed op2) const;
+	DecimalFixed mul(DecimalStatus decSt, DecimalFixed op2) const;
+	DecimalFixed div(DecimalStatus decSt, DecimalFixed op2) const;
+
+	DecimalFixed operator=(Decimal128Base d128b)
+	{
+		memcpy(&dec, &d128b.dec, sizeof(dec));
+		return *this;
 	}
 };
 

--- a/src/common/DecFloat.h
+++ b/src/common/DecFloat.h
@@ -68,6 +68,8 @@ struct DecimalBinding
 class Decimal64
 {
 	friend class Decimal128;
+	friend class DecimalFixed;
+	friend class Decimal128Base;
 
 public:
 #if SIZEOF_LONG < 8
@@ -116,12 +118,14 @@ class Decimal128Base
 	friend class DecimalFixed;
 
 public:
-	void toString(DecimalStatus decSt, unsigned length, char* to) const;
-	void toString(string& to) const;
 	double toDouble(DecimalStatus decSt) const;
+	Decimal64 toDecimal64(DecimalStatus decSt) const;
 
 	UCHAR* getBytes();
 	int compare(DecimalStatus decSt, Decimal128Base tgt) const;
+
+	bool isInf() const;
+	bool isNan() const;
 	int sign() const;
 
 	void makeKey(ULONG* key) const;
@@ -158,9 +162,10 @@ public:
 		return *this;
 	}
 
+	void toString(DecimalStatus decSt, unsigned length, char* to) const;
+	void toString(string& to) const;
 	int toInteger(DecimalStatus decSt, int scale) const;
 	SINT64 toInt64(DecimalStatus decSt, int scale) const;
-	Decimal64 toDecimal64(DecimalStatus decSt) const;
 	Decimal128 ceil(DecimalStatus decSt) const;
 	Decimal128 floor(DecimalStatus decSt) const;
 	Decimal128 abs() const;
@@ -175,9 +180,6 @@ public:
 	Decimal128 pow(DecimalStatus decSt, Decimal128 op2) const;
 	Decimal128 ln(DecimalStatus decSt) const;
 	Decimal128 log10(DecimalStatus decSt) const;
-
-	bool isInf() const;
-	bool isNan() const;
 
 	Decimal128 quantize(DecimalStatus decSt, Decimal128 op2) const;
 	Decimal128 normalize(DecimalStatus decSt) const;
@@ -211,14 +213,20 @@ class DecimalFixed : public Decimal128Base
 {
 public:
 #if SIZEOF_LONG < 8
-	DecimalFixed set(int value);
+	DecimalFixed set(int value)
+	{
+		return set(SLONG(value));
+	}
 #endif
 	DecimalFixed set(SLONG value);
 	DecimalFixed set(SINT64 value);
-	DecimalFixed set(DecimalStatus decSt, const char* value);
+	DecimalFixed set(const char* value, DecimalStatus decSt);
+	DecimalFixed set(double value, int scale, DecimalStatus decSt);
 
 	int toInteger(DecimalStatus decSt) const;
 	SINT64 toInt64(DecimalStatus decSt) const;
+	void toString(DecimalStatus decSt, int scale, unsigned length, char* to) const;
+	void toString(DecimalStatus decSt, int scale, string& to) const;
 
 	DecimalFixed abs() const;
 	DecimalFixed neg() const;
@@ -226,12 +234,16 @@ public:
 	DecimalFixed sub(DecimalStatus decSt, DecimalFixed op2) const;
 	DecimalFixed mul(DecimalStatus decSt, DecimalFixed op2) const;
 	DecimalFixed div(DecimalStatus decSt, DecimalFixed op2) const;
+	DecimalFixed mod(DecimalStatus decSt, DecimalFixed op2) const;
 
 	DecimalFixed operator=(Decimal128Base d128b)
 	{
 		memcpy(&dec, &d128b.dec, sizeof(dec));
 		return *this;
 	}
+
+private:
+	Decimal128 scaled128(DecimalStatus decSt, int scale) const;
 };
 
 } // namespace Firebird

--- a/src/common/DecFloat.h
+++ b/src/common/DecFloat.h
@@ -110,9 +110,9 @@ public:
 #endif
 
 private:
-	decDouble dec;
-
 	void setScale(DecimalStatus decSt, int scale);
+
+	decDouble dec;
 };
 
 class Decimal128Base
@@ -141,6 +141,8 @@ public:
 #endif
 
 private:
+	void setScale(DecimalStatus decSt, int scale);
+
 	decQuad dec;
 };
 
@@ -186,8 +188,6 @@ public:
 	short decCompare(Decimal128 op2) const;
 
 private:
-	void setScale(DecimalStatus decSt, int scale);
-
 	Decimal128 operator=(Decimal128Base d128b)
 	{
 		memcpy(&dec, &d128b.dec, sizeof(dec));
@@ -238,7 +238,7 @@ public:
 	DecimalFixed add(DecimalStatus decSt, DecimalFixed op2) const;
 	DecimalFixed sub(DecimalStatus decSt, DecimalFixed op2) const;
 	DecimalFixed mul(DecimalStatus decSt, DecimalFixed op2) const;
-	DecimalFixed div(DecimalStatus decSt, DecimalFixed op2) const;
+	DecimalFixed div(DecimalStatus decSt, DecimalFixed op2, int scale) const;
 	DecimalFixed mod(DecimalStatus decSt, DecimalFixed op2) const;
 
 	DecimalFixed operator=(Decimal128Base d128b)
@@ -247,7 +247,7 @@ public:
 		return *this;
 	}
 
-	void exactInt(DecimalStatus decSt);	// makes it integer after conversions
+	void exactInt(DecimalStatus decSt, int scale);	// rescale & make it integer after conversions
 
 private:
 	Decimal128 scaled128(DecimalStatus decSt, int scale) const;

--- a/src/common/classes/InternalMessageBuffer.cpp
+++ b/src/common/classes/InternalMessageBuffer.cpp
@@ -182,6 +182,12 @@ MetadataFromBlr::MetadataFromBlr(unsigned aBlrLength, const unsigned char* aBlr,
 			item->length = sizeof(Decimal128);
 			break;
 
+		case blr_dec_fixed:
+			item->type = SQL_DEC_FIXED;
+			item->length = sizeof(DecimalFixed);
+			item->scale = rdr.getByte();
+			break;
+
 		default:
 			(Arg::Gds(isc_sqlerr) << Arg::Num(-804) <<
 			 Arg::Gds(isc_dsql_sqlda_err)

--- a/src/common/cvt.cpp
+++ b/src/common/cvt.cpp
@@ -2810,41 +2810,7 @@ DecimalFixed CVT_get_dec_fixed(const dsc* desc, SSHORT scale, DecimalStatus decS
 		err(v);
 	}
 
-	DecimalFixed C1, C10;
-	C1.set(1);
-	C10.set(10);
-
-	// Adjust for scale
-	if (scale > 0)
-	{
-		SLONG fraction = 0;
-		do {
-			if (scale == 1)
-				fraction = dfix.mod(decSt, C10).toInteger(decSt);
-			dfix = dfix.div(decSt, C10);
-		} while (--scale);
-		if (fraction > 4)
-			dfix = dfix.add(decSt, C1);
-		// The following 2 lines are correct for platforms where
-		// (-85 / 10 == -8) && (-85 % 10 == -5)).  If we port to
-		// a platform where ((-85 / 10 == -9) && (-85 % 10 == 5)),
-		// we'll have to change this depending on the platform.
-		else if (fraction < -4)
-			dfix = dfix.sub(decSt, C1);
-	}
-	else if (scale < 0)
-	{
-		DecimalFixed DECFIXED_LIMIT;
-		DECFIXED_LIMIT.set("999999999999999999999999999999999", 0, 0);
-						  //012345678901234567890123456789012
-		do {
-			if (dfix.abs().compare(decSt, DECFIXED_LIMIT) > 0)
-				err(Arg::Gds(isc_arith_except) << Arg::Gds(isc_numeric_out_of_range));
-			dfix = dfix.mul(decSt, C10);
-		} while (++scale);
-	}
-
-	dfix.exactInt(decSt);
+	dfix.exactInt(decSt, scale);
 	return dfix;
 }
 

--- a/src/common/cvt.cpp
+++ b/src/common/cvt.cpp
@@ -307,13 +307,10 @@ static void decimal_float_to_text(const dsc* from, dsc* to, DecimalStatus decSt,
 
 	try
 	{
-		Decimal128 d;
 		if (from->dsc_dtype == dtype_dec64)
-			d = *((Decimal64*) from->dsc_address);
+			((Decimal64*) from->dsc_address)->toString(decSt, sizeof(temp), temp);
 		else
-			d = *((Decimal128*) from->dsc_address);
-
-		d.toString(decSt, sizeof(temp), temp);
+			((Decimal128Base*) from->dsc_address)->toString(decSt, sizeof(temp), temp);
 	}
 	catch (const Exception& ex)
 	{
@@ -982,6 +979,9 @@ SLONG CVT_get_long(const dsc* desc, SSHORT scale, DecimalStatus decSt, ErrorFunc
 
 		return d128.toInteger(decSt, scale);
 
+	case dtype_dec_fixed:
+		return ((DecimalFixed*) p)->toInteger(scale);
+
 	case dtype_real:
 	case dtype_double:
 		if (desc->dsc_dtype == dtype_real)
@@ -1181,6 +1181,10 @@ double CVT_get_double(const dsc* desc, DecimalStatus decSt, ErrorFunction err, b
 
 			return d128.toDouble(decSt);
 		}
+
+	case dtype_dec_fixed:
+		value = ((DecimalFixed*) desc->dsc_address)->toDouble(decSt);
+		break;
 
 	case dtype_varying:
 	case dtype_cstring:
@@ -1470,6 +1474,7 @@ void CVT_move_common(const dsc* from, dsc* to, DecimalStatus decSt, Callbacks* c
 		case dtype_boolean:
 		case dtype_dec64:
 		case dtype_dec128:
+		case dtype_dec_fixed:
 			CVT_conversion_error(from, cb->err);
 			break;
 		}
@@ -1505,6 +1510,7 @@ void CVT_move_common(const dsc* from, dsc* to, DecimalStatus decSt, Callbacks* c
 		case dtype_boolean:
 		case dtype_dec64:
 		case dtype_dec128:
+		case dtype_dec_fixed:
 			CVT_conversion_error(from, cb->err);
 			break;
 		}
@@ -1540,6 +1546,7 @@ void CVT_move_common(const dsc* from, dsc* to, DecimalStatus decSt, Callbacks* c
 		case dtype_boolean:
 		case dtype_dec64:
 		case dtype_dec128:
+		case dtype_dec_fixed:
 			CVT_conversion_error(from, cb->err);
 			break;
 		}
@@ -1729,6 +1736,7 @@ void CVT_move_common(const dsc* from, dsc* to, DecimalStatus decSt, Callbacks* c
 
 		case dtype_dec64:
 		case dtype_dec128:
+		case dtype_dec_fixed:
 			decimal_float_to_text(from, to, decSt, cb);
 			return;
 
@@ -1855,6 +1863,10 @@ void CVT_move_common(const dsc* from, dsc* to, DecimalStatus decSt, Callbacks* c
 		*((Decimal128*) p) = CVT_get_dec128(from, decSt, cb->err);
 		return;
 
+	case dtype_dec_fixed:
+		*((DecimalFixed*) p) = CVT_get_dec_fixed(from, (SSHORT) to->dsc_scale, decSt, cb->err);
+		return;
+
 	case dtype_boolean:
 		switch (from->dsc_dtype)
 		{
@@ -1877,6 +1889,7 @@ void CVT_move_common(const dsc* from, dsc* to, DecimalStatus decSt, Callbacks* c
 		case dtype_double:
 		case dtype_dec64:
 		case dtype_dec128:
+		case dtype_dec_fixed:
 			CVT_conversion_error(from, cb->err);
 			break;
 		}
@@ -2591,7 +2604,8 @@ Decimal64 CVT_get_dec64(const dsc* desc, DecimalStatus decSt, ErrorFunction err)
 			return *(Decimal64*) p;
 
 		case dtype_dec128:
-			return ((Decimal128*) p)->toDecimal64(decSt);
+		case dtype_dec_fixed:
+			return ((Decimal128Base*) p)->toDecimal64(decSt);
 
 		default:
 			fb_assert(false);
@@ -2677,6 +2691,9 @@ Decimal128 CVT_get_dec128(const dsc* desc, DecimalStatus decSt, ErrorFunction er
 		case dtype_dec128:
 			return *(Decimal128*) p;
 
+		case dtype_dec_fixed:
+			return ((DecimalFixed*) p)->toDecimal128();
+
 		default:
 			fb_assert(false);
 			err(Arg::Gds(isc_badblk));	// internal error
@@ -2688,6 +2705,121 @@ Decimal128 CVT_get_dec128(const dsc* desc, DecimalStatus decSt, ErrorFunction er
 		// reraise using passed error function
 		Arg::StatusVector v(ex);
 		err(v);
+	}
+
+	// compiler silencer
+	return d128;
+}
+
+
+DecimalFixed CVT_get_dec_fixed(const dsc* desc, SSHORT* toScale, DecimalStatus decSt, ErrorFunction err)
+{
+/**************************************
+ *
+ *      C V T _ g e t _ d e c 1 2 8
+ *
+ **************************************
+ *
+ * Functional description
+ *      Convert something arbitrary to a DecFloat(34) / (128 bit).
+ *
+ **************************************/
+	VaryStr<1024> buffer;			// represents unreasonably long decfloat literal in ASCII
+	DecimalFixed dfix;
+
+	// adjust exact numeric values to same scaling
+	int scale = 0;
+	if (DTYPE_IS_EXACT(desc->dsc_dtype))
+		scale = -desc->dsc_scale;
+
+	const char* p = reinterpret_cast<char*>(desc->dsc_address);
+
+	try
+	{
+		switch (desc->dsc_dtype)
+		{
+		case dtype_short:
+			return d128.set(*(SSHORT*) p, decSt, scale);
+
+		case dtype_long:
+			return d128.set(*(SLONG*) p, decSt, scale);
+
+		case dtype_quad:
+			return d128.set(CVT_get_int64(desc, 0, decSt, err), decSt, scale);
+
+		case dtype_int64:
+			return d128.set(*(SINT64*) p, decSt, scale);
+
+		case dtype_varying:
+		case dtype_cstring:
+		case dtype_text:
+			CVT_make_null_string(desc, ttype_ascii, &p, &buffer, sizeof(buffer) - 1, decSt, err);
+			return d128.set(buffer.vary_string, decSt);
+
+		case dtype_blob:
+		case dtype_sql_date:
+		case dtype_sql_time:
+		case dtype_timestamp:
+		case dtype_array:
+		case dtype_dbkey:
+		case dtype_boolean:
+			CVT_conversion_error(desc, err);
+			break;
+
+		case dtype_real:
+			return d128.set(*((float*) p), decSt);
+
+		case dtype_double:
+			return d128.set(*((double*) p), decSt);
+
+		case dtype_dec64:
+			return (d128 = (*(Decimal64*) p));			// cast to higher precision never cause rounding/traps
+
+		case dtype_dec128:
+			return *(Decimal128*) p;
+
+		case dtype_dec_fixed:
+			return ((DecimalFixed*) p)->toDecimal128();
+
+		default:
+			fb_assert(false);
+			err(Arg::Gds(isc_badblk));	// internal error
+			break;
+		}
+	}
+	catch (const Exception& ex)
+	{
+		// reraise using passed error function
+		Arg::StatusVector v(ex);
+		err(v);
+	}
+
+	// Adjust for scale
+
+	if (scale > 0)
+	{
+		SLONG fraction = 0;
+		do {
+			if (scale == 1)
+				fraction = (SLONG) (value % 10);
+			value /= 10;
+		} while (--scale);
+		if (fraction > 4)
+			value++;
+		// The following 2 lines are correct for platforms where
+		// (-85 / 10 == -8) && (-85 % 10 == -5)).  If we port to
+		// a platform where ((-85 / 10 == -9) && (-85 % 10 == 5)),
+		// we'll have to change this depending on the platform.
+		else if (fraction < -4)
+			value--;
+	}
+	else if (scale < 0)
+	{
+		do {
+			if (value > INT64_LIMIT || value < -INT64_LIMIT)
+				err(Arg::Gds(isc_arith_except) << Arg::Gds(isc_numeric_out_of_range));
+			value *= 10;
+		} while (++scale);
 	}
 
 	// compiler silencer
@@ -2766,6 +2898,7 @@ SQUAD CVT_get_quad(const dsc* desc, SSHORT scale, DecimalStatus decSt, ErrorFunc
 
 	case dtype_dec64:
 	case dtype_dec128:
+	case dtype_dec_fixed:
 		SINT64_to_SQUAD(CVT_get_int64(desc, scale, decSt, err), value);
 		break;
 
@@ -2840,6 +2973,9 @@ SINT64 CVT_get_int64(const dsc* desc, SSHORT scale, DecimalStatus decSt, ErrorFu
 
 			return d128.toInt64(decSt, scale);
 		}
+
+	case dtype_dec_fixed:
+		return ((DecimalFixed*) p)->toInt64(decSt, scale);
 
 	case dtype_real:
 	case dtype_double:

--- a/src/common/cvt.h
+++ b/src/common/cvt.h
@@ -77,6 +77,7 @@ bool CVT_get_boolean(const dsc*, ErrorFunction);
 double CVT_get_double(const dsc*, Firebird::DecimalStatus, ErrorFunction, bool* getNumericOverflow = nullptr);
 Firebird::Decimal64 CVT_get_dec64(const dsc*, Firebird::DecimalStatus, ErrorFunction);
 Firebird::Decimal128 CVT_get_dec128(const dsc*, Firebird::DecimalStatus, ErrorFunction);
+Firebird::DecimalFixed CVT_get_dec_fixed(const dsc*, SSHORT, Firebird::DecimalStatus, ErrorFunction);
 USHORT CVT_make_string(const dsc*, USHORT, const char**, vary*, USHORT, Firebird::DecimalStatus, ErrorFunction);
 void CVT_make_null_string(const dsc*, USHORT, const char**, vary*, USHORT, Firebird::DecimalStatus, ErrorFunction);
 void CVT_move_common(const dsc*, dsc*, Firebird::DecimalStatus, Firebird::Callbacks*);

--- a/src/common/dsc.cpp
+++ b/src/common/dsc.cpp
@@ -66,7 +66,8 @@ static const USHORT _DSC_convert_to_text_length[DTYPE_TYPE_MAX] =
 	0,							// dtype_dbkey
 	5,							// dtype_boolean
 	23,							// dtype_dec64		1 + 1 + 1 + 1 + 16(34) + 3(4)
-	42							// dtype_dec128		+-  .   e   +-  coeff  + exp
+	42,							// dtype_dec128		+-  .   e   +-  coeff  + exp
+	35							// dtype_dec_fixed	coeff(34) + 1(+-)
 };
 
 // blr to dsc type conversions
@@ -142,6 +143,7 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	dtype_double	dtype_d_float	dtype_sql_date	dtype_sql_time
 	dtype_timestamp	dtype_blob		dtype_array		dtype_int64
 	dtype_dbkey		dtype_boolean	dtype_dec64		dtype_dec128
+	dtype_dec_fixed
 	*/
 
 	// dtype_unknown
@@ -150,7 +152,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_unknown, dtype_unknown, DTYPE_CANNOT, dtype_unknown,
 	 dtype_unknown, dtype_unknown, dtype_unknown, dtype_unknown,
 	 dtype_unknown, DTYPE_CANNOT, DTYPE_CANNOT, dtype_unknown,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_unknown, dtype_unknown},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_unknown, dtype_unknown,
+	 dtype_unknown},
 
 	// dtype_text
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -158,7 +161,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 dtype_timestamp, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_cstring
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -166,7 +170,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 dtype_timestamp, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_varying
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -174,7 +179,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 dtype_timestamp, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// 4 (unused)
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -182,7 +188,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// 5 (unused)
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -190,7 +197,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_packed
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -198,7 +206,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_byte
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -206,7 +215,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_short
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -214,7 +224,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_int64, dtype_int64, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, dtype_sql_date, dtype_sql_time,
 	 dtype_timestamp, DTYPE_CANNOT, DTYPE_CANNOT, dtype_int64,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_long
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -222,7 +233,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_int64, dtype_int64, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, dtype_sql_date, dtype_sql_time,
 	 dtype_timestamp, DTYPE_CANNOT, DTYPE_CANNOT, dtype_int64,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_quad
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -230,7 +242,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_real
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -238,7 +251,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, dtype_sql_date, dtype_sql_time,
 	 dtype_timestamp, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_double, dtype_double},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_double, dtype_double,
+	 dtype_double},
 
 	// dtype_double
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -246,7 +260,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, dtype_sql_date, dtype_sql_time,
 	 dtype_timestamp, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_double, dtype_double},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_double, dtype_double,
+	 dtype_double},
 
 	// dtype_d_float -- VMS deprecated
 	{dtype_unknown, dtype_d_float, dtype_d_float, dtype_d_float,
@@ -254,7 +269,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_d_float, dtype_d_float, DTYPE_CANNOT, dtype_d_float,
 	 dtype_d_float, dtype_d_float, dtype_sql_date, dtype_sql_time,
 	 dtype_timestamp, DTYPE_CANNOT, DTYPE_CANNOT, dtype_d_float,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_d_float, dtype_d_float},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_d_float, dtype_d_float,
+	 dtype_d_float},
 
 	// dtype_sql_date
 	{dtype_unknown, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -262,7 +278,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_sql_date, dtype_sql_date, DTYPE_CANNOT, dtype_sql_date,
 	 dtype_sql_date, dtype_sql_date, DTYPE_CANNOT, dtype_timestamp,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_sql_date,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_sql_date, dtype_sql_date},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_sql_date, dtype_sql_date,
+	 dtype_sql_date},
 
 	// dtype_sql_time
 	{dtype_unknown, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -270,7 +287,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_sql_time, dtype_sql_time, DTYPE_CANNOT, dtype_sql_time,
 	 dtype_sql_time, dtype_sql_time, dtype_timestamp, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_sql_time,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_sql_time, dtype_sql_time},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_sql_time, dtype_sql_time,
+	 dtype_sql_time},
 
 	// dtype_timestamp
 	{dtype_unknown, dtype_timestamp, dtype_timestamp, dtype_timestamp,
@@ -278,7 +296,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_timestamp, dtype_timestamp, DTYPE_CANNOT, dtype_timestamp,
 	 dtype_timestamp, dtype_timestamp, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_timestamp,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_timestamp, dtype_timestamp},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_timestamp, dtype_timestamp,
+	 dtype_timestamp},
 
 	// dtype_blob
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -286,7 +305,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_array
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -294,7 +314,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_int64
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -302,7 +323,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_int64, dtype_int64, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, dtype_sql_date, dtype_sql_time,
 	 dtype_timestamp, DTYPE_CANNOT, DTYPE_CANNOT, dtype_int64,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_dbkey
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -310,7 +332,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_boolean
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -318,7 +341,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_dec64
 	{dtype_unknown, dtype_dec128, dtype_dec128, dtype_dec128,
@@ -326,7 +350,8 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_dec128, dtype_dec128, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, dtype_sql_date, dtype_sql_time,
 	 dtype_timestamp, DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec128},
 
 	// dtype_dec128
 	{dtype_unknown, dtype_dec128, dtype_dec128, dtype_dec128,
@@ -334,7 +359,17 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_dec128, dtype_dec128, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, dtype_sql_date, dtype_sql_time,
 	 dtype_timestamp, DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128}
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec128}
+
+	// dtype_dec_fixed
+	{dtype_unknown, dtype_dec_fixed, dtype_dec_fixed, dtype_dec_fixed,
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 dtype_dec_fixed, dtype_dec_fixed, DTYPE_CANNOT, dtype_double,
+	 dtype_double, dtype_d_float, dtype_sql_date, dtype_sql_time,
+	 dtype_timestamp, DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec_fixed,
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed}
 
 };
 
@@ -353,6 +388,7 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	dtype_double	dtype_d_float	dtype_sql_date	dtype_sql_time
 	dtype_timestamp	dtype_blob		dtype_array		dtype_int64
 	dtype_dbkey		dtype_boolean	dtype_dec64		dtype_dec128
+	dtype_dec_fixed
 	*/
 
 	// dtype_unknown
@@ -361,7 +397,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_unknown, dtype_unknown, DTYPE_CANNOT, dtype_unknown,
 	 dtype_unknown, dtype_unknown, dtype_unknown, dtype_unknown,
 	 dtype_unknown, DTYPE_CANNOT, DTYPE_CANNOT, dtype_unknown,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_unknown, dtype_unknown},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_unknown, dtype_unknown,
+	 dtype_unknown},
 
 	// dtype_text
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -369,7 +406,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 dtype_timestamp, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_cstring
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -377,7 +415,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 dtype_timestamp, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_varying
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -385,7 +424,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 dtype_timestamp, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// 4 (unused)
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -393,7 +433,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// 5 (unused)
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -401,7 +442,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_packed
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -409,7 +451,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_byte
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -417,7 +460,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_short
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -425,7 +469,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_int64, dtype_int64, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_int64,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_long
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -433,7 +478,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_int64, dtype_int64, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_int64,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_quad
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -441,7 +487,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_real
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -449,7 +496,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_double, dtype_double},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_double, dtype_double,
+	 dtype_double},
 
 	// dtype_double
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -457,7 +505,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_double, dtype_double},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_double, dtype_double,
+	 dtype_double},
 
 	// dtype_d_float -- VMS deprecated
 	{dtype_unknown, dtype_d_float, dtype_d_float, dtype_d_float,
@@ -465,7 +514,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_d_float, dtype_d_float, DTYPE_CANNOT, dtype_d_float,
 	 dtype_d_float, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_d_float,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_d_float, dtype_d_float},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_d_float, dtype_d_float,
+	 dtype_d_float},
 
 	// dtype_sql_date
 	{dtype_unknown, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -473,7 +523,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_sql_date, dtype_sql_date, DTYPE_CANNOT, dtype_sql_date,
 	 dtype_sql_date, dtype_sql_date, dtype_long, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_sql_date,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_sql_date, dtype_sql_date},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_sql_date, dtype_sql_date,
+	 dtype_sql_date},
 
 	// dtype_sql_time
 	{dtype_unknown, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -481,7 +532,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_sql_time, dtype_sql_time, DTYPE_CANNOT, dtype_sql_time,
 	 dtype_sql_time, dtype_sql_time, DTYPE_CANNOT, dtype_long,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_sql_time,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_sql_time, dtype_sql_time},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_sql_time, dtype_sql_time,
+	 dtype_sql_time},
 
 	// dtype_timestamp
 	{dtype_unknown, dtype_timestamp, dtype_timestamp, dtype_timestamp,
@@ -489,7 +541,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_timestamp, dtype_timestamp, DTYPE_CANNOT, dtype_timestamp,
 	 dtype_timestamp, dtype_timestamp, DTYPE_CANNOT, DTYPE_CANNOT,
 	 dtype_double, DTYPE_CANNOT, DTYPE_CANNOT, dtype_timestamp,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_timestamp, dtype_timestamp},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_timestamp, dtype_timestamp,
+	 dtype_timestamp},
 
 	// dtype_blob
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -497,7 +550,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_array
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -505,7 +559,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_int64
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -513,7 +568,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_int64, dtype_int64, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_int64,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_dbkey
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -521,7 +577,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_boolean
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -529,7 +586,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_dec64
 	{dtype_unknown, dtype_dec128, dtype_dec128, dtype_dec128,
@@ -537,7 +595,8 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_dec128, dtype_dec128, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec128},
 
 	// dtype_dec128
 	{dtype_unknown, dtype_dec128, dtype_dec128, dtype_dec128,
@@ -545,8 +604,17 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_dec128, dtype_dec128, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128}
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec128}
 
+	// dtype_dec_fixed
+	{dtype_unknown, dtype_dec_fixed, dtype_dec_fixed, dtype_dec_fixed,
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 dtype_dec_fixed, dtype_dec_fixed, DTYPE_CANNOT, dtype_double,
+	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec_fixed,
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed}
 };
 
 
@@ -565,6 +633,7 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	dtype_double	dtype_d_float	dtype_sql_date	dtype_sql_time
 	dtype_timestamp	dtype_blob		dtype_array		dtype_int64
 	dtype_dbkey		dtype_boolean	dtype_dec64		dtype_dec128
+	dtype_dec_fixed
 	*/
 
 	// dtype_unknown
@@ -573,7 +642,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_unknown, dtype_unknown, DTYPE_CANNOT, dtype_unknown,
 	 dtype_unknown, dtype_unknown, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_unknown,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_unknown, dtype_unknown},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_unknown, dtype_unknown,
+	 dtype_unknown},
 
 	// dtype_text
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -581,7 +651,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_cstring
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -589,7 +660,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_varying
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -597,7 +669,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// 4 (unused)
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -605,7 +678,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// 5 (unused)
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -613,7 +687,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_packed
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -621,7 +696,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_byte
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -629,7 +705,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_short
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -637,7 +714,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_int64, dtype_int64, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_int64,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_long
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -645,7 +723,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_int64, dtype_int64, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_int64,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_quad
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -653,7 +732,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_real
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -661,7 +741,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_double, dtype_double},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_double, dtype_double,
+	 dtype_double},
 
 	// dtype_double
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -669,7 +750,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_double, dtype_double},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_double, dtype_double,
+	 dtype_double},
 
 	// dtype_d_float -- VMS deprecated
 	{dtype_unknown, dtype_d_float, dtype_d_float, dtype_d_float,
@@ -677,7 +759,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_d_float, dtype_d_float, DTYPE_CANNOT, dtype_d_float,
 	 dtype_d_float, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_d_float,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_d_float, dtype_d_float},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_d_float, dtype_d_float,
+	 dtype_double},
 
 	// dtype_sql_date
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -685,7 +768,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_sql_time
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -693,7 +777,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_timestamp
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -701,7 +786,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_blob
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -709,7 +795,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_array
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -717,7 +804,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_int64
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -725,7 +813,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_int64, dtype_int64, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_int64,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_dbkey
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -733,7 +822,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_boolean
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -741,7 +831,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_dec64
 	{dtype_unknown, dtype_dec128, dtype_dec128, dtype_dec128,
@@ -749,7 +840,8 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_dec128, dtype_dec128, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec128},
 
 	// dtype_dec128
 	{dtype_unknown, dtype_dec128, dtype_dec128, dtype_dec128,
@@ -757,8 +849,17 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_dec128, dtype_dec128, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128}
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec128}
 
+	// dtype_dec_fixed
+	{dtype_unknown, dtype_dec_fixed, dtype_dec_fixed, dtype_dec_fixed,
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 dtype_dec_fixed, dtype_dec_fixed, DTYPE_CANNOT, dtype_double,
+	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec_fixed,
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed}
 };
 
 /* The result of multiplying two datatypes in blr_version4 semantics.
@@ -776,6 +877,7 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	dtype_double	dtype_d_float	dtype_sql_date	dtype_sql_time
 	dtype_timestamp	dtype_blob		dtype_array		dtype_int64
 	dtype_dbkey		dtype_boolean	dtype_dec64		dtype_dec128
+	dtype_dec_fixed
 	*/
 
 	// dtype_unknown
@@ -784,7 +886,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_unknown, dtype_unknown, DTYPE_CANNOT, dtype_unknown,
 	 dtype_unknown, dtype_unknown, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_unknown,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_unknown, dtype_unknown},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_unknown, dtype_unknown,
+	 dtype_unknown},
 
 	// dtype_text
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -792,7 +895,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_cstring
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -800,7 +904,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_varying
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -808,7 +913,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// 4 (unused)
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -816,7 +922,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// 5 (unused)
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -824,7 +931,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_packed
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -832,7 +940,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_byte
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -840,7 +949,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_short
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -848,7 +958,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_long, dtype_long, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_long
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -856,7 +967,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_long, dtype_long, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_quad
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -864,7 +976,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_real
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -872,7 +985,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_double, dtype_double},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_double, dtype_double,
+	 dtype_double},
 
 	// dtype_double
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -880,7 +994,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_double, dtype_double},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_double, dtype_double,
+	 dtype_double},
 
 	// dtype_d_float -- VMS deprecated
 	{dtype_unknown, dtype_d_float, dtype_d_float, dtype_d_float,
@@ -888,7 +1003,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_d_float, dtype_d_float, DTYPE_CANNOT, dtype_d_float,
 	 dtype_d_float, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_d_float,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_d_float, dtype_d_float},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_d_float, dtype_d_float,
+	 dtype_d_float},
 
 	// dtype_sql_date
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -896,7 +1012,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_sql_time
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -904,7 +1021,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_timestamp
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -912,7 +1030,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_blob
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -920,7 +1039,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_array
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -928,7 +1048,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_int64
 	{dtype_unknown, dtype_double, dtype_double, dtype_double,
@@ -936,7 +1057,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_double, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_double,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed},
 
 	// dtype_dbkey
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -944,7 +1066,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_boolean
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -952,7 +1075,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
-	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT},
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT},
 
 	// dtype_dec64
 	{dtype_unknown, dtype_dec128, dtype_dec128, dtype_dec128,
@@ -960,7 +1084,8 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_dec128, dtype_dec128, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128},
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec128},
 
 	// dtype_dec128
 	{dtype_unknown, dtype_dec128, dtype_dec128, dtype_dec128,
@@ -968,8 +1093,17 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_dec128, dtype_dec128, DTYPE_CANNOT, dtype_double,
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128,
-	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128}
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec128}
 
+	// dtype_dec_fixed
+	{dtype_unknown, dtype_dec_fixed, dtype_dec_fixed, dtype_dec_fixed,
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
+	 dtype_dec_fixed, dtype_dec_fixed, DTYPE_CANNOT, dtype_double,
+	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
+	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec_fixed,
+	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
+	 dtype_dec_fixed}
 };
 
 #ifdef DEV_BUILD
@@ -1082,6 +1216,11 @@ bool DSC_make_descriptor(DSC* desc,
 	case blr_dec128:
 		desc->dsc_length = sizeof(Decimal128);
 		desc->dsc_dtype = dtype_dec128;
+		break;
+
+	case blr_dec_fixed:
+		desc->dsc_length = sizeof(DecimalFixed);
+		desc->dsc_dtype = dtype_dec_fixed;
 		break;
 
 	case blr_timestamp:
@@ -1249,6 +1388,8 @@ const char* dsc::typeToText() const
 		return "decfloat(16)";
 	case dtype_dec128:
 		return "decfloat(34)";
+	case dtype_dec_fixed:
+		return "decimal";
 	default:
 		return "out of range";
 	}
@@ -1345,6 +1486,11 @@ void dsc::getSqlInfo(SLONG* sqlLength, SLONG* sqlSubType, SLONG* sqlScale, SLONG
 		case dtype_dec128:
 			*sqlType = SQL_DEC34;
 			*sqlScale = 0;
+			break;
+
+		case dtype_dec_fixed:
+			*sqlType = SQL_DEC_FIXED;
+			*sqlScale = dsc_scale;
 			break;
 
 		default:

--- a/src/common/dsc.cpp
+++ b/src/common/dsc.cpp
@@ -360,7 +360,7 @@ const BYTE DSC_add_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_d_float, dtype_sql_date, dtype_sql_time,
 	 dtype_timestamp, DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128,
 	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
-	 dtype_dec128}
+	 dtype_dec128},
 
 	// dtype_dec_fixed
 	{dtype_unknown, dtype_dec_fixed, dtype_dec_fixed, dtype_dec_fixed,
@@ -605,7 +605,7 @@ const BYTE DSC_sub_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128,
 	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
-	 dtype_dec128}
+	 dtype_dec128},
 
 	// dtype_dec_fixed
 	{dtype_unknown, dtype_dec_fixed, dtype_dec_fixed, dtype_dec_fixed,
@@ -760,7 +760,7 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_d_float, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_d_float,
 	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_d_float, dtype_d_float,
-	 dtype_double},
+	 dtype_d_float},
 
 	// dtype_sql_date
 	{DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT,
@@ -850,7 +850,7 @@ const BYTE DSC_multiply_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128,
 	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
-	 dtype_dec128}
+	 dtype_dec128},
 
 	// dtype_dec_fixed
 	{dtype_unknown, dtype_dec_fixed, dtype_dec_fixed, dtype_dec_fixed,
@@ -1094,7 +1094,7 @@ const BYTE DSC_multiply_blr4_result[DTYPE_TYPE_MAX][DTYPE_TYPE_MAX] =
 	 dtype_double, dtype_d_float, DTYPE_CANNOT, DTYPE_CANNOT,
 	 DTYPE_CANNOT, DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128,
 	 DTYPE_CANNOT, DTYPE_CANNOT, dtype_dec128, dtype_dec128,
-	 dtype_dec128}
+	 dtype_dec128},
 
 	// dtype_dec_fixed
 	{dtype_unknown, dtype_dec_fixed, dtype_dec_fixed, dtype_dec_fixed,
@@ -1535,13 +1535,16 @@ static bool validate_dsc_tables()
  *	is called as part of a DEV_BUILD assertion check
  *	only once per server.
  *
- * WARNING: the fprintf's are commented out because trying to print
+ * WARNING: the fprintf's are ifdef'd because trying to print
  *          to stderr when the server is running detached will trash
  *          server memory.  If you uncomment the printf's and build a
  *          kit, make sure that you run that server with the -d flag
  *          so it won't detach from its controlling terminal.
  *
  **************************************/
+
+#define DSC_DIAG(a)
+
 	for (BYTE op1 = dtype_unknown; op1 < DTYPE_TYPE_MAX; op1++)
 	{
 		for (BYTE op2 = dtype_unknown; op2 < DTYPE_TYPE_MAX; op2++)
@@ -1550,59 +1553,48 @@ static bool validate_dsc_tables()
 			if ((DSC_add_result[op1][op2] >= DTYPE_TYPE_MAX) &&
 				(DSC_add_result[op1][op2] != DTYPE_CANNOT))
 			{
-				/*
-				fprintf (stderr, "DSC_add_result [%d][%d] is %d, invalid.\n",
-					op1, op2, DSC_add_result [op1][op2]);
-				*/
+				DSC_DIAG(fprintf (stderr, "DSC_add_result [%d][%d] is %d, invalid.\n",
+					op1, op2, DSC_add_result [op1][op2]));
 				return false;
 			}
 
 			// Addition operator must be communitive
 			if (DSC_add_result[op1][op2] != DSC_add_result[op2][op1])
 			{
-				/*
-				fprintf (stderr,
+				DSC_DIAG(fprintf (stderr,
 					"Not commutative: DSC_add_result[%d][%d] = %d, ... [%d][%d] = %d\n",
 					op1, op2, DSC_add_result [op1][op2],
-					op2, op1, DSC_add_result [op2][op1] );
-				*/
+					op2, op1, DSC_add_result [op2][op1] ));
 				return false;
 			}
 
 			// Difficult to validate Subtraction
-
 			if ((DSC_sub_result[op1][op2] >= DTYPE_TYPE_MAX) &&
 				(DSC_sub_result[op1][op2] != DTYPE_CANNOT))
 			{
-				/*
-				fprintf (stderr, "DSC_sub_result [%d][%d] is %d, invalid.\n",
-					op1, op2, DSC_sub_result [op1][op2]);
-				*/
+				DSC_DIAG(fprintf (stderr, "DSC_sub_result [%d][%d] is %d, invalid.\n",
+					op1, op2, DSC_sub_result [op1][op2]));
 				return false;
 			}
 
 			// Multiplication operator must be commutative
 			if (DSC_multiply_result[op1][op2] != DSC_multiply_result[op2][op1])
 			{
-				/*
-				fprintf (stderr,
+				DSC_DIAG(fprintf (stderr,
 					"Not commutative: DSC_multiply_result [%d][%d] = %d,\n\t... [%d][%d] = %d\n",
 					op1, op2, DSC_multiply_result [op1][op2],
-					op2, op1, DSC_multiply_result [op2][op1]);
-				*/
+					op2, op1, DSC_multiply_result [op2][op1]));
 				return false;
 			}
 
 			// Multiplication operator must be communitive
 			if (DSC_multiply_blr4_result[op1][op2] != DSC_multiply_blr4_result[op2][op1])
 			{
-				/*
-				fprintf (stderr,
+				DSC_DIAG(fprintf (stderr,
 					"Not commutative: DSC_multiply_blr4_result [%d][%d] = %d\n\
 					\t... [%d][%d] = %d\n",
 					op1, op2, DSC_multiply_blr4_result [op1][op2],
-					op2, op1, DSC_multiply_blr4_result [op2][op1] );
-				*/
+					op2, op1, DSC_multiply_blr4_result [op2][op1] ));
 				return false;
 			}
 		}

--- a/src/common/dsc.h
+++ b/src/common/dsc.h
@@ -163,12 +163,22 @@ typedef struct dsc
 
 	bool isDecFloat() const
 	{
-		return DTYPE_IS_DECFLOAT(dsc_dtype);
+		return dsc_dtype == dtype_dec128 || dsc_dtype == dtype_dec64;
+	}
+
+	bool isDecFixed() const
+	{
+		return dsc_dtype == dtype_dec_fixed;
 	}
 
 	bool isDecOrInt() const
 	{
 		return isDecFloat() || isExact();
+	}
+
+	bool isDecFixedOrInt() const
+	{
+		return isDecFixed() || isExact();
 	}
 
 	bool isApprox() const

--- a/src/common/dsc.h
+++ b/src/common/dsc.h
@@ -70,7 +70,7 @@ inline bool DTYPE_IS_APPROX(UCHAR d)
 
 inline bool DTYPE_IS_DECFLOAT(UCHAR d)
 {
-	return d == dtype_dec128 || d  == dtype_dec64;
+	return d == dtype_dec128 || d  == dtype_dec64 || d == dtype_dec_fixed;
 }
 
 inline bool DTYPE_IS_NUMERIC(UCHAR d)
@@ -293,6 +293,14 @@ typedef struct dsc
 		clear();
 		dsc_dtype = dtype_dec128;
 		dsc_length = sizeof(Firebird::Decimal128);
+		dsc_address = (UCHAR*) address;
+	}
+
+	void makeDecimalFixed(Firebird::DecimalFixed* address = NULL)
+	{
+		clear();
+		dsc_dtype = dtype_dec_fixed;
+		dsc_length = sizeof(Firebird::DecimalFixed);
 		dsc_address = (UCHAR*) address;
 	}
 

--- a/src/common/dsc.h
+++ b/src/common/dsc.h
@@ -60,7 +60,7 @@ inline bool DTYPE_IS_BLOB_OR_QUAD(UCHAR d)
 // Exact numeric?
 inline bool DTYPE_IS_EXACT(UCHAR d)
 {
-	return d == dtype_int64 || d == dtype_long || d == dtype_short;
+	return d == dtype_int64 || d == dtype_long || d == dtype_short || d == dtype_dec_fixed;
 }
 
 inline bool DTYPE_IS_APPROX(UCHAR d)
@@ -174,11 +174,6 @@ typedef struct dsc
 	bool isDecOrInt() const
 	{
 		return isDecFloat() || isExact();
-	}
-
-	bool isDecFixedOrInt() const
-	{
-		return isDecFixed() || isExact();
 	}
 
 	bool isApprox() const

--- a/src/common/dsc.h
+++ b/src/common/dsc.h
@@ -301,14 +301,6 @@ typedef struct dsc
 		dsc_address = (UCHAR*) address;
 	}
 
-	void makeDecimalFixed(Firebird::DecimalFixed* address = NULL)
-	{
-		clear();
-		dsc_dtype = dtype_dec_fixed;
-		dsc_length = sizeof(Firebird::DecimalFixed);
-		dsc_address = (UCHAR*) address;
-	}
-
 	void makeInt64(SCHAR scale, SINT64* address = NULL)
 	{
 		clear();

--- a/src/common/dsc_pub.h
+++ b/src/common/dsc_pub.h
@@ -63,7 +63,8 @@
 #define dtype_boolean	21
 #define dtype_dec64		22
 #define dtype_dec128	23
-#define DTYPE_TYPE_MAX	24
+#define dtype_dec_fixed	24
+#define DTYPE_TYPE_MAX	25
 
 #define ISC_TIME_SECONDS_PRECISION		10000
 #define ISC_TIME_SECONDS_PRECISION_SCALE	(-4)

--- a/src/common/sdl.cpp
+++ b/src/common/sdl.cpp
@@ -855,6 +855,11 @@ static const UCHAR* sdl_desc(const UCHAR* ptr, DSC* desc)
 		desc->dsc_length = sizeof(Decimal128);
 		break;
 
+	case blr_dec_fixed:
+		desc->dsc_dtype = dtype_dec_fixed;
+		desc->dsc_length = sizeof(DecimalFixed);
+		break;
+
 	case blr_timestamp:
 		desc->dsc_dtype = dtype_timestamp;
 		desc->dsc_length = sizeof(ISC_QUAD);

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -1520,6 +1520,8 @@ UCHAR sqlTypeToDscType(SSHORT sqlType)
 		return dtype_dec64;
 	case SQL_DEC34:
 		return dtype_dec128;
+	case SQL_DEC_FIXED:
+		return dtype_dec_fixed;
 	default:
 		return dtype_unknown;
 	}

--- a/src/common/xdr.cpp
+++ b/src/common/xdr.cpp
@@ -260,6 +260,7 @@ bool_t xdr_datum( XDR* xdrs, const dsc* desc, UCHAR* buffer)
 		break;
 
 	case dtype_dec128:
+	case dtype_dec_fixed:
 		fb_assert(desc->dsc_length >= sizeof(Firebird::Decimal128));
 		if (!xdr_dec128(xdrs, reinterpret_cast<Firebird::Decimal128*>(p)))
 			return FALSE;

--- a/src/dsql/DdlNodes.epp
+++ b/src/dsql/DdlNodes.epp
@@ -4462,6 +4462,7 @@ void AlterDomainNode::checkUpdate(const dyn_fld& origFld, const dyn_fld& newFld)
 	case blr_float:
 	case blr_dec64:
 	case blr_dec128:
+	case blr_dec_fixed:
 		switch (newFld.dyn_dtype)
 		{
 		case blr_blob:
@@ -4587,6 +4588,23 @@ void AlterDomainNode::checkUpdate(const dyn_fld& origFld, const dyn_fld& newFld)
 			case blr_double:
 			case blr_dec64:
 			case blr_dec128:
+			case blr_dec_fixed:
+				break;
+
+			default:
+				// Cannot change datatype for column %s.  Conversion from base type %s to base type %s is not supported.
+				errorCode = isc_dyn_invalid_dtype_conversion;
+				break;
+			}
+			break;
+
+		case blr_dec_fixed:
+			switch (origFld.dyn_dtype)
+			{
+			case blr_short:
+			case blr_long:
+			case blr_int64:
+			case blr_dec_fixed:
 				break;
 
 			default:

--- a/src/dsql/ExprNodes.cpp
+++ b/src/dsql/ExprNodes.cpp
@@ -842,9 +842,12 @@ void ArithmeticNode::makeDialect3(dsc* desc, dsc& desc1, dsc& desc2)
 			// the operation, as <timestamp>-<timestamp> uses
 			// <timestamp> arithmetic, but returns a <double>
 			if (DTYPE_IS_EXACT(dtype1) && DTYPE_IS_EXACT(dtype2))
-				dtype = dtype_int64;
-			else if (desc1.isDecFixedOrInt() && desc2.isDecFixedOrInt())
-				dtype = dtype_dec_fixed;
+			{
+				if (desc1.isDecFixed() || desc2.isDecFixed())
+					dtype = dtype_dec_fixed;
+				else
+					dtype = dtype_int64;
+			}
 			else if (desc1.isDecOrInt() && desc2.isDecOrInt())
 				dtype = dtype_dec128;
 			else if (DTYPE_IS_NUMERIC(dtype1) && DTYPE_IS_NUMERIC(dtype2))
@@ -1410,10 +1413,13 @@ void ArithmeticNode::getDescDialect3(thread_db* /*tdbb*/, dsc* desc, dsc& desc1,
 			// the result dtype. The rule is that two exact numeric operands yield an int64
 			// result, while an approximate numeric and anything yield a double result.
 
-			if (DTYPE_IS_EXACT(desc1.dsc_dtype) && DTYPE_IS_EXACT(desc2.dsc_dtype))
-				dtype = dtype_int64;
-			else if (desc1.isDecFixedOrInt() && desc2.isDecFixedOrInt())
-				dtype = dtype_dec_fixed;
+			if (DTYPE_IS_EXACT(dtype1) && DTYPE_IS_EXACT(dtype2))
+			{
+				if (desc1.isDecFixed() || desc2.isDecFixed())
+					dtype = dtype_dec_fixed;
+				else
+					dtype = dtype_int64;
+			}
 			else if (desc1.isDecOrInt() && desc2.isDecOrInt())
 				dtype = dtype_dec128;
 			else if (DTYPE_IS_NUMERIC(desc1.dsc_dtype) && DTYPE_IS_NUMERIC(desc2.dsc_dtype))

--- a/src/dsql/ExprNodes.cpp
+++ b/src/dsql/ExprNodes.cpp
@@ -488,7 +488,7 @@ const UCHAR decDescTable[5][5] = {
 
 UCHAR getFType(const dsc& desc)
 {
-	switch(desc.dsc_dtype)
+	switch (desc.dsc_dtype)
 	{
 	case dtype_dec64:
 		return f64;
@@ -504,7 +504,7 @@ UCHAR getFType(const dsc& desc)
 	return other;
 }
 
-enum Scaling {SCALE_MIN, SCALE_SUM};
+enum Scaling { SCALE_MIN, SCALE_SUM };
 
 unsigned setDecDesc(dsc* desc, const dsc& desc1, const dsc& desc2, Scaling sc, SCHAR* nodScale = nullptr)
 {
@@ -517,9 +517,10 @@ unsigned setDecDesc(dsc* desc, const dsc& desc1, const dsc& desc2, Scaling sc, S
 	desc->dsc_sub_type = 0;
 	desc->dsc_flags = (desc1.dsc_flags | desc2.dsc_flags) & DSC_nullable;
 	desc->dsc_scale = 0;
+
 	if (ft == fixed)
 	{
-		switch(sc)
+		switch (sc)
 		{
 		case SCALE_MIN:
 			desc->dsc_scale = MIN(NUMERIC_SCALE(desc1), NUMERIC_SCALE(desc2));
@@ -529,9 +530,12 @@ unsigned setDecDesc(dsc* desc, const dsc& desc1, const dsc& desc2, Scaling sc, S
 			break;
 		}
 	}
+
 	if (nodScale)
 		*nodScale = desc->dsc_scale;
+
 	desc->dsc_length = ft == f64 ? sizeof(Decimal64) : ft == f128 ? sizeof(Decimal128) : sizeof(DecimalFixed);
+
 	return ft == fixed ? ExprNode::FLAG_DECFIXED : ExprNode::FLAG_DECFLOAT;
 }
 

--- a/src/dsql/Nodes.h
+++ b/src/dsql/Nodes.h
@@ -526,6 +526,7 @@ public:
 	static const unsigned FLAG_DATE			= 0x20;
 	static const unsigned FLAG_DECFLOAT		= 0x40;
 	static const unsigned FLAG_VALUE		= 0x80;	// Full value area required in impure space.
+	static const unsigned FLAG_DECFIXED		= 0x100;
 
 	explicit ExprNode(Type aType, MemoryPool& pool, Kind aKind)
 		: DmlNode(pool, aKind),

--- a/src/dsql/ddl_proto.h
+++ b/src/dsql/ddl_proto.h
@@ -59,7 +59,8 @@ const USHORT blr_dtypes[] = {
 	0,							// DB_KEY
 	blr_bool,					// dtype_boolean
 	blr_dec64,					// dtype_dec64
-	blr_dec128					// dtype_dec128
+	blr_dec128,					// dtype_dec128
+	blr_dec_fixed				// dtype_dec_fixed
 };
 
 bool DDL_ids(const Jrd::DsqlCompilerScratch*);

--- a/src/dsql/dsql.h
+++ b/src/dsql/dsql.h
@@ -257,6 +257,10 @@ public:
 				precision = 18;
 				break;
 
+			case dtype_dec_fixed:
+				precision = 34;
+				break;
+
 			default:
 				fb_assert(!DTYPE_IS_EXACT(dtype));
 		}

--- a/src/dsql/gen.cpp
+++ b/src/dsql/gen.cpp
@@ -393,6 +393,11 @@ void GEN_descriptor( DsqlCompilerScratch* dsqlScratch, const dsc* desc, bool tex
 		dsqlScratch->appendUChar(blr_dec128);
 		break;
 
+	case dtype_dec_fixed:
+		dsqlScratch->appendUChar(blr_dec_fixed);
+		dsqlScratch->appendUChar(desc->dsc_scale);
+		break;
+
 	case dtype_sql_date:
 		dsqlScratch->appendUChar(blr_sql_date);
 		break;

--- a/src/dsql/parse.y
+++ b/src/dsql/parse.y
@@ -4842,10 +4842,15 @@ prec_scale
 		{
 			$$ = newNode<dsql_fld>();
 
-			if ($2 < 1 || $2 > 18)
-				yyabandon(YYPOSNARG(2), -842, isc_precision_err);	// Precision must be between 1 and 18.
+			if ($2 < 1 || $2 > 34)
+				yyabandon(YYPOSNARG(2), -842, isc_precision_err/*2!!!!!*/);	// Precision must be between 1 and 34.
 
-			if ($2 > 9)
+			if ($2 > 18)
+			{
+				$$->dtype = dtype_dec_fixed;
+				$$->length = sizeof(DecimalFixed);
+			}
+			else if ($2 > 9)
 			{
 				if ( ( (client_dialect <= SQL_DIALECT_V5) && (db_dialect > SQL_DIALECT_V5) ) ||
 					( (client_dialect > SQL_DIALECT_V5) && (db_dialect <= SQL_DIALECT_V5) ) )
@@ -4892,13 +4897,18 @@ prec_scale
 		{
 			$$ = newNode<dsql_fld>();
 
-			if ($2 < 1 || $2 > 18)
-				yyabandon(YYPOSNARG(2), -842, isc_precision_err);	// Precision should be between 1 and 18
+			if ($2 < 1 || $2 > 34)
+				yyabandon(YYPOSNARG(2), -842, isc_precision_err/*2!!!!!*/);	// Precision must be between 1 and 34.
 
 			if ($4 > $2 || $4 < 0)
 				yyabandon(YYPOSNARG(4), -842, isc_scale_nogt);	// Scale must be between 0 and precision
 
-			if ($2 > 9)
+			if ($2 > 18)
+			{
+				$$->dtype = dtype_dec_fixed;
+				$$->length = sizeof(DecimalFixed);
+			}
+			else if ($2 > 9)
 			{
 				if ( ( (client_dialect <= SQL_DIALECT_V5) && (db_dialect > SQL_DIALECT_V5) ) ||
 					( (client_dialect > SQL_DIALECT_V5) && (db_dialect <= SQL_DIALECT_V5) ) )

--- a/src/dsql/sqlda_pub.h
+++ b/src/dsql/sqlda_pub.h
@@ -78,6 +78,7 @@ typedef struct
 #define SQL_TYPE_TIME                      560
 #define SQL_TYPE_DATE                      570
 #define SQL_INT64                          580
+#define SQL_DEC_FIXED                    32758
 #define SQL_DEC16                        32760
 #define SQL_DEC34                        32762
 #define SQL_BOOLEAN                      32764

--- a/src/include/firebird/FirebirdInterface.idl
+++ b/src/include/firebird/FirebirdInterface.idl
@@ -31,6 +31,7 @@ typedef ISC_QUAD;
 typedef ISC_TIME;
 typedef FB_DEC16;
 typedef FB_DEC34;
+typedef FB_DEC_FIXED;
 
 // Versioned interface - base for all FB interfaces
 interface Versioned
@@ -989,6 +990,7 @@ version:	// 3.0 => 4.0
 	EventBlock createEventBlock(Status status, const string* events);
 	DecFloat16 getDecFloat16(Status status);
 	DecFloat34 getDecFloat34(Status status);
+	DecFixed getDecFixed(Status status);
 }
 
 interface OffsetsCallback : Versioned
@@ -1391,4 +1393,14 @@ interface DecFloat34 : Versioned
 	void toString(Status status, const FB_DEC34* from, uint bufferLength, string buffer);
 	void fromBcd(int sign, const uchar* bcd, int exp, FB_DEC34* to);
 	void fromString(Status status, const string from, FB_DEC34* to);
+}
+
+interface DecFixed : Versioned
+{
+	const uint BCD_SIZE = 34;
+	const uint STRING_SIZE = 41;	// may include exponent not more than 3 digits
+	void toBcd(const FB_DEC_FIXED* from, int* sign, uchar* bcd);
+	void toString(Status status, const FB_DEC_FIXED* from, int scale, uint bufferLength, string buffer);
+	void fromBcd(int sign, const uchar* bcd, FB_DEC_FIXED* to);
+	void fromString(Status status, const string from, int scale, FB_DEC_FIXED* to);
 }

--- a/src/include/firebird/IdlFbInterfaces.h
+++ b/src/include/firebird/IdlFbInterfaces.h
@@ -113,6 +113,7 @@ namespace Firebird
 	class IUdrPlugin;
 	class IDecFloat16;
 	class IDecFloat34;
+	class IDecFixed;
 
 	// Interfaces declarations
 
@@ -3699,6 +3700,7 @@ namespace Firebird
 			IEventBlock* (CLOOP_CARG *createEventBlock)(IUtil* self, IStatus* status, const char** events) throw();
 			IDecFloat16* (CLOOP_CARG *getDecFloat16)(IUtil* self, IStatus* status) throw();
 			IDecFloat34* (CLOOP_CARG *getDecFloat34)(IUtil* self, IStatus* status) throw();
+			IDecFixed* (CLOOP_CARG *getDecFixed)(IUtil* self, IStatus* status) throw();
 		};
 
 	protected:
@@ -3838,6 +3840,20 @@ namespace Firebird
 			}
 			StatusType::clearException(status);
 			IDecFloat34* ret = static_cast<VTable*>(this->cloopVTable)->getDecFloat34(this, status);
+			StatusType::checkException(status);
+			return ret;
+		}
+
+		template <typename StatusType> IDecFixed* getDecFixed(StatusType* status)
+		{
+			if (cloopVTable->version < 3)
+			{
+				StatusType::setVersionError(status, "IUtil", cloopVTable->version, 3);
+				StatusType::checkException(status);
+				return 0;
+			}
+			StatusType::clearException(status);
+			IDecFixed* ret = static_cast<VTable*>(this->cloopVTable)->getDecFixed(this, status);
 			StatusType::checkException(status);
 			return ret;
 		}
@@ -5416,6 +5432,58 @@ namespace Firebird
 		{
 			StatusType::clearException(status);
 			static_cast<VTable*>(this->cloopVTable)->fromString(this, status, from, to);
+			StatusType::checkException(status);
+		}
+	};
+
+	class IDecFixed : public IVersioned
+	{
+	public:
+		struct VTable : public IVersioned::VTable
+		{
+			void (CLOOP_CARG *toBcd)(IDecFixed* self, const FB_DEC_FIXED* from, int* sign, unsigned char* bcd) throw();
+			void (CLOOP_CARG *toString)(IDecFixed* self, IStatus* status, const FB_DEC_FIXED* from, int scale, unsigned bufferLength, char* buffer) throw();
+			void (CLOOP_CARG *fromBcd)(IDecFixed* self, int sign, const unsigned char* bcd, FB_DEC_FIXED* to) throw();
+			void (CLOOP_CARG *fromString)(IDecFixed* self, IStatus* status, const char* from, int scale, FB_DEC_FIXED* to) throw();
+		};
+
+	protected:
+		IDecFixed(DoNotInherit)
+			: IVersioned(DoNotInherit())
+		{
+		}
+
+		~IDecFixed()
+		{
+		}
+
+	public:
+		static const unsigned VERSION = 2;
+
+		static const unsigned BCD_SIZE = 34;
+		static const unsigned STRING_SIZE = 41;
+
+		void toBcd(const FB_DEC_FIXED* from, int* sign, unsigned char* bcd)
+		{
+			static_cast<VTable*>(this->cloopVTable)->toBcd(this, from, sign, bcd);
+		}
+
+		template <typename StatusType> void toString(StatusType* status, const FB_DEC_FIXED* from, int scale, unsigned bufferLength, char* buffer)
+		{
+			StatusType::clearException(status);
+			static_cast<VTable*>(this->cloopVTable)->toString(this, status, from, scale, bufferLength, buffer);
+			StatusType::checkException(status);
+		}
+
+		void fromBcd(int sign, const unsigned char* bcd, FB_DEC_FIXED* to)
+		{
+			static_cast<VTable*>(this->cloopVTable)->fromBcd(this, sign, bcd, to);
+		}
+
+		template <typename StatusType> void fromString(StatusType* status, const char* from, int scale, FB_DEC_FIXED* to)
+		{
+			StatusType::clearException(status);
+			static_cast<VTable*>(this->cloopVTable)->fromString(this, status, from, scale, to);
 			StatusType::checkException(status);
 		}
 	};
@@ -13093,6 +13161,7 @@ namespace Firebird
 					this->createEventBlock = &Name::cloopcreateEventBlockDispatcher;
 					this->getDecFloat16 = &Name::cloopgetDecFloat16Dispatcher;
 					this->getDecFloat34 = &Name::cloopgetDecFloat34Dispatcher;
+					this->getDecFixed = &Name::cloopgetDecFixedDispatcher;
 				}
 			} vTable;
 
@@ -13320,6 +13389,21 @@ namespace Firebird
 				return static_cast<IDecFloat34*>(0);
 			}
 		}
+
+		static IDecFixed* CLOOP_CARG cloopgetDecFixedDispatcher(IUtil* self, IStatus* status) throw()
+		{
+			StatusType status2(status);
+
+			try
+			{
+				return static_cast<Name*>(self)->Name::getDecFixed(&status2);
+			}
+			catch (...)
+			{
+				StatusType::catchException(&status2);
+				return static_cast<IDecFixed*>(0);
+			}
+		}
 	};
 
 	template <typename Name, typename StatusType, typename Base = IVersionedImpl<Name, StatusType, Inherit<IUtil> > >
@@ -13351,6 +13435,7 @@ namespace Firebird
 		virtual IEventBlock* createEventBlock(StatusType* status, const char** events) = 0;
 		virtual IDecFloat16* getDecFloat16(StatusType* status) = 0;
 		virtual IDecFloat34* getDecFloat34(StatusType* status) = 0;
+		virtual IDecFixed* getDecFixed(StatusType* status) = 0;
 	};
 
 	template <typename Name, typename StatusType, typename Base>
@@ -16747,6 +16832,101 @@ namespace Firebird
 		virtual void toString(StatusType* status, const FB_DEC34* from, unsigned bufferLength, char* buffer) = 0;
 		virtual void fromBcd(int sign, const unsigned char* bcd, int exp, FB_DEC34* to) = 0;
 		virtual void fromString(StatusType* status, const char* from, FB_DEC34* to) = 0;
+	};
+
+	template <typename Name, typename StatusType, typename Base>
+	class IDecFixedBaseImpl : public Base
+	{
+	public:
+		typedef IDecFixed Declaration;
+
+		IDecFixedBaseImpl(DoNotInherit = DoNotInherit())
+		{
+			static struct VTableImpl : Base::VTable
+			{
+				VTableImpl()
+				{
+					this->version = Base::VERSION;
+					this->toBcd = &Name::clooptoBcdDispatcher;
+					this->toString = &Name::clooptoStringDispatcher;
+					this->fromBcd = &Name::cloopfromBcdDispatcher;
+					this->fromString = &Name::cloopfromStringDispatcher;
+				}
+			} vTable;
+
+			this->cloopVTable = &vTable;
+		}
+
+		static void CLOOP_CARG clooptoBcdDispatcher(IDecFixed* self, const FB_DEC_FIXED* from, int* sign, unsigned char* bcd) throw()
+		{
+			try
+			{
+				static_cast<Name*>(self)->Name::toBcd(from, sign, bcd);
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+			}
+		}
+
+		static void CLOOP_CARG clooptoStringDispatcher(IDecFixed* self, IStatus* status, const FB_DEC_FIXED* from, int scale, unsigned bufferLength, char* buffer) throw()
+		{
+			StatusType status2(status);
+
+			try
+			{
+				static_cast<Name*>(self)->Name::toString(&status2, from, scale, bufferLength, buffer);
+			}
+			catch (...)
+			{
+				StatusType::catchException(&status2);
+			}
+		}
+
+		static void CLOOP_CARG cloopfromBcdDispatcher(IDecFixed* self, int sign, const unsigned char* bcd, FB_DEC_FIXED* to) throw()
+		{
+			try
+			{
+				static_cast<Name*>(self)->Name::fromBcd(sign, bcd, to);
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+			}
+		}
+
+		static void CLOOP_CARG cloopfromStringDispatcher(IDecFixed* self, IStatus* status, const char* from, int scale, FB_DEC_FIXED* to) throw()
+		{
+			StatusType status2(status);
+
+			try
+			{
+				static_cast<Name*>(self)->Name::fromString(&status2, from, scale, to);
+			}
+			catch (...)
+			{
+				StatusType::catchException(&status2);
+			}
+		}
+	};
+
+	template <typename Name, typename StatusType, typename Base = IVersionedImpl<Name, StatusType, Inherit<IDecFixed> > >
+	class IDecFixedImpl : public IDecFixedBaseImpl<Name, StatusType, Base>
+	{
+	protected:
+		IDecFixedImpl(DoNotInherit = DoNotInherit())
+		{
+		}
+
+	public:
+		virtual ~IDecFixedImpl()
+		{
+		}
+
+		virtual void toBcd(const FB_DEC_FIXED* from, int* sign, unsigned char* bcd) = 0;
+		virtual void toString(StatusType* status, const FB_DEC_FIXED* from, int scale, unsigned bufferLength, char* buffer) = 0;
+		virtual void fromBcd(int sign, const unsigned char* bcd, FB_DEC_FIXED* to) = 0;
+		virtual void fromString(StatusType* status, const char* from, int scale, FB_DEC_FIXED* to) = 0;
 	};
 };
 

--- a/src/include/firebird/Message.h
+++ b/src/include/firebird/Message.h
@@ -141,6 +141,10 @@
 	builder->setType(status, index, SQL_DEC34);	\
 	builder->setLength(status, index, sizeof(FB_DEC34));
 
+#define FB__META_FB_DEC_FIXED	\
+	builder->setType(status, index, SQL_DEC_FIXED);	\
+	builder->setLength(status, index, sizeof(FB_DEC_FIXED));
+
 #define FB__META_FB_BLOB	\
 	builder->setType(status, index, SQL_BLOB);	\
 	builder->setLength(status, index, sizeof(ISC_QUAD));
@@ -195,6 +199,7 @@
 #define FB__TYPE_FB_DOUBLE						double
 #define FB__TYPE_FB_DECFLOAT16					FB_DEC16
 #define FB__TYPE_FB_DECFLOAT34					FB_DEC34
+#define FB__TYPE_FB_DEC_FIXED					FB_DEC_FIXED
 #define FB__TYPE_FB_BLOB						ISC_QUAD
 #define FB__TYPE_FB_BOOLEAN						ISC_UCHAR
 #define FB__TYPE_FB_DATE						::Firebird::FbDate

--- a/src/include/firebird/Message.h
+++ b/src/include/firebird/Message.h
@@ -141,9 +141,10 @@
 	builder->setType(status, index, SQL_DEC34);	\
 	builder->setLength(status, index, sizeof(FB_DEC34));
 
-#define FB__META_FB_DEC_FIXED	\
+#define FB__META_FB_DEC_FIXED(scale)	\
 	builder->setType(status, index, SQL_DEC_FIXED);	\
-	builder->setLength(status, index, sizeof(FB_DEC_FIXED));
+	builder->setLength(status, index, sizeof(FB_DEC_FIXED));	\
+	builder->setScale(status, index, scale);
 
 #define FB__META_FB_BLOB	\
 	builder->setType(status, index, SQL_BLOB);	\

--- a/src/include/types_pub.h
+++ b/src/include/types_pub.h
@@ -178,7 +178,12 @@ struct FB_DEC34_t {
 	ISC_UINT64 fb_data[2];
 };
 
+struct FB_DEC_FIXED_t {
+	ISC_UINT64 fb_data[2];
+};
+
 typedef struct FB_DEC16_t FB_DEC16;
 typedef struct FB_DEC34_t FB_DEC34;
+typedef struct FB_DEC_FIXED_t FB_DEC_FIXED;
 
 #endif /* INCLUDE_TYPES_PUB_H */

--- a/src/isql/isql.epp
+++ b/src/isql/isql.epp
@@ -3100,7 +3100,7 @@ static processing_state bulk_insert_hack(const char* command)
 				case SQL_DEC16:
 					d64value = (FB_DEC16*) datap;
 					if (isqlGlob.df16)
-						isqlGlob.df16->fromString(fbStatus, lastInputLine, d64value);
+						isqlGlob.df16->fromString(fbStatus, lastPos, d64value);
 					if ((!isqlGlob.df16) || (fbStatus->getState() & Firebird::IStatus::STATE_ERRORS))
 					{
 						STDERROUT("Input parsing problem");
@@ -3111,7 +3111,7 @@ static processing_state bulk_insert_hack(const char* command)
 				case SQL_DEC34:
 					d128value = (FB_DEC34*) datap;
 					if (isqlGlob.df34)
-						isqlGlob.df34->fromString(fbStatus, lastInputLine, d128value);
+						isqlGlob.df34->fromString(fbStatus, lastPos, d128value);
 					if ((!isqlGlob.df34) || (fbStatus->getState() & Firebird::IStatus::STATE_ERRORS))
 					{
 						STDERROUT("Input parsing problem");
@@ -3126,7 +3126,7 @@ static processing_state bulk_insert_hack(const char* command)
 
 					dfixvalue = (FB_DEC_FIXED*) datap;
 					if (isqlGlob.dfix)
-						isqlGlob.dfix->fromString(fbStatus, lastInputLine, scale, dfixvalue);
+						isqlGlob.dfix->fromString(fbStatus, lastPos, scale, dfixvalue);
 					if ((!isqlGlob.dfix) || (fbStatus->getState() & Firebird::IStatus::STATE_ERRORS))
 					{
 						STDERROUT("Input parsing problem");

--- a/src/isql/isql.epp
+++ b/src/isql/isql.epp
@@ -1986,6 +1986,50 @@ void ISQL_print_validation(FILE* fp,
 }
 
 
+static Firebird::string get_numeric_value(const char* fromStr)
+{
+/**************************************
+ *
+ *	g e t _ n u m e r i c _ v a l u e
+ *
+ **************************************
+ *
+ * Functional description
+ *	Prepares data for converting into decfloat by interface function.
+ *
+ **************************************/
+	Firebird::string val;
+	for (const char* q = fromStr; *q; ++q)
+	{
+		switch(*q)
+		{
+		case '0':
+		case '1':
+		case '2':
+		case '3':
+		case '4':
+		case '5':
+		case '6':
+		case '7':
+		case '8':
+		case '9':
+		case '.':
+		case '+':
+		case '-':
+		case 'e':
+		case 'E':
+			val += *q;
+			break;
+
+		default:
+			return val;
+		}
+	}
+
+	return val;
+}
+
+
 static processing_state add_row(TEXT* tabname)
 {
 /**************************************
@@ -3100,7 +3144,7 @@ static processing_state bulk_insert_hack(const char* command)
 				case SQL_DEC16:
 					d64value = (FB_DEC16*) datap;
 					if (isqlGlob.df16)
-						isqlGlob.df16->fromString(fbStatus, lastPos, d64value);
+						isqlGlob.df16->fromString(fbStatus, get_numeric_value(lastPos).c_str(), d64value);
 					if ((!isqlGlob.df16) || (fbStatus->getState() & Firebird::IStatus::STATE_ERRORS))
 					{
 						STDERROUT("Input parsing problem");
@@ -3111,7 +3155,7 @@ static processing_state bulk_insert_hack(const char* command)
 				case SQL_DEC34:
 					d128value = (FB_DEC34*) datap;
 					if (isqlGlob.df34)
-						isqlGlob.df34->fromString(fbStatus, lastPos, d128value);
+						isqlGlob.df34->fromString(fbStatus, get_numeric_value(lastPos).c_str(), d128value);
 					if ((!isqlGlob.df34) || (fbStatus->getState() & Firebird::IStatus::STATE_ERRORS))
 					{
 						STDERROUT("Input parsing problem");
@@ -3126,7 +3170,9 @@ static processing_state bulk_insert_hack(const char* command)
 
 					dfixvalue = (FB_DEC_FIXED*) datap;
 					if (isqlGlob.dfix)
-						isqlGlob.dfix->fromString(fbStatus, lastPos, scale, dfixvalue);
+					{
+						isqlGlob.dfix->fromString(fbStatus, get_numeric_value(lastPos).c_str(), scale, dfixvalue);
+					}
 					if ((!isqlGlob.dfix) || (fbStatus->getState() & Firebird::IStatus::STATE_ERRORS))
 					{
 						STDERROUT("Input parsing problem");

--- a/src/isql/isql.epp
+++ b/src/isql/isql.epp
@@ -317,6 +317,7 @@ IsqlGlobals::IsqlGlobals()
 
 	df16 = Firebird::UtilInterfacePtr()->getDecFloat16(&statusWrapper);
 	df34 = Firebird::UtilInterfacePtr()->getDecFloat34(&statusWrapper);
+	dfix = Firebird::UtilInterfacePtr()->getDecFixed(&statusWrapper);
 }
 
 // I s q l G l o b a l s : : p r i n t f
@@ -1835,6 +1836,7 @@ bool ISQL_printNumericType(const char* fieldName, const int fieldType, const int
 	case INTEGER:
 	case BIGINT:
 	case DOUBLE_PRECISION:
+	case DEC_FIXED_TYPE:
 		// Handle Integral subtypes NUMERIC and DECIMAL
 		// We are ODS >= 10 and could be any Dialect
 
@@ -1867,6 +1869,9 @@ bool ISQL_printNumericType(const char* fieldName, const int fieldType, const int
 					break;
 				case DOUBLE_PRECISION:
 					isqlGlob.printf("NUMERIC(15, %d)", -fieldScale);
+					break;
+				case DEC_FIXED_TYPE:
+					isqlGlob.printf("NUMERIC(34, %d)", -fieldScale);
 					break;
 				}
 			}
@@ -2237,6 +2242,7 @@ static processing_state add_row(TEXT* tabname)
 				double* dvalue;
 				FB_DEC16* d64value;
 				FB_DEC34* d128value;
+				FB_DEC_FIXED* dfixvalue;
 				UCHAR* boolean;
 				ISC_QUAD* blobid;
 				vary* avary;
@@ -2319,6 +2325,21 @@ static processing_state add_row(TEXT* tabname)
 					if (isqlGlob.df34)
 						isqlGlob.df34->fromString(fbStatus, lastInputLine, d128value);
 					if ((!isqlGlob.df34) || (fbStatus->getState() & Firebird::IStatus::STATE_ERRORS))
+					{
+						STDERROUT("Input parsing problem");
+						done = true;
+					}
+					break;
+
+				case SQL_DEC_FIXED:
+					scale = msg->getScale(fbStatus, i);
+					if (ISQL_errmsg(fbStatus))
+						return (SKIP);
+
+					dfixvalue = (FB_DEC_FIXED*) datap;
+					if (isqlGlob.dfix)
+						isqlGlob.dfix->fromString(fbStatus, lastInputLine, scale, dfixvalue);
+					if ((!isqlGlob.dfix) || (fbStatus->getState() & Firebird::IStatus::STATE_ERRORS))
 					{
 						STDERROUT("Input parsing problem");
 						done = true;
@@ -3016,6 +3037,7 @@ static processing_state bulk_insert_hack(const char* command)
 				tm times;
 				FB_DEC16* d64value;
 				FB_DEC34* d128value;
+				FB_DEC_FIXED* dfixvalue;
 				// Initialize the time structure.
 				memset(&times, 0, sizeof(times));
 				char msec_str[5] = "";
@@ -3091,6 +3113,21 @@ static processing_state bulk_insert_hack(const char* command)
 					if (isqlGlob.df34)
 						isqlGlob.df34->fromString(fbStatus, lastInputLine, d128value);
 					if ((!isqlGlob.df34) || (fbStatus->getState() & Firebird::IStatus::STATE_ERRORS))
+					{
+						STDERROUT("Input parsing problem");
+						done = true;
+					}
+					break;
+
+				case SQL_DEC_FIXED:
+					scale = message->getScale(fbStatus, i);
+					if (ISQL_errmsg(fbStatus))
+						return (SKIP);
+
+					dfixvalue = (FB_DEC_FIXED*) datap;
+					if (isqlGlob.dfix)
+						isqlGlob.dfix->fromString(fbStatus, lastInputLine, scale, dfixvalue);
+					if ((!isqlGlob.dfix) || (fbStatus->getState() & Firebird::IStatus::STATE_ERRORS))
 					{
 						STDERROUT("Input parsing problem");
 						done = true;
@@ -7272,6 +7309,25 @@ static unsigned print_item(TEXT** s, const IsqlVar* var, const unsigned length)
 			}
 			break;
 
+		case SQL_DEC_FIXED:
+			{
+				char decStr[Firebird::IDecFixed::STRING_SIZE];
+				if (isqlGlob.dfix)
+				{
+					isqlGlob.dfix->toString(fbStatus, var->value.asDecFixed, dscale, sizeof(decStr), decStr);
+					if (ISQL_errmsg(fbStatus))
+						strcpy(decStr, convErr);
+				}
+				else
+					strcpy(decStr, convErr);
+
+				if (setValues.List)
+					isqlGlob.printf("%*.*s%s", sizeof(decStr) - 1, sizeof(decStr) - 1, decStr, NEWLINE);
+				else
+					sprintf(p, "%*.*s ", sizeof(decStr) - 1, sizeof(decStr) - 1, decStr);
+			}
+			break;
+
 		case SQL_TEXT:
 			str2 = var->value.asChar;
 			// See if it is character set OCTETS
@@ -8054,6 +8110,9 @@ static unsigned process_message_display(Firebird::IMessageMetadata* message, uns
 		case SQL_DEC34:
 			disp_length = Firebird::IDecFloat34::STRING_SIZE - 1;
 			break;
+		case SQL_DEC_FIXED:
+			disp_length = Firebird::IDecFixed::STRING_SIZE - 1;
+			break;
 		case SQL_TEXT:
 			alignment = 1;
 			data_length++;
@@ -8710,6 +8769,8 @@ static const char* sqltype_to_string(unsigned sqltype)
 		return "DECFLOAT(16)";
 	case SQL_DEC34:
 		return "DECFLOAT(34)";
+	case SQL_DEC_FIXED:
+		return "DECIMAL FIXED";
 	case SQL_D_FLOAT:
 		return "D_FLOAT";
 	case SQL_TIMESTAMP:

--- a/src/isql/isql.epp
+++ b/src/isql/isql.epp
@@ -2001,7 +2001,7 @@ static Firebird::string get_numeric_value(const char* fromStr)
 	Firebird::string val;
 	for (const char* q = fromStr; *q; ++q)
 	{
-		switch(*q)
+		switch (*q)
 		{
 		case '0':
 		case '1':
@@ -2381,8 +2381,10 @@ static processing_state add_row(TEXT* tabname)
 						return (SKIP);
 
 					dfixvalue = (FB_DEC_FIXED*) datap;
+
 					if (isqlGlob.dfix)
 						isqlGlob.dfix->fromString(fbStatus, lastInputLine, scale, dfixvalue);
+
 					if ((!isqlGlob.dfix) || (fbStatus->getState() & Firebird::IStatus::STATE_ERRORS))
 					{
 						STDERROUT("Input parsing problem");

--- a/src/isql/isql.h
+++ b/src/isql/isql.h
@@ -297,6 +297,7 @@ const int BIGINT		= 16;
 const int BOOLEAN_TYPE	= 23;
 const int DEC64_TYPE	= 24;
 const int DEC128_TYPE	= 25;
+const int DEC_FIXED_TYPE = 26;
 
 static const sqltypes Column_types[] = {
 	{SMALLINT, "SMALLINT"},		// keyword
@@ -316,6 +317,7 @@ static const sqltypes Column_types[] = {
 	{BOOLEAN_TYPE, "BOOLEAN"},	// keyword
 	{DEC64_TYPE, "DECFLOAT(16)"},
 	{DEC128_TYPE, "DECFLOAT(34)"},
+	{DEC_FIXED_TYPE, "<Should not be shown>"},
 	{0, ""}
 };
 
@@ -404,6 +406,7 @@ public:
 	USHORT att_charset;
 	Firebird::IDecFloat16* df16;
 	Firebird::IDecFloat34* df34;
+	Firebird::IDecFixed* dfix;
 	void printf(const char* buffer, ...);
 	void prints(const char* buffer);
 
@@ -463,6 +466,7 @@ struct IsqlVar
 		char* asChar;
 		FB_DEC16* asDec16;
 		FB_DEC34* asDec34;
+		FB_DEC_FIXED* asDecFixed;
 		void* setPtr;
 	};
 	TypeMix value;

--- a/src/jrd/PreparedStatement.cpp
+++ b/src/jrd/PreparedStatement.cpp
@@ -109,6 +109,11 @@ namespace
 				item.length = sizeof(Decimal128);
 				break;
 
+			case dtype_dec_fixed:
+				item.type = SQL_DEC_FIXED;
+				item.length = sizeof(DecimalFixed);
+				break;
+
 			case dtype_sql_date:
 				item.type = SQL_TYPE_DATE;
 				item.length = sizeof(SLONG);

--- a/src/jrd/PreparedStatement.cpp
+++ b/src/jrd/PreparedStatement.cpp
@@ -111,6 +111,7 @@ namespace
 
 			case dtype_dec_fixed:
 				item.type = SQL_DEC_FIXED;
+				item.scale = desc->dsc_scale;
 				item.length = sizeof(DecimalFixed);
 				break;
 

--- a/src/jrd/align.h
+++ b/src/jrd/align.h
@@ -70,7 +70,7 @@ static const USHORT gds_cvt_blr_dtype[DTYPE_BLR_MAX + 1] =
 	dtype_boolean,				// blr_bool == 23
 	dtype_dec64,				/* blr_dec64 == 24 */
 	dtype_dec128,				/* blr_dec128 == 25 */
-	0,
+	dtype_dec_fixed,			/* blr_dec_fixed == 26 */
 	dtype_double,				/* blr_double == 27 */
 	0, 0, 0, 0, 0, 0, 0,
 	dtype_timestamp,			/* blr_timestamp == 35 */
@@ -108,7 +108,8 @@ static const USHORT type_alignments[DTYPE_TYPE_MAX] =
 	sizeof(ULONG),				/* dtype_dbkey */
 	sizeof(UCHAR),				/* dtype_boolean */
 	sizeof(Firebird::Decimal64),/* dtype_dec64 */
-	sizeof(Firebird::Decimal64)	/* dtype_dec128 */
+	sizeof(Firebird::Decimal64),/* dtype_dec128 */
+	sizeof(Firebird::Decimal64)	/* dtype_dec_fixed */
 };
 
 static const USHORT type_lengths[DTYPE_TYPE_MAX] =
@@ -133,10 +134,11 @@ static const USHORT type_lengths[DTYPE_TYPE_MAX] =
 	sizeof(ISC_QUAD),			/* dtype_blob */
 	sizeof(ISC_QUAD),			/* dtype_array */
 	sizeof(SINT64),				/* dtype_int64 */
-	sizeof(RecordNumber::Packed), /*dtype_dbkey */
+	sizeof(RecordNumber::Packed),/*dtype_dbkey */
 	sizeof(UCHAR),				/* dtype_boolean */
 	sizeof(Firebird::Decimal64),/* dtype_dec64 */
-	sizeof(Firebird::Decimal128)/* dtype_dec128 */
+	sizeof(Firebird::Decimal128),/*dtype_dec128 */
+	sizeof(Firebird::DecimalFixed)	/*	dtype_dec_fixed */
 };
 
 
@@ -167,7 +169,8 @@ static const USHORT type_significant_bits[DTYPE_TYPE_MAX] =
 	0,							// dtype_dbkey
 	0,							// dtype_boolean
 	0,							// dtype_dec64
-	0							// dtype_dec128
+	0,							// dtype_dec128
+	0							// dtype_dec_fixed
 };
 
 #endif /* JRD_ALIGN_H */

--- a/src/jrd/blr.h
+++ b/src/jrd/blr.h
@@ -69,6 +69,7 @@
 #define blr_bool			(unsigned char)23
 #define blr_dec64			(unsigned char)24
 #define blr_dec128			(unsigned char)25
+#define blr_dec_fixed		(unsigned char)26
 
 // first sub parameter for blr_domain_name[2]
 #define blr_domain_type_of	(unsigned char)0

--- a/src/jrd/cvt2.cpp
+++ b/src/jrd/cvt2.cpp
@@ -292,6 +292,9 @@ int CVT2_compare(const dsc* arg1, const dsc* arg2, Firebird::DecimalStatus decSt
 		case dtype_dec128:
 			return ((Decimal128*) p1)->compare(decSt, *(Decimal128*) p2);
 
+		case dtype_dec_fixed:
+			return ((DecimalFixed*) p1)->compare(decSt, *(DecimalFixed*) p2);
+
 		case dtype_boolean:
 			return *p1 == *p2 ? 0 : *p1 < *p2 ? -1 : 1;
 
@@ -521,6 +524,13 @@ int CVT2_compare(const dsc* arg1, const dsc* arg2, Firebird::DecimalStatus decSt
 		{
 			const Decimal128 temp1 = CVT_get_dec128(arg1, decSt, ERR_post);
 			const Decimal128 temp2 = CVT_get_dec128(arg2, decSt, ERR_post);
+			return temp1.compare(decSt, temp2);
+		}
+
+	case dtype_dec_fixed:
+		{
+			const DecimalFixed temp1 = CVT_get_dec_fixed(arg1, decSt, ERR_post);
+			const DecimalFixed temp2 = CVT_get_dec_fixed(arg2, decSt, ERR_post);
 			return temp1.compare(decSt, temp2);
 		}
 

--- a/src/jrd/cvt2.cpp
+++ b/src/jrd/cvt2.cpp
@@ -529,8 +529,14 @@ int CVT2_compare(const dsc* arg1, const dsc* arg2, Firebird::DecimalStatus decSt
 
 	case dtype_dec_fixed:
 		{
-			const DecimalFixed temp1 = CVT_get_dec_fixed(arg1, decSt, ERR_post);
-			const DecimalFixed temp2 = CVT_get_dec_fixed(arg2, decSt, ERR_post);
+			SSHORT scale;
+			if (arg2->dsc_dtype > dtype_varying)
+				scale = MIN(arg1->dsc_scale, arg2->dsc_scale);
+			else
+				scale = arg1->dsc_scale;
+
+			const DecimalFixed temp1 = CVT_get_dec_fixed(arg1, scale, decSt, ERR_post);
+			const DecimalFixed temp2 = CVT_get_dec_fixed(arg2, scale, decSt, ERR_post);
 			return temp1.compare(decSt, temp2);
 		}
 

--- a/src/jrd/dfw.epp
+++ b/src/jrd/dfw.epp
@@ -1243,6 +1243,7 @@ USHORT DFW_assign_index_type(thread_db* tdbb, const Firebird::MetaName& name, SS
 		return idx_boolean;
 	case dtype_dec64:
 	case dtype_dec128:
+	case dtype_dec_fixed:
 		return idx_decimal;
 	default:
 		return idx_numeric;

--- a/src/jrd/evl.cpp
+++ b/src/jrd/evl.cpp
@@ -434,6 +434,10 @@ void EVL_make_value(thread_db* tdbb, const dsc* desc, impure_value* value, Memor
 		value->vlu_misc.vlu_dec128 = *((Decimal128*) from.dsc_address);
 		return;
 
+	case dtype_dec_fixed:
+		value->vlu_misc.vlu_dec_fixed = *((DecimalFixed*) from.dsc_address);
+		return;
+
 	case dtype_timestamp:
 	case dtype_quad:
 		value->vlu_misc.vlu_dbkey[0] = ((SLONG*) from.dsc_address)[0];

--- a/src/jrd/fun.epp
+++ b/src/jrd/fun.epp
@@ -605,6 +605,7 @@ void FUN_evaluate(thread_db* tdbb, const Function* function, const NestValueArra
 				break;
 
 			case dtype_dec128:
+			case dtype_dec_fixed:
 				{
 					const Decimal128 d = MOV_get_dec128(tdbb, input);
 					if (parameter->prm_fun_mechanism == FUN_value)
@@ -812,6 +813,21 @@ void FUN_evaluate(thread_db* tdbb, const Function* function, const NestValueArra
 									Arg::Str(function->getName().toString()));
 			}
 			else if (value->vlu_misc.vlu_dec128.isNan())
+			{
+				status_exception::raise(Arg::Gds(isc_expression_eval_err) <<
+									Arg::Gds(isc_udf_fp_nan) <<
+									Arg::Str(function->getName().toString()));
+			}
+			break;
+
+		case dtype_dec_fixed:
+			if (value->vlu_misc.vlu_dec_fixed.isInf())
+			{
+				status_exception::raise(Arg::Gds(isc_expression_eval_err) <<
+									Arg::Gds(isc_udf_fp_overflow) <<
+									Arg::Str(function->getName().toString()));
+			}
+			else if (value->vlu_misc.vlu_dec_fixed.isNan())
 			{
 				status_exception::raise(Arg::Gds(isc_expression_eval_err) <<
 									Arg::Gds(isc_udf_fp_nan) <<
@@ -1118,6 +1134,10 @@ static void invoke(thread_db* tdbb,
 
 		case dtype_dec128:
 			value->vlu_misc.vlu_dec128 = CALL_UDF<Decimal128>(tdbb, function->fun_entrypoint, args);
+			break;
+
+		case dtype_dec_fixed:
+			value->vlu_misc.vlu_dec_fixed = CALL_UDF<DecimalFixed>(tdbb, function->fun_entrypoint, args);
 			break;
 
 		case dtype_timestamp:

--- a/src/jrd/mov.cpp
+++ b/src/jrd/mov.cpp
@@ -440,6 +440,18 @@ Decimal128 MOV_get_dec128(Jrd::thread_db* tdbb, const dsc* desc)
 }
 
 
+DecimalFixed MOV_get_dec_fixed(Jrd::thread_db* tdbb, const dsc* desc, SSHORT scale)
+{
+/**************************************
+ *
+ *	M O V _ g e t _ d e c 1 2 8
+ *
+ **************************************/
+
+	return CVT_get_dec_fixed(desc, scale, tdbb->getAttachment()->att_dec_status, ERR_post);
+}
+
+
 namespace Jrd
 {
 

--- a/src/jrd/mov.cpp
+++ b/src/jrd/mov.cpp
@@ -444,7 +444,7 @@ DecimalFixed MOV_get_dec_fixed(Jrd::thread_db* tdbb, const dsc* desc, SSHORT sca
 {
 /**************************************
  *
- *	M O V _ g e t _ d e c 1 2 8
+ *	M O V _ g e t _ d e c _ f i x e d
  *
  **************************************/
 

--- a/src/jrd/mov_proto.h
+++ b/src/jrd/mov_proto.h
@@ -52,6 +52,7 @@ Firebird::string MOV_make_string2(Jrd::thread_db* tdbb, const dsc* desc, USHORT 
 void	MOV_move(Jrd::thread_db*, /*const*/ dsc*, dsc*);
 Firebird::Decimal64 MOV_get_dec64(Jrd::thread_db*, const dsc*);
 Firebird::Decimal128 MOV_get_dec128(Jrd::thread_db*, const dsc*);
+Firebird::DecimalFixed MOV_get_dec_fixed(Jrd::thread_db*, const dsc*, SSHORT);
 
 namespace Jrd
 {

--- a/src/jrd/opt.cpp
+++ b/src/jrd/opt.cpp
@@ -396,7 +396,8 @@ static const UCHAR sort_dtypes[] =
 	SKD_text,					// dtype_dbkey - use text sort for backward compatibility
 	SKD_bytes,					// dtype_boolean
 	SKD_dec64,					// dtype_dec64
-	SKD_dec128					// dtype_dec128
+	SKD_dec128,					// dtype_dec128
+	SKD_dec_fixed				// dtype_dec_fixed
 };
 
 

--- a/src/jrd/par.cpp
+++ b/src/jrd/par.cpp
@@ -395,6 +395,11 @@ USHORT PAR_datatype(BlrReader& blrReader, dsc* desc)
 			desc->dsc_length = sizeof(Decimal128);
 			break;
 
+		case blr_dec_fixed:
+			desc->dsc_dtype = dtype_dec_fixed;
+			desc->dsc_length = sizeof(DecimalFixed);
+			break;
+
 		case blr_blob2:
 			desc->dsc_dtype = dtype_blob;
 			desc->dsc_length = sizeof(ISC_QUAD);

--- a/src/jrd/par.cpp
+++ b/src/jrd/par.cpp
@@ -398,6 +398,7 @@ USHORT PAR_datatype(BlrReader& blrReader, dsc* desc)
 		case blr_dec_fixed:
 			desc->dsc_dtype = dtype_dec_fixed;
 			desc->dsc_length = sizeof(DecimalFixed);
+			desc->dsc_scale = (int) blrReader.getByte();
 			break;
 
 		case blr_blob2:

--- a/src/jrd/sort.h
+++ b/src/jrd/sort.h
@@ -143,6 +143,7 @@ const int SKD_sql_date		= 14;
 const int SKD_int64			= 15;
 const int SKD_dec64			= 16;
 const int SKD_dec128		= 17;
+const int SKD_dec_fixed		= 18;
 
 // skd_flags
 const UCHAR SKD_ascending		= 0;	// default initializer

--- a/src/jrd/val.h
+++ b/src/jrd/val.h
@@ -97,6 +97,7 @@ struct impure_value
 	void make_int64(const SINT64 val, const signed char scale = 0);
 	void make_double(const double val);
 	void make_decimal128(const Firebird::Decimal128 val);
+	void make_decimal_fixed(const Firebird::DecimalFixed val, const signed char scale);
 };
 
 // Do not use these methods where dsc_sub_type is not explicitly set to zero.
@@ -138,6 +139,16 @@ inline void impure_value::make_decimal128(const Firebird::Decimal128 val)
 	this->vlu_desc.dsc_scale = 0;
 	this->vlu_desc.dsc_sub_type = 0;
 	this->vlu_desc.dsc_address = reinterpret_cast<UCHAR*>(&this->vlu_misc.vlu_dec128);
+}
+
+inline void impure_value::make_decimal_fixed(const Firebird::DecimalFixed val, const signed char scale)
+{
+	this->vlu_misc.vlu_dec_fixed = val;
+	this->vlu_desc.dsc_dtype = dtype_dec_fixed;
+	this->vlu_desc.dsc_length = sizeof(Firebird::DecimalFixed);
+	this->vlu_desc.dsc_scale = scale;
+	this->vlu_desc.dsc_sub_type = 0;
+	this->vlu_desc.dsc_address = reinterpret_cast<UCHAR*>(&this->vlu_misc.vlu_dec_fixed);
 }
 
 struct impure_value_ex : public impure_value

--- a/src/jrd/val.h
+++ b/src/jrd/val.h
@@ -84,6 +84,7 @@ struct impure_value
 		double vlu_double;
 		Firebird::Decimal64 vlu_dec64;
 		Firebird::Decimal128 vlu_dec128;
+		Firebird::DecimalFixed vlu_dec_fixed;
 		GDS_TIMESTAMP vlu_timestamp;
 		GDS_TIME vlu_sql_time;
 		GDS_DATE vlu_sql_date;

--- a/src/misc/pascal/Pascal.interface.pas
+++ b/src/misc/pascal/Pascal.interface.pas
@@ -17,6 +17,7 @@
 	ISC_QUAD = array [1..2] of Integer;
 	FB_DEC16 = array [1..1] of Int64;
 	FB_DEC34 = array [1..2] of Int64;
+	FB_DEC_FIXED = array [1..2] of Int64;
 
 	ntrace_relation_t = Integer;
 	TraceCounts = Record

--- a/src/remote/client/BlrFromMessage.cpp
+++ b/src/remote/client/BlrFromMessage.cpp
@@ -127,6 +127,12 @@ void BlrFromMessage::buildBlr(IMessageMetadata* metadata)
 				dtype = dtype_dec128;
 				break;
 
+			case SQL_DEC_FIXED:
+				appendUChar(blr_dec_fixed);
+				appendUChar(scale);
+				dtype = dtype_dec_fixed;
+				break;
+
 			case SQL_DOUBLE:
 				appendUChar(blr_double);
 				dtype = dtype_double;

--- a/src/remote/parser.cpp
+++ b/src/remote/parser.cpp
@@ -303,6 +303,7 @@ static rem_fmt* parse_format(const UCHAR*& blr, size_t& blr_length)
 		case blr_dec_fixed:
 			desc->dsc_dtype = dtype_dec_fixed;
 			desc->dsc_length = sizeof(DecimalFixed);
+			desc->dsc_scale = *blr++;
 			align = type_alignments[dtype_dec_fixed];
 			break;
 

--- a/src/remote/parser.cpp
+++ b/src/remote/parser.cpp
@@ -300,6 +300,12 @@ static rem_fmt* parse_format(const UCHAR*& blr, size_t& blr_length)
 			align = type_alignments[dtype_dec128];
 			break;
 
+		case blr_dec_fixed:
+			desc->dsc_dtype = dtype_dec_fixed;
+			desc->dsc_length = sizeof(DecimalFixed);
+			align = type_alignments[dtype_dec_fixed];
+			break;
+
 		// this case cannot occur as switch paramater is char and blr_blob
         // is 261. blob_ids are actually passed around as blr_quad.
 

--- a/src/utilities/ntrace/TracePluginImpl.cpp
+++ b/src/utilities/ntrace/TracePluginImpl.cpp
@@ -755,6 +755,9 @@ void TracePluginImpl::appendParams(ITraceParams* params)
 			case dtype_dec128:
 				paramtype = "decfloat(34)";
 				break;
+			case dtype_dec_fixed:
+				paramtype = "decimal";
+				break;
 
 			case dtype_sql_date:
 				paramtype = "date";
@@ -875,6 +878,10 @@ void TracePluginImpl::appendParams(ITraceParams* params)
 
 				case dtype_dec128:
 					((Decimal128*) parameters->dsc_address)->toString(paramvalue);
+					break;
+
+				case dtype_dec_fixed:
+					((DecimalFixed*) parameters->dsc_address)->toString(parameters->dsc_scale, paramvalue);
 					break;
 
 				case dtype_sql_date:

--- a/src/utilities/ntrace/TracePluginImpl.cpp
+++ b/src/utilities/ntrace/TracePluginImpl.cpp
@@ -881,7 +881,17 @@ void TracePluginImpl::appendParams(ITraceParams* params)
 					break;
 
 				case dtype_dec_fixed:
-					((DecimalFixed*) parameters->dsc_address)->toString(parameters->dsc_scale, paramvalue);
+					try
+					{
+						DecimalStatus decSt(DEC_Errors);
+						((DecimalFixed*) parameters->dsc_address)->toString(decSt, parameters->dsc_scale, paramvalue);
+					}
+					catch(const Exception& ex)
+					{
+						StaticStatusVector status;
+						ex.stuffException(status);
+						paramvalue.printf("Conversion error %d\n", status[1]);
+					}
 					break;
 
 				case dtype_sql_date:

--- a/src/utilities/ntrace/TracePluginImpl.cpp
+++ b/src/utilities/ntrace/TracePluginImpl.cpp
@@ -886,7 +886,7 @@ void TracePluginImpl::appendParams(ITraceParams* params)
 						DecimalStatus decSt(DEC_Errors);
 						((DecimalFixed*) parameters->dsc_address)->toString(decSt, parameters->dsc_scale, paramvalue);
 					}
-					catch(const Exception& ex)
+					catch (const Exception& ex)
 					{
 						StaticStatusVector status;
 						ex.stuffException(status);

--- a/src/yvalve/YObjects.h
+++ b/src/yvalve/YObjects.h
@@ -590,6 +590,7 @@ public:
 	Firebird::IEventBlock* createEventBlock(Firebird::CheckStatusWrapper* status, const char** events);
 	Firebird::IDecFloat16* getDecFloat16(Firebird::CheckStatusWrapper* status);
 	Firebird::IDecFloat34* getDecFloat34(Firebird::CheckStatusWrapper* status);
+	Firebird::IDecFixed* getDecFixed(Firebird::CheckStatusWrapper* status);
 };
 
 }	// namespace Why

--- a/src/yvalve/utl.cpp
+++ b/src/yvalve/utl.cpp
@@ -1214,7 +1214,7 @@ public:
 		{
 			DecimalStatus decSt(DEC_Errors);
 			DecimalFixed* val = reinterpret_cast<DecimalFixed*>(to);
-			val->set(from, decSt);		// !!!!!!!!!!!!!!!!!!!
+			val->set(from, scale, decSt);
 		}
 		catch (const Exception& ex)
 		{

--- a/src/yvalve/utl.cpp
+++ b/src/yvalve/utl.cpp
@@ -1076,7 +1076,7 @@ public:
 			{
 				char temp[STRING_SIZE];
 				decDoubleToString(reinterpret_cast<const decDouble*>(from), temp);
-				int len = strlen(temp);
+				unsigned int len = strlen(temp);
 				if (len < bufSize)
 					strncpy(buffer, temp, bufSize);
 				else
@@ -1137,7 +1137,7 @@ public:
 			{
 				char temp[STRING_SIZE];
 				decQuadToString(reinterpret_cast<const decQuad*>(from), temp);
-				int len = strlen(temp);
+				unsigned int len = strlen(temp);
 				if (len < bufSize)
 					strncpy(buffer, temp, bufSize);
 				else
@@ -1177,6 +1177,56 @@ IDecFloat34* UtilInterface::getDecFloat34(CheckStatusWrapper* status)
 {
 	static DecFloat34 decFloat34;
 	return &decFloat34;
+}
+
+class DecFixed FB_FINAL : public AutoIface<IDecFixedImpl<DecFixed, CheckStatusWrapper> >
+{
+public:
+	// IDecFixed implementation
+	void toBcd(const FB_DEC_FIXED* from, int* sign, unsigned char* bcd)
+	{
+		int exp = 0;
+		*sign = decQuadToBCD(reinterpret_cast<const decQuad*>(from), &exp, bcd);
+		fb_assert(exp == 0);
+	}
+
+	void toString(CheckStatusWrapper* status, const FB_DEC_FIXED* from, int scale, unsigned bufSize, char* buffer)
+	{
+		try
+		{
+			DecimalStatus decSt(DEC_Errors);
+			reinterpret_cast<const DecimalFixed*>(from)->toString(decSt, scale, bufSize, buffer);
+		}
+		catch (const Exception& ex)
+		{
+			ex.stuffException(status);
+		}
+	}
+
+	void fromBcd(int sign, const unsigned char* bcd, FB_DEC_FIXED* to)
+	{
+		decQuadFromBCD(reinterpret_cast<decQuad*>(to), 0, bcd, sign ? DECFLOAT_Sign : 0);
+	}
+
+	void fromString(CheckStatusWrapper* status, const char* from, int scale, FB_DEC_FIXED* to)
+	{
+		try
+		{
+			DecimalStatus decSt(DEC_Errors);
+			DecimalFixed* val = reinterpret_cast<DecimalFixed*>(to);
+			val->set(from, decSt);		// !!!!!!!!!!!!!!!!!!!
+		}
+		catch (const Exception& ex)
+		{
+			ex.stuffException(status);
+		}
+	}
+};
+
+IDecFixed* UtilInterface::getDecFixed(CheckStatusWrapper* status)
+{
+	static DecFixed decFixed;
+	return &decFixed;
 }
 
 unsigned UtilInterface::setOffsets(CheckStatusWrapper* status, IMessageMetadata* metadata,

--- a/src/yvalve/utl.cpp
+++ b/src/yvalve/utl.cpp
@@ -1223,7 +1223,7 @@ public:
 	}
 };
 
-IDecFixed* UtilInterface::getDecFixed(CheckStatusWrapper* status)
+IDecFixed* UtilInterface::getDecFixed(CheckStatusWrapper* /*status*/)
 {
 	static DecFixed decFixed;
 	return &decFixed;


### PR DESCRIPTION
New datatype is based on decQuad from decNumber library - same as DecFloat(34). Fixed scale is enhanced programmatically by additional code around decNumber library. This resolves CORE-4409.