### PR TITLE
Stop database restore with -o option when no space left on disk

### DIFF
--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -3056,17 +3056,8 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 					BURP_error_redirect(status_vector, 342);	// isc_gbak_invalid_data
 			}
 			else
-			{
-				if (tdgbl->gbl_sw_incremental)
-				{
-					BURP_print (false, 114, relation->rel_name);
-					// msg 114 restore failed for record in relation %s
-					BURP_print_status (false, status_vector);
-				}
-				else
-					BURP_error_redirect (status_vector, 48);
-					// msg 48 isc_send failed
-			}
+				BURP_error_redirect (status_vector, 48);
+				// msg 48 isc_send failed
 
 			records--;
 		}

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -3030,9 +3030,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 
 		if (s)
 		{
-			ISC_STATUS error_code = status_vector[1];
-
-			if (error_code == isc_not_valid)
+			if (status_vector[1] == isc_not_valid)
 			{
 				if (tdgbl->gbl_sw_incremental)
 				{
@@ -3044,7 +3042,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 					BURP_error_redirect (status_vector, 47);
 					// msg 47 warning -- record could not be restored
 			}
-			else if (error_code == isc_malformed_string)
+			else if (status_vector[1] == isc_malformed_string)
 			{
 				if (tdgbl->gbl_sw_incremental)
 				{
@@ -3059,10 +3057,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 			}
 			else
 			{
-				if (tdgbl->gbl_sw_incremental &&
-					error_code != isc_io_error &&
-					error_code != isc_att_shutdown &&
-					error_code != isc_net_write_err)
+				if (tdgbl->gbl_sw_incremental && isc_sqlcode(status_vector) != -902)
 				{
 					BURP_print (false, 114, relation->rel_name);
 					// msg 114 restore failed for record in relation %s

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -3030,7 +3030,9 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 
 		if (s)
 		{
-			if (status_vector[1] == isc_not_valid)
+			ISC_STATUS error_code = status_vector[1];
+
+			if (error_code == isc_not_valid)
 			{
 				if (tdgbl->gbl_sw_incremental)
 				{
@@ -3042,7 +3044,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 					BURP_error_redirect (status_vector, 47);
 					// msg 47 warning -- record could not be restored
 			}
-			else if (status_vector[1] == isc_malformed_string)
+			else if (error_code == isc_malformed_string)
 			{
 				if (tdgbl->gbl_sw_incremental)
 				{
@@ -3056,8 +3058,20 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 					BURP_error_redirect(status_vector, 342);	// isc_gbak_invalid_data
 			}
 			else
-				BURP_error_redirect (status_vector, 48);
-				// msg 48 isc_send failed
+			{
+				if (tdgbl->gbl_sw_incremental &&
+					error_code != isc_io_error &&
+					error_code != isc_att_shutdown &&
+					error_code != isc_net_write_err)
+				{
+					BURP_print (false, 114, relation->rel_name);
+					// msg 114 restore failed for record in relation %s
+					BURP_print_status (false, status_vector);
+				}
+				else
+					BURP_error_redirect (status_vector, 48);
+					// msg 48 isc_send failed
+			}
 
 			records--;
 		}


### PR DESCRIPTION
When this error occurs, gbak tries to restore all remained records. Restore log and firebird.log are growing up to several GB because of errors. The same occurs if connection was lost. I think it's better to allow to continue restore for some errors (currently isc_not_valid and isc_malformed_string), but prohibit for all others.