### PR TITLE
CMake Linux fixes

### DIFF
--- a/builds/cmake/Configure.cmake
+++ b/builds/cmake/Configure.cmake
@@ -200,6 +200,7 @@ set(functions_list
     accept4
     AO_compare_and_swap_full
     clock_gettime
+    ctime_r
     dirname
     fallocate
     fchmod

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,7 +54,6 @@ set(epp_boot_gds_files
     jrd/grant.epp
     jrd/ini.epp
     jrd/met.epp
-    jrd/pcmet.epp
     jrd/scl.epp
     jrd/Function.epp
 )
@@ -484,7 +483,6 @@ set(engine12_generated_src
     jrd/grant.epp
     jrd/ini.epp
     jrd/met.epp
-    jrd/pcmet.epp
     jrd/scl.epp
     utilities/gstat/dba.epp
 )

--- a/src/include/gen/autoconfig.h.in
+++ b/src/include/gen/autoconfig.h.in
@@ -403,6 +403,9 @@
 /* Define to 1 if you have the `clock_gettime' function. */
 #cmakedefine HAVE_CLOCK_GETTIME 1
 
+/* Define to 1 if you have the `ctime_r' function. */
+#cmakedefine HAVE_CTIME_R 1
+
 /* Define to 1 if you have the `dirname' function. */
 #cmakedefine HAVE_DIRNAME 1
 


### PR DESCRIPTION
With these changes, build using CMake succeeds under Debian x86_64.

NB: this extends and replaces #130.