### PR TITLE
Use compact form for numbers in information buffer

### DIFF
--- a/src/jrd/inf.cpp
+++ b/src/jrd/inf.cpp
@@ -191,19 +191,22 @@ USHORT INF_convert(SINT64 number, UCHAR* buffer)
  *
  * Functional description
  *	Convert a number to VAX form -- least significant bytes first.
+ *  Do not store leading zero bytes.
  *	Return the length.
  *
  **************************************/
-	if (number >= MIN_SLONG && number <= MAX_SLONG)
+
+	UCHAR* p = buffer;
+	USHORT result = 0;
+
+	do
 	{
-		put_vax_long(buffer, (SLONG) number);
-		return sizeof(SLONG);
-	}
-	else
-	{
-		put_vax_int64(buffer, number);
-		return sizeof(SINT64);
-	}
+		*p++ = (UCHAR)(number % 0x100);
+		number /= 0x100;
+		result++;
+	} while (number != 0);
+
+	return result;
 }
 
 

--- a/src/jrd/svc.cpp
+++ b/src/jrd/svc.cpp
@@ -1464,9 +1464,9 @@ ISC_STATUS Service::query2(thread_db* /*tdbb*/,
 		memmove(start_info + 7, start_info, number);
 		if (stdin_request_notification)
 			stdin_request_notification += 7;
-		USHORT length2 = INF_convert(number, buffer);
-		fb_assert(length2 == 4); // We only accept SLONG
-		INF_put_item(isc_info_length, length2, buffer, start_info, end, true);
+		// Do not use INF_convert() as it can produce variable length result
+		put_vax_long(buffer, number);
+		INF_put_item(isc_info_length, sizeof(SLONG), buffer, start_info, end, true);
 	}
 
 	if (svc_trace_manager->needs(ITraceFactory::TRACE_EVENT_SERVICE_QUERY))


### PR DESCRIPTION
It should improve performance of prepare and execute queries with big number of parameters/fields over slow network using uncompressed connection.