### PR TITLE
Clear tdbb_status_vector after unsuccessful conversion to UTF8 in trace

### DIFF
--- a/src/dsql/dsql.cpp
+++ b/src/dsql/dsql.cpp
@@ -1654,7 +1654,7 @@ string IntlString::toUtf8(DsqlCompilerScratch* dsqlScratch) const
 	}
 
 	string utf;
-	return DataTypeUtil::convertToUTF8(s, utf, id) ? utf : s;
+	return DataTypeUtil::convertToUTF8(s, utf, id, ERRD_post) ? utf : s;
 }
 
 

--- a/src/jrd/DataTypeUtil.cpp
+++ b/src/jrd/DataTypeUtil.cpp
@@ -34,7 +34,6 @@
 #include "../common/dsc_proto.h"
 #include "../jrd/intl_proto.h"
 #include "../common/gdsassert.h"
-#include "../jrd/err_proto.h"
 
 using namespace Firebird;
 
@@ -369,7 +368,7 @@ USHORT DataTypeUtil::getDialect() const
 }
 
 // Returns false if conversion is not needed.
-bool DataTypeUtil::convertToUTF8(const string& src, string& dst, CHARSET_ID charset)
+bool DataTypeUtil::convertToUTF8(const string& src, string& dst, CHARSET_ID charset, ErrorFunction err)
 {
 	thread_db* tdbb = JRD_get_thread_data();
 
@@ -400,7 +399,7 @@ bool DataTypeUtil::convertToUTF8(const string& src, string& dst, CHARSET_ID char
 		length = INTL_convert_bytes(tdbb,
 			CS_UTF8, (UCHAR*) dst.getBuffer(length), length,
 			charset, (const BYTE*) src.begin(), src.length(),
-			ERR_post);
+			err);
 
 		dst.resize(length);
 	}

--- a/src/jrd/DataTypeUtil.h
+++ b/src/jrd/DataTypeUtil.h
@@ -29,6 +29,7 @@
 
 #include "../intl/charsets.h"
 #include "../common/classes/fb_string.h"
+#include "../jrd/err_proto.h"
 
 struct dsc;
 
@@ -78,7 +79,7 @@ public:
 
 public:
 	static bool convertToUTF8(const Firebird::string& src, Firebird::string& dst,
-		CHARSET_ID charset = CS_dynamic);
+		CHARSET_ID charset = CS_dynamic, ErrorFunction err = ERR_post);
 
 private:
 	thread_db* tdbb;

--- a/src/jrd/trace/TraceObjects.cpp
+++ b/src/jrd/trace/TraceObjects.cpp
@@ -182,7 +182,7 @@ const char* TraceSQLStatementImpl::getTextUTF8()
 
 	if (m_textUTF8.isEmpty() && stmtText && !stmtText->isEmpty())
 	{
-		if (!DataTypeUtil::convertToUTF8(*stmtText, m_textUTF8))
+		if (!DataTypeUtil::convertToUTF8(*stmtText, m_textUTF8, CS_dynamic, status_exception::raise))
 			return stmtText->c_str();
 	}
 
@@ -306,12 +306,11 @@ const char* TraceSQLStatementImpl::DSQLParamsImpl::getTextUTF8(CheckStatusWrappe
 
 	try
 	{
-		if (!DataTypeUtil::convertToUTF8(src, temp_utf8_text, param->dsc_sub_type))
+		if (!DataTypeUtil::convertToUTF8(src, temp_utf8_text, param->dsc_sub_type, status_exception::raise))
 			temp_utf8_text = src;
 	}
 	catch (const Firebird::Exception&)
 	{
-		fb_utils::init_status(JRD_get_thread_data()->tdbb_status_vector);
 		temp_utf8_text = src;
 	}
 
@@ -325,7 +324,7 @@ const char* TraceFailedSQLStatement::getTextUTF8()
 {
 	if (m_textUTF8.isEmpty() && !m_text.isEmpty())
 	{
-		if (!DataTypeUtil::convertToUTF8(m_text, m_textUTF8))
+		if (!DataTypeUtil::convertToUTF8(m_text, m_textUTF8, CS_dynamic, status_exception::raise))
 			return m_text.c_str();
 	}
 
@@ -371,12 +370,11 @@ const char* TraceParamsImpl::getTextUTF8(CheckStatusWrapper* status, FB_SIZE_T i
 
 	try
 	{
-		if (!DataTypeUtil::convertToUTF8(src, temp_utf8_text, param->dsc_sub_type))
+		if (!DataTypeUtil::convertToUTF8(src, temp_utf8_text, param->dsc_sub_type, status_exception::raise))
 			temp_utf8_text = src;
 	}
 	catch (const Firebird::Exception&)
 	{
-		fb_utils::init_status(JRD_get_thread_data()->tdbb_status_vector);
 		temp_utf8_text = src;
 	}
 

--- a/src/jrd/trace/TraceObjects.cpp
+++ b/src/jrd/trace/TraceObjects.cpp
@@ -304,8 +304,16 @@ const char* TraceSQLStatementImpl::DSQLParamsImpl::getTextUTF8(CheckStatusWrappe
 
 	string src(address, length);
 
-	if (!DataTypeUtil::convertToUTF8(src, temp_utf8_text, param->dsc_sub_type))
+	try
+	{
+		if (!DataTypeUtil::convertToUTF8(src, temp_utf8_text, param->dsc_sub_type))
+			temp_utf8_text = src;
+	}
+	catch (const Firebird::Exception&)
+	{
+		fb_utils::init_status(JRD_get_thread_data()->tdbb_status_vector);
 		temp_utf8_text = src;
+	}
 
 	return temp_utf8_text.c_str();
 }
@@ -361,8 +369,16 @@ const char* TraceParamsImpl::getTextUTF8(CheckStatusWrapper* status, FB_SIZE_T i
 
 	string src(address, length);
 
-	if (!DataTypeUtil::convertToUTF8(src, temp_utf8_text, param->dsc_sub_type))
+	try
+	{
+		if (!DataTypeUtil::convertToUTF8(src, temp_utf8_text, param->dsc_sub_type))
+			temp_utf8_text = src;
+	}
+	catch (const Firebird::Exception&)
+	{
+		fb_utils::init_status(JRD_get_thread_data()->tdbb_status_vector);
 		temp_utf8_text = src;
+	}
 
 	return temp_utf8_text.c_str();
 }


### PR DESCRIPTION
In this case dirty status vector can cause errors during statement execution.