### PR TITLE
Do not scan function if compiling not needed

### DIFF
--- a/src/jrd/dfw.epp
+++ b/src/jrd/dfw.epp
@@ -694,7 +694,7 @@ namespace
 					getDependencies(work, compile, transaction);
 
 					T* routine = lookupByName(tdbb,
-						QualifiedName(work->dfw_name, work->dfw_package), compile);
+						QualifiedName(work->dfw_name, work->dfw_package), !compile);
 
 					if (!routine)
 						return false;


### PR DESCRIPTION
Argument 'compile' wasn't negated in this place, for argument 'noscan'