### PR TITLE
Services API simplification

### DIFF
--- a/doc/README.services_extension
+++ b/doc/README.services_extension
@@ -252,3 +252,19 @@ fbsvcmgr host:service_mgr user leg password leg action_restore dbname target.fdb
 fbsvcmgr host:service_mgr user leg password leg role 'rdb$admin' action_restore dbname target.fdb bkp_file some.fbk
    (works as expected)
 
+
+8) Services API extension - passing database connection string as a service manager name.
+(Dmitry Sibiryakov, 2017)
+
+When database connection string is used in call isc_service_attach() or as
+the first parameter of fbsvcmgr utility, this database is used
+as a default value for "expected_db". And expected db become a default value
+for "dbname".
+If "expected_db" or "dbname" tags are specified explicitly, defaults have no
+effect.
+Old service names are still recognized, so this feature cannot be used with
+databases named like "service_mgr", "backup", "anonymous", etc.
+
+Example (following commands do exactly the same):
+fbsvcmgr host:service_mgr user sysdba password xxx expected_db employee action_db_stats dbname employee
+fbsvcmgr host:employee user sysdba password xxx action_db_stats

--- a/src/jrd/svc_tab.cpp
+++ b/src/jrd/svc_tab.cpp
@@ -95,6 +95,7 @@ const serv_entry services[] =
 
 	// NEW VERSION 2 calls, the name field MUST be different from those names above
 	{ isc_action_max, "service_mgr", NULL, NULL },
+	{ isc_action_max, NULL, NULL, NULL }, // Cut off services that are not supposed to be located by name
 	{ isc_action_svc_backup, "Backup Database", NULL, BURP_main },
 	{ isc_action_svc_restore, "Restore Database", NULL, BURP_main },
 	{ isc_action_svc_repair, "Repair Database", NULL, ALICE_main },


### PR DESCRIPTION
If you have specified database in isc_service_attach() call, you can omit it in following isc_service_start() calls.