### PR TITLE
Gbak

### DIFF
--- a/builds/posix/make.rules
+++ b/builds/posix/make.rules
@@ -74,7 +74,7 @@ WCXXFLAGS = $(WFLAGS) $(THR_FLAGS) $(RTTI_FLAG) $(CXXFLAGS) $(GLOB_OPTIONS)
 
 GPRE_FLAGS= -m -z -n
 JRD_GPRE_FLAGS = -n -z -gds_cxx -ids
-ISQL_GPRE_FLAGS = -m -z -n -ocxx
+OBJECT_GPRE_FLAGS = -m -z -n -ocxx
 
 
 .SUFFIXES: .c .e .epp .cpp
@@ -87,7 +87,10 @@ $(OBJ)/jrd/%.cpp: $(SRC_ROOT)/jrd/%.epp
 	$(GPRE_CURRENT) $(JRD_GPRE_FLAGS) $(firstword $<) $@
 
 $(OBJ)/isql/%.cpp: $(SRC_ROOT)/isql/%.epp
-	$(GPRE_CURRENT) $(ISQL_GPRE_FLAGS) $< $@
+	$(GPRE_CURRENT) $(OBJECT_GPRE_FLAGS) $< $@
+
+$(OBJ)/burp/%.cpp: $(SRC_ROOT)/burp/%.epp
+	$(GPRE_CURRENT) $(OBJECT_GPRE_FLAGS) $< $@
 
 $(OBJ)/%.cpp: $(SRC_ROOT)/%.epp
 	$(GPRE_CURRENT) $(GPRE_FLAGS) $(firstword $<) $@

--- a/builds/win32/msvc10/common.vcxproj
+++ b/builds/win32/msvc10/common.vcxproj
@@ -25,6 +25,7 @@
     <ClCompile Include="..\..\..\src\common\CharSet.cpp" />
     <ClCompile Include="..\..\..\src\common\classes\alloc.cpp" />
     <ClCompile Include="..\..\..\src\common\classes\BaseStream.cpp" />
+    <ClCompile Include="..\..\..\src\common\classes\BlobWrapper.cpp" />
     <ClCompile Include="..\..\..\src\common\classes\BlrWriter.cpp" />
     <ClCompile Include="..\..\..\src\common\classes\ClumpletReader.cpp" />
     <ClCompile Include="..\..\..\src\common\classes\ClumpletWriter.cpp" />
@@ -115,6 +116,7 @@
     <ClInclude Include="..\..\..\src\common\classes\auto.h" />
     <ClInclude Include="..\..\..\src\common\classes\BaseStream.h" />
     <ClInclude Include="..\..\..\src\common\classes\BatchCompletionState.h" />
+    <ClInclude Include="..\..\..\src\common\classes\BlobWrapper.h" />
     <ClInclude Include="..\..\..\src\common\classes\BlrReader.h" />
     <ClInclude Include="..\..\..\src\common\classes\BlrWriter.h" />
     <ClInclude Include="..\..\..\src\common\classes\ByteChunk.h" />

--- a/builds/win32/msvc10/common.vcxproj.filters
+++ b/builds/win32/msvc10/common.vcxproj.filters
@@ -225,6 +225,9 @@
     <ClCompile Include="..\..\..\src\common\classes\TomCryptHash.cpp">
       <Filter>classes</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\src\common\classes\BlobWrapper.cpp">
+      <Filter>classes</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\src\common\xdr_proto.h">
@@ -543,6 +546,9 @@
       <Filter>headers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\common\classes\BatchCompletionState.h">
+      <Filter>headers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\common\classes\BlobWrapper.h">
       <Filter>headers</Filter>
     </ClInclude>
   </ItemGroup>

--- a/builds/win32/msvc12/common.vcxproj
+++ b/builds/win32/msvc12/common.vcxproj
@@ -25,6 +25,7 @@
     <ClCompile Include="..\..\..\src\common\CharSet.cpp" />
     <ClCompile Include="..\..\..\src\common\classes\alloc.cpp" />
     <ClCompile Include="..\..\..\src\common\classes\BaseStream.cpp" />
+    <ClCompile Include="..\..\..\src\common\classes\BlobWrapper.cpp" />
     <ClCompile Include="..\..\..\src\common\classes\BlrWriter.cpp" />
     <ClCompile Include="..\..\..\src\common\classes\ClumpletReader.cpp" />
     <ClCompile Include="..\..\..\src\common\classes\ClumpletWriter.cpp" />
@@ -106,6 +107,7 @@
     <ClInclude Include="..\..\..\src\common\classes\auto.h" />
     <ClInclude Include="..\..\..\src\common\classes\BaseStream.h" />
     <ClInclude Include="..\..\..\src\common\classes\BatchCompletionState.h" />
+    <ClInclude Include="..\..\..\src\common\classes\BlobWrapper.h" />
     <ClInclude Include="..\..\..\src\common\classes\BlrReader.h" />
     <ClInclude Include="..\..\..\src\common\classes\BlrWriter.h" />
     <ClInclude Include="..\..\..\src\common\classes\ByteChunk.h" />

--- a/builds/win32/msvc12/common.vcxproj.filters
+++ b/builds/win32/msvc12/common.vcxproj.filters
@@ -222,6 +222,9 @@
     <ClCompile Include="..\..\..\src\common\classes\TomCryptHash.cpp">
       <Filter>classes</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\src\common\classes\BlobWrapper.cpp">
+      <Filter>classes</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\src\common\xdr_proto.h">
@@ -540,6 +543,9 @@
       <Filter>headers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\common\classes\BatchCompletionState.h">
+      <Filter>headers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\common\classes\BlobWrapper.h">
       <Filter>headers</Filter>
     </ClInclude>
   </ItemGroup>

--- a/builds/win32/msvc14/common.vcxproj
+++ b/builds/win32/msvc14/common.vcxproj
@@ -25,6 +25,7 @@
     <ClCompile Include="..\..\..\src\common\CharSet.cpp" />
     <ClCompile Include="..\..\..\src\common\classes\alloc.cpp" />
     <ClCompile Include="..\..\..\src\common\classes\BaseStream.cpp" />
+    <ClCompile Include="..\..\..\src\common\classes\BlobWrapper.cpp" />
     <ClCompile Include="..\..\..\src\common\classes\BlrWriter.cpp" />
     <ClCompile Include="..\..\..\src\common\classes\ClumpletReader.cpp" />
     <ClCompile Include="..\..\..\src\common\classes\ClumpletWriter.cpp" />
@@ -106,6 +107,7 @@
     <ClInclude Include="..\..\..\src\common\classes\auto.h" />
     <ClInclude Include="..\..\..\src\common\classes\BaseStream.h" />
     <ClInclude Include="..\..\..\src\common\classes\BatchCompletionState.h" />
+    <ClInclude Include="..\..\..\src\common\classes\BlobWrapper.h" />
     <ClInclude Include="..\..\..\src\common\classes\BlrReader.h" />
     <ClInclude Include="..\..\..\src\common\classes\BlrWriter.h" />
     <ClInclude Include="..\..\..\src\common\classes\ByteChunk.h" />

--- a/builds/win32/msvc14/common.vcxproj.filters
+++ b/builds/win32/msvc14/common.vcxproj.filters
@@ -222,6 +222,9 @@
     <ClCompile Include="..\..\..\src\common\classes\TomCryptHash.cpp">
       <Filter>classes</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\src\common\classes\BlobWrapper.cpp">
+      <Filter>classes</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\src\common\xdr_proto.h">
@@ -540,6 +543,9 @@
       <Filter>headers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\common\classes\BatchCompletionState.h">
+      <Filter>headers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\common\classes\BlobWrapper.h">
       <Filter>headers</Filter>
     </ClInclude>
   </ItemGroup>

--- a/builds/win32/preprocess.bat
+++ b/builds/win32/preprocess.bat
@@ -55,10 +55,7 @@ goto :EOF
 :BOOT_PROCESS
 @echo.
 @set GPRE=%FB_BIN_DIR%\gpre_boot -lang_internal
-@for %%i in (array, blob) do @call :PREPROCESS yvalve %%i
-@for %%i in (metd, DdlNodes, PackageNodes) do @call :PREPROCESS dsql %%i -gds_cxx
-@for %%i in (gpre_meta) do @call :PREPROCESS gpre/std %%i
-@for %%i in (backup, restore, OdsDetection) do @call :PREPROCESS burp %%i
+@for %%i in (backup, restore, OdsDetection) do @call :PREPROCESS burp %%i -ocxx -m
 @for %%i in (extract, isql, show) do @call :PREPROCESS isql %%i -ocxx
 @for %%i in (dba) do @call :PREPROCESS utilities/gstat %%i
 
@@ -76,7 +73,7 @@ goto :EOF
 @set GPRE=%FB_BIN_DIR%\gpre
 @for %%i in (alice_meta) do @call :PREPROCESS alice %%i
 @for %%i in (LegacyManagement) do @call :PREPROCESS auth/SecurityDatabase %%i
-@for %%i in (backup, restore, OdsDetection) do @call :PREPROCESS burp %%i
+@for %%i in (backup, restore, OdsDetection) do @call :PREPROCESS burp %%i -ocxx -m
 @for %%i in (array, blob) do @call :PREPROCESS yvalve %%i
 @for %%i in (metd) do @call :PREPROCESS dsql %%i -gds_cxx
 @for %%i in (DdlNodes, PackageNodes) do @call :PREPROCESS dsql %%i -gds_cxx

--- a/src/burp/OdsDetection.epp
+++ b/src/burp/OdsDetection.epp
@@ -64,8 +64,11 @@ namespace
 DATABASE DB = STATIC FILENAME "yachts.lnk";
 
 #define DB			tdgbl->db_handle
+#define fbTrans		tdgbl->tr_handle
 #define gds_trans	tdgbl->tr_handle
-#define isc_status	tdgbl->status_vector
+#define fbStatus	(&tdgbl->status_vector)
+#define isc_status	(&tdgbl->status_vector)
+#define gds_status	(&tdgbl->status_vector)
 
 
 void detectRuntimeODS()
@@ -91,7 +94,7 @@ void detectRuntimeODS()
 	// and rdb$field_name = 'RDB$SYSTEM_FLAG';
 
 	int count = 0;
-	isc_req_handle req_handle = 0;
+	Firebird::IRequest* req_handle = nullptr;
 	FOR (REQUEST_HANDLE req_handle)
 		RFR IN RDB$RELATION_FIELDS
 		WITH (RFR.RDB$RELATION_NAME = 'RDB$RELATIONS' OR RFR.RDB$RELATION_NAME = 'RDB$RELATION_FIELDS')
@@ -106,7 +109,7 @@ void detectRuntimeODS()
 	if (count != 2)
 		return;
 
-	isc_req_handle req_handle2 = 0;
+	Firebird::IRequest* req_handle2 = nullptr;
 	for (const rel_field_t* rel = relations; rel->relation; ++rel)
 	{
 		FOR (REQUEST_HANDLE req_handle2)
@@ -125,7 +128,7 @@ void detectRuntimeODS()
 	if (tdgbl->runtimeODS < DB_VERSION_DDL8)
 		return;
 
-	isc_req_handle req_handle3 = 0;
+	Firebird::IRequest* req_handle3 = nullptr;
 	for (const rel_field_t* rf = rel_fields; rf->relation; ++rf)
 	{
 		FOR (REQUEST_HANDLE req_handle3)

--- a/src/burp/backup.epp
+++ b/src/burp/backup.epp
@@ -833,11 +833,13 @@ SINT64 get_gen_id( const TEXT* name, SSHORT name_len)
  **************************************/
 	try
 	{
+		BurpGlobals* tdgbl = BurpGlobals::getSpecific();
+
 		Firebird::string nm, sql;
 		nm.assign(name, name_len);
+		BURP_makeSymbol(tdgbl, nm);
 		sql = "select first(1) gen_id(" + nm + ", 0) from rdb$database";
 
-		BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 		BurpSql getGenerator(tdgbl, sql.c_str());
 		FB_MESSAGE(GetGen, Firebird::ThrowStatusWrapper, (FB_BIGINT, id));
 		GetGen getGen(&tdgbl->throwStatus, Firebird::MasterInterfacePtr());

--- a/src/burp/backup.epp
+++ b/src/burp/backup.epp
@@ -845,7 +845,7 @@ SINT64 get_gen_id( const TEXT* name, SSHORT name_len)
 		getGenerator.singleSelect(tdgbl->tr_handle, &getGen);
 		return getGen->id;
 	}
-	catch(const Firebird::FbException& ex)
+	catch (const Firebird::FbException& ex)
 	{
 		Firebird::IStatus* st = ex.getStatus();
 
@@ -1022,6 +1022,7 @@ void put_array( burp_fld* field, burp_rel* relation, ISC_QUAD* blob_id)
 	unsigned return_length = DB->getSlice(&status_vector, gds_trans, blob_id, blr_length, blr_buffer,
 		0, nullptr,		// parameters for subset of an array handling
 		slice_length, slice);
+
 	if (!status_vector.isSuccess())
 	{
 		BURP_print(false, 81, field->fld_name);

--- a/src/burp/backup.epp
+++ b/src/burp/backup.epp
@@ -469,7 +469,7 @@ void compress(const UCHAR* data, ULONG length)
 	{
 		for (q = p + 2; q < end && (q[-2] != q[-1] || q[-1] != q[0]); q++)
 			;
-		USHORT run = (q < end) ? q - p - 2 : end - p;
+		ULONG run = (q < end) ? q - p - 2 : end - p;
 		if (run)
 		{
 			for (; run > 127; run -= 127)

--- a/src/burp/backup.epp
+++ b/src/burp/backup.epp
@@ -1405,13 +1405,7 @@ void put_data(burp_rel* relation)
  *
  **************************************/
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
-
-	// CVC: A signed short isn't enough if the engine allows near 32K fields,
-	// each being char(1) ASCII in the worst case. Looking at BLR generation
-	// below, it's clear an extreme case won't compile => blr_length >= 32K.
-	// However, SSHORT is the limit for request_length in isc_compile_request.
-	SSHORT field_count = 1;
-
+	USHORT field_count = 1;	// eof field
 	burp_fld* field;
 	for (field = relation->rel_fields; field; field = field->fld_next)
 	{
@@ -1433,7 +1427,7 @@ void put_data(burp_rel* relation)
 	add_word(blr, field_count);		// Number of fields, counting eof
 
 	RCRD_OFFSET offset = 0;
-	SSHORT count = 0;   // This is param count.
+	USHORT count = 0;   // This is param count.
 
 	for (field = relation->rel_fields; field; field = field->fld_next)
 	{
@@ -1563,7 +1557,7 @@ void put_data(burp_rel* relation)
 	RCRD_OFFSET record_length = offset;
 	RCRD_OFFSET eof_offset = FB_ALIGN(offset, sizeof(SSHORT));
 	// To be used later for the buffer size to receive data
-	const FLD_LENGTH length = (USHORT) (eof_offset + sizeof(SSHORT));
+	const RCRD_LENGTH length = (RCRD_LENGTH) (eof_offset + sizeof(SSHORT));
 
 	// Build FOR loop, body, and eof handler
 
@@ -1617,7 +1611,7 @@ void put_data(burp_rel* relation)
 	add_byte(blr, blr_end);
 	add_byte(blr, blr_eoc);
 
-	SSHORT blr_length = blr - blr_buffer;
+	unsigned blr_length = blr - blr_buffer;
 
 #ifdef DEBUG
 	if (debug_on)

--- a/src/burp/backup.epp
+++ b/src/burp/backup.epp
@@ -57,11 +57,12 @@
 #include "../common/prett_proto.h"
 #endif
 
-#include "../common/classes/UserBlob.h"
+#include "../common/classes/BlobWrapper.h"
 #include "../common/classes/MsgPrint.h"
 #include "../burp/OdsDetection.h"
 
 using MsgFormat::SafeArg;
+using Firebird::FbLocalStatus;
 
 
 // For service APIs the follow DB handle is a value stored
@@ -72,8 +73,11 @@ using MsgFormat::SafeArg;
 DATABASE DB = STATIC FILENAME "yachts.lnk" RUNTIME * dbb_file;
 
 #define DB			tdgbl->db_handle
+#define fbTrans		tdgbl->tr_handle
 #define gds_trans	tdgbl->tr_handle
-#define isc_status	tdgbl->status_vector
+#define fbStatus	(&tdgbl->status_vector)
+#define isc_status	(&tdgbl->status_vector)
+#define gds_status	(&tdgbl->status_vector)
 
 namespace // unnamed, private
 {
@@ -173,7 +177,7 @@ const UCHAR source_items[] =
 	isc_info_blob_total_length,
 	isc_info_blob_num_segments
 };
-const SCHAR db_info_items[] =
+const UCHAR db_info_items[] =
 {
 	isc_info_db_sql_dialect,
 	isc_info_page_size,
@@ -184,12 +188,12 @@ const SCHAR db_info_items[] =
 	isc_info_db_read_only,
 	isc_info_end
 };
-const SCHAR limbo_tpb[] =
+const UCHAR limbo_tpb[] =
 {
 	isc_tpb_version1,
 	isc_tpb_ignore_limbo
 };
-const SCHAR limbo_nau_tpb[] =
+const UCHAR limbo_nau_tpb[] =
 {
 	isc_tpb_version1,
 	isc_tpb_ignore_limbo,
@@ -211,7 +215,7 @@ int BACKUP_backup(const TEXT* dbb_file, const TEXT* file_name)
  *	Backup a database.
  *
  **************************************/
-	ISC_STATUS_ARRAY status_vector;
+	FbLocalStatus status_vector;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -229,23 +233,23 @@ int BACKUP_backup(const TEXT* dbb_file, const TEXT* file_name)
 
 	if (tdgbl->gbl_sw_ignore_limbo)
 	{
-		if (isc_start_transaction(status_vector, &gds_trans, 1, &DB,
-								  sizeof(limbo_nau_tpb), limbo_nau_tpb))
+		gds_trans = DB->startTransaction(&status_vector, sizeof(limbo_nau_tpb), limbo_nau_tpb);
+		if (status_vector->getState() & Firebird::IStatus::STATE_ERRORS)
 		{
-			isc_start_transaction(status_vector, &gds_trans, 1, &DB, sizeof(limbo_tpb), limbo_tpb);
+			gds_trans = DB->startTransaction(&status_vector, sizeof(limbo_tpb), limbo_tpb);
 		}
 	}
 	else
 	{
 		EXEC SQL SET TRANSACTION NO_AUTO_UNDO;
-		if (isc_status[1])
+		if (isc_status->getState() & Firebird::IStatus::STATE_ERRORS)
 			EXEC SQL SET TRANSACTION;
 	}
 
 	if (!gds_trans)
 	{
 		EXEC SQL SET TRANSACTION NAME gds_trans NO_AUTO_UNDO;
-		if (isc_status[1])
+		if (isc_status->getState() & Firebird::IStatus::STATE_ERRORS)
 			EXEC SQL SET TRANSACTION NAME gds_trans;
 	}
 
@@ -827,125 +831,32 @@ SINT64 get_gen_id( const TEXT* name, SSHORT name_len)
  *	Read id for a generator;
  *
  **************************************/
-	UCHAR blr_buffer[100];	// enough to fit blr
-
-	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
-
-	FB_API_HANDLE gen_id_reqh = 0;
-	UCHAR* blr = blr_buffer;
-
-	// If this is ODS 10 (IB version 6.0) or greater, build BLR to retrieve
-	// the 64-bit value of the generator.  If not, build BLR to retrieve the
-	// 32-bit value, which we will cast to the expected INT64 format.
-
-	if (tdgbl->runtimeODS >= DB_VERSION_DDL10)
+	try
 	{
-		// build the blr with the right relation name and 64-bit results.
-		add_byte(blr, blr_version5);
-		add_byte(blr, blr_begin);
-		add_byte(blr, blr_message);
-		add_byte(blr, 0);
-		add_word(blr, 1);
-		add_byte(blr, blr_int64);
-		add_byte(blr, 0);
-		add_byte(blr, blr_send);
-		add_byte(blr, 0);
-		add_byte(blr, blr_assignment);
-		add_byte(blr, blr_gen_id);
-		add_byte(blr, name_len);
-		while (name_len--)
-		{
-			const UCHAR c = *name++;
-			add_byte(blr, c);
-		}
-		add_byte(blr, blr_literal);
-		add_byte(blr, blr_long);
-		add_byte(blr, 0);
-		add_word(blr, 0);
-		add_word(blr, 0);
-		add_byte(blr, blr_parameter);
-		add_byte(blr, 0);
-		add_word(blr, 0);
-		add_byte(blr, blr_end);
-		add_byte(blr, blr_eoc);
+		Firebird::string nm, sql;
+		nm.assign(name, name_len);
+		sql = "select first(1) gen_id(" + nm + ", 0) from rdb$database";
+
+		BurpGlobals* tdgbl = BurpGlobals::getSpecific();
+		BurpSql getGenerator(tdgbl, sql.c_str());
+		FB_MESSAGE(GetGen, Firebird::ThrowStatusWrapper, (FB_BIGINT, id));
+		GetGen getGen(&tdgbl->throwStatus, Firebird::MasterInterfacePtr());
+
+		getGenerator.singleSelect(tdgbl->tr_handle, &getGen);
+		return getGen->id;
 	}
-	else
+	catch(const Firebird::FbException& ex)
 	{
-		// build the blr with the right relation name and 32-bit results
-		add_byte(blr, blr_version4);
-		add_byte(blr, blr_begin);
-		add_byte(blr, blr_message);
-		add_byte(blr, 0);
-		add_word(blr, 1);
-		add_byte(blr, blr_long);
-		add_byte(blr, 0);
-		add_byte(blr, blr_send);
-		add_byte(blr, 0);
-		add_byte(blr, blr_assignment);
-		add_byte(blr, blr_gen_id);
-		add_byte(blr, name_len);
-		while (name_len--)
-		{
-			const UCHAR c = *name++;
-			add_byte(blr, c);
-		}
-		add_byte(blr, blr_literal);
-		add_byte(blr, blr_long);
-		add_byte(blr, 0);
-		add_word(blr, 0);
-		add_word(blr, 0);
-		add_byte(blr, blr_parameter);
-		add_byte(blr, 0);
-		add_word(blr, 0);
-		add_byte(blr, blr_end);
-		add_byte(blr, blr_eoc);
-	}
+		Firebird::IStatus* st = ex.getStatus();
 
-	const SSHORT blr_length = blr - blr_buffer;
-
-#ifdef DEBUG
-	if (debug_on)
-		fb_print_blr(blr_buffer, blr_length, NULL, NULL, 0);
-#endif
-
-	ISC_STATUS_ARRAY status_vector;
-	if (isc_compile_request(status_vector, &DB, &gen_id_reqh, blr_length, (const char*) blr_buffer))
-	{
 		// if there's no gen_id, never mind ...
-		return 0;
-	}
+		if (st->getErrors()[1] == isc_dsql_error)
+			return 0;
 
-	// use the same gds_trans generated by gpre
-	if (isc_start_request(status_vector, &gen_id_reqh, &gds_trans, 0))
-	{
-		BURP_error_redirect(status_vector, 25);
+		BURP_error_redirect(st, 25);
 		// msg 25 Failed in put_blr_gen_id
 	}
-
-
-	SINT64 read_msg1;
-	if (tdgbl->runtimeODS >= DB_VERSION_DDL10)
-	{
-		if (isc_receive(status_vector, &gen_id_reqh, 0, sizeof(read_msg1), &read_msg1, 0))
-		{
-			BURP_error_redirect(status_vector, 25);
-			// msg 25 Failed in put_blr_gen_id
-		}
-	}
-	else
-	{
-		SLONG read_msg0;
-		if (isc_receive(status_vector, &gen_id_reqh, 0, sizeof(read_msg0), &read_msg0, 0))
-		{
-			BURP_error_redirect(status_vector, 25);
-			// msg 25 Failed in put_blr_gen_id
-		}
-		read_msg1 = (SINT64) read_msg0;
-	}
-
-	isc_release_request(status_vector, &gen_id_reqh);
-
-	return read_msg1;
+	return 0;	// warning silencer
 }
 
 
@@ -1107,16 +1018,15 @@ void put_array( burp_fld* field, burp_rel* relation, ISC_QUAD* blob_id)
 		xdr_buffer.lstr_allocated = xdr_buffer.lstr_length;
 	}
 
-	ISC_STATUS_ARRAY status_vector;
-	ULONG return_length = 0;
-	if (isc_get_slice(status_vector, &DB, &gds_trans, blob_id, blr_length, (const char*) blr_buffer,
-					  0,	// param length for subset of an array handling
-					  NULL,	// param for subset of an array handling
-					  slice_length, slice, (SLONG*) &return_length))
+	FbLocalStatus status_vector;
+	unsigned return_length = DB->getSlice(&status_vector, gds_trans, blob_id, blr_length, blr_buffer,
+		0, nullptr,		// parameters for subset of an array handling
+		slice_length, slice);
+	if (!status_vector.isSuccess())
 	{
 		BURP_print(false, 81, field->fld_name);
 		// msg 81 error accessing blob field %s -- continuing
-		BURP_print_status(false, status_vector);
+		BURP_print_status(false, &status_vector);
 #ifdef DEBUG
 		PRETTY_print_sdl(blr_buffer, NULL, NULL, 0);
 #endif
@@ -1244,31 +1154,31 @@ void put_blob( burp_fld* field, ISC_QUAD& blob_id)
  *	This is for user data blobs.
  *
  **************************************/
-	ISC_STATUS_ARRAY status_vector;
+	FbLocalStatus status_vector;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
 	// If the blob is null, don't store it.  It will be restored as null.
 
-	if (UserBlob::blobIsNull(blob_id))
+	if (BlobWrapper::blobIsNull(blob_id))
 		return;
 
 	// Open the blob and get it's vital statistics
 
-	UserBlob blob(status_vector);
+	BlobWrapper blob(&status_vector);
 
 	if (!blob.open(DB, gds_trans, blob_id))
 	{
 		BURP_print(false, 81, field->fld_name);
 		// msg 81 error accessing blob field %s -- continuing
-		BURP_print_status(false, status_vector);
+		BURP_print_status(false, &status_vector);
 		return;
 	}
 
 	UCHAR blob_info[32];
 	if (!blob.getInfo(sizeof(blob_items), blob_items, sizeof(blob_info), blob_info))
 	{
-		BURP_error_redirect(status_vector, 20);
+		BURP_error_redirect(&status_vector, 20);
 		// msg 20 isc_blob_info failed
 	}
 
@@ -1342,13 +1252,9 @@ void put_blob( burp_fld* field, ISC_QUAD& blob_id)
 	while (segments > 0)
 	{
 		FB_SIZE_T segment_length;
-		blob.getSegment(max_segment, buffer, segment_length);
-
-		const ISC_STATUS status = blob.getCode();
-		// Handle the errors. For stream blob isc_segment is not error here.
-		if (status && (status != isc_segment || blob_type == 0))
+		if (!blob.getSegment(max_segment, buffer, segment_length))
 		{
-			BURP_error_redirect(status_vector, 22);
+			BURP_error_redirect(&status_vector, 22);
 			// msg 22 isc_get_segment failed
 		}
 
@@ -1362,7 +1268,7 @@ void put_blob( burp_fld* field, ISC_QUAD& blob_id)
 	}
 
 	if (!blob.close())
-		BURP_error_redirect(status_vector, 23);
+		BURP_error_redirect(&status_vector, 23);
 		// msg 23 isc_close_blob failed
 
 	if (buffer != static_buffer)
@@ -1383,28 +1289,28 @@ bool put_blr_blob( att_type attribute, ISC_QUAD& blob_id)
  *	Return true if the blob was present, false otherwise.
  *
  **************************************/
-	ISC_STATUS_ARRAY status_vector;
+	FbLocalStatus status_vector;
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
 	// If the blob is null, don't store it.  It will be restored as null.
 
-	if (UserBlob::blobIsNull(blob_id))
+	if (BlobWrapper::blobIsNull(blob_id))
 		return false;
 
 	// Open the blob and get it's vital statistics
 
-	UserBlob blob(status_vector);
+	BlobWrapper blob(&status_vector);
 
 	if (!blob.open(DB, gds_trans, blob_id))
 	{
-		BURP_error_redirect(status_vector, 24);
+		BURP_error_redirect(&status_vector, 24);
 		// msg 24 isc_open_blob failed
 	}
 
 	UCHAR blob_info[32];
 	if (!blob.getInfo(sizeof(blr_items), blr_items, sizeof(blob_info), blob_info))
 	{
-		BURP_error_redirect(status_vector, 20);
+		BURP_error_redirect(&status_vector, 20);
 		// msg 20 isc_blob_info failed
 	}
 
@@ -1433,7 +1339,7 @@ bool put_blr_blob( att_type attribute, ISC_QUAD& blob_id)
 			BURP_print(true, 79, SafeArg() << int(item));
 			// msg 79 don't understand blob info item %ld
 			if (!blob.close())
-				BURP_error_redirect(status_vector, 23);
+				BURP_error_redirect(&status_vector, 23);
 				// msg 23 isc_close_blob failed
 			return false;
 		}
@@ -1442,7 +1348,7 @@ bool put_blr_blob( att_type attribute, ISC_QUAD& blob_id)
 	if (!length)
 	{
 		if (!blob.close())
-			BURP_error_redirect(status_vector, 23);
+			BURP_error_redirect(&status_vector, 23);
 			// msg 23 isc_close_blob failed
 		return false;
 	}
@@ -1475,7 +1381,7 @@ bool put_blr_blob( att_type attribute, ISC_QUAD& blob_id)
 
 	if (!blob.close())
 	{
-		BURP_error_redirect(status_vector, 23);
+		BURP_error_redirect(&status_vector, 23);
 		// msg 23 isc_close_blob failed
 	}
 
@@ -1498,9 +1404,6 @@ void put_data(burp_rel* relation)
  *	Write relation meta-data and data.
  *
  **************************************/
-	burp_fld* field;
-	ISC_STATUS_ARRAY status_vector;
-
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
 	// CVC: A signed short isn't enough if the engine allows near 32K fields,
@@ -1509,6 +1412,7 @@ void put_data(burp_rel* relation)
 	// However, SSHORT is the limit for request_length in isc_compile_request.
 	SSHORT field_count = 1;
 
+	burp_fld* field;
 	for (field = relation->rel_fields; field; field = field->fld_next)
 	{
 		if (!(field->fld_flags & FLD_computed))
@@ -1722,10 +1626,11 @@ void put_data(burp_rel* relation)
 
 	// Compile request
 
-	FB_API_HANDLE request = 0;
-	if (isc_compile_request(status_vector, &DB, &request, blr_length, (const SCHAR*) blr_buffer))
+	FbLocalStatus status_vector;
+	Firebird::IRequest* request = DB->compileRequest(&status_vector, blr_length, blr_buffer);
+	if (!status_vector.isSuccess())
 	{
-		BURP_error_redirect(status_vector, 27);
+		BURP_error_redirect(&status_vector, 27);
 		// msg 27 isc_compile_request failed
 		fb_print_blr(blr_buffer, blr_length, NULL, NULL, 0);
 	}
@@ -1735,9 +1640,10 @@ void put_data(burp_rel* relation)
 	BURP_verbose(142, relation->rel_name);
 	// msg 142  writing data for relation %s
 
-	if (isc_start_request(status_vector, &request, &gds_trans, 0))
+	request->start(&status_vector, gds_trans, 0);
+	if (!status_vector.isSuccess())
 	{
-		BURP_error_redirect(status_vector, 28);
+		BURP_error_redirect(&status_vector, 28);
 		// msg 28 isc_start_request failed
 	}
 
@@ -1760,9 +1666,10 @@ void put_data(burp_rel* relation)
 	ULONG records = 0;
 	while (true)
 	{
-		if (isc_receive(status_vector, &request, 0, length, buffer, 0))
+		request->receive(&status_vector, 0, 0, length, buffer);
+		if (!status_vector.isSuccess())
 		{
-			BURP_error_redirect(status_vector, 29);
+			BURP_error_redirect(&status_vector, 29);
 			// msg 29 isc_receive failed
 		}
 		if (!*eof)
@@ -1819,8 +1726,9 @@ void put_data(burp_rel* relation)
 	BURP_verbose(108, SafeArg() << records);
 	// msg 108 %ld records written
 
-	if (isc_release_request(status_vector, &request))
-		BURP_error_redirect(status_vector, 30);
+	request->free(&status_vector);
+	if (!status_vector.isSuccess())
+		BURP_error_redirect(&status_vector, 30);
 	// msg 30 isc_release_request failed
 }
 
@@ -2249,12 +2157,12 @@ bool put_source_blob(att_type attribute, att_type old_attribute, ISC_QUAD& blob_
  *	Include the NULL character to separate each segment.
  *
  **************************************/
-	ISC_STATUS_ARRAY status_vector;
+	FbLocalStatus status_vector;
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
 	// If the blob is null, don't store it.  It will be restored as null.
 
-	if (UserBlob::blobIsNull(blob_id))
+	if (BlobWrapper::blobIsNull(blob_id))
 		return false;
 
 	if (tdgbl->gbl_sw_old_descriptions && attribute != att_field_query_header)
@@ -2262,18 +2170,18 @@ bool put_source_blob(att_type attribute, att_type old_attribute, ISC_QUAD& blob_
 
 	// Open the blob and get it's vital statistics
 
-	UserBlob blob(status_vector);
+	BlobWrapper blob(&status_vector);
 
 	if (!blob.open(DB, gds_trans, blob_id))
 	{
-		BURP_error_redirect(status_vector, 24);
+		BURP_error_redirect(&status_vector, 24);
 		// msg 24 isc_open_blob failed
 	}
 
 	UCHAR blob_info[48];
 	if (!blob.getInfo(sizeof(source_items), source_items, sizeof(blob_info), blob_info))
 	{
-		BURP_error_redirect(status_vector, 20);
+		BURP_error_redirect(&status_vector, 20);
 		// msg 20 isc_blob_info failed
 	}
 
@@ -2308,7 +2216,7 @@ bool put_source_blob(att_type attribute, att_type old_attribute, ISC_QUAD& blob_
 			// msg 79 don't understand blob info item %ld
 			if (!blob.close())
 			{
-				BURP_error_redirect(status_vector, 23);
+				BURP_error_redirect(&status_vector, 23);
 				// msg 23 isc_close_blob failed
 			}
 			return false;
@@ -2319,7 +2227,7 @@ bool put_source_blob(att_type attribute, att_type old_attribute, ISC_QUAD& blob_
 	{
 		if (!blob.close())
 		{
-			BURP_error_redirect(status_vector, 23);
+			BURP_error_redirect(&status_vector, 23);
 			// msg 23 isc_close_blob failed
 		}
 		return false;
@@ -2354,7 +2262,7 @@ bool put_source_blob(att_type attribute, att_type old_attribute, ISC_QUAD& blob_
 	}
 
 	if (!blob.close())
-		BURP_error_redirect(status_vector, 23);
+		BURP_error_redirect(&status_vector, 23);
 	// msg 23 isc_close_blob failed
 
 	if (buffer != static_buffer)
@@ -2414,7 +2322,7 @@ void write_character_sets()
  *	each user defined character set.
  *
  **************************************/
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -2512,7 +2420,7 @@ void write_check_constraints()
  *	each check constraint.
  *
  **************************************/
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -2546,7 +2454,7 @@ void write_collations()
  *	each user defined collation
  *
  **************************************/
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -2646,28 +2554,29 @@ void write_database( const TEXT* dbb_file)
  *	the database itself.
  *
  **************************************/
-	ISC_STATUS_ARRAY status_vector;
-	SCHAR buffer[256];
-	isc_req_handle req_handle1 = 0;
+	FbLocalStatus status_vector;
+	UCHAR buffer[256];
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
 	put(tdgbl, (UCHAR) rec_physical_db);
 
-	if (isc_database_info(status_vector, &DB, sizeof(db_info_items), db_info_items,
-						  sizeof(buffer), buffer))
+	DB->getInfo(&status_vector, sizeof(db_info_items), db_info_items,
+						  sizeof(buffer), buffer);
+	if (!status_vector.isSuccess())
 	{
-		BURP_error_redirect(status_vector, 31);
+		BURP_error_redirect(&status_vector, 31);
 		// msg 31 isc_database_info failed
 	}
 
 	USHORT page_size = 0, forced_writes, no_reserve, SQL_dialect, db_read_only;
  	ULONG sweep_interval, page_buffers;
  	USHORT length = 0;
-	for (const SCHAR* d = buffer; *d != isc_info_end; d += length)
+	for (const UCHAR* d = buffer; *d != isc_info_end; d += length)
 	{
 		const UCHAR item = *d++;
-		length = (USHORT) isc_vax_integer(d, 2);
+		length = (USHORT) gds__vax_integer(d, 2);
 		d += 2;
 		switch (item)
 		{
@@ -2675,27 +2584,27 @@ void write_database( const TEXT* dbb_file)
 			break;
 
 		case isc_info_page_size:
-			page_size = (USHORT) isc_vax_integer(d, length);
+			page_size = (USHORT) gds__vax_integer(d, length);
 			put_int32(att_page_size, page_size);
 			break;
 
 		case isc_info_sweep_interval:
-			sweep_interval = isc_vax_integer(d, length);
+			sweep_interval = gds__vax_integer(d, length);
 			put_int32(att_sweep_interval, sweep_interval);
 			break;
 
 		case isc_info_forced_writes:
-			forced_writes = (USHORT) isc_vax_integer(d, length);
+			forced_writes = (USHORT) gds__vax_integer(d, length);
 			put_int32(att_forced_writes, forced_writes);
 			break;
 
 		case isc_info_no_reserve:
-			if (no_reserve = (USHORT) isc_vax_integer(d, length))
+			if (no_reserve = (USHORT) gds__vax_integer(d, length))
 				put_int32(att_no_reserve, no_reserve);
 			break;
 
 		case isc_info_set_page_buffers:
-			if (page_buffers = isc_vax_integer(d, length))
+			if (page_buffers = gds__vax_integer(d, length))
 				put_int32(att_page_buffers, page_buffers);
 			break;
 
@@ -2703,17 +2612,17 @@ void write_database( const TEXT* dbb_file)
 			break;				// parameter and returns isc_info_error. skip it
 
 		case isc_info_db_sql_dialect:
-			SQL_dialect = (USHORT) isc_vax_integer(d, length);
+			SQL_dialect = (USHORT) gds__vax_integer(d, length);
 			put_int32(att_SQL_dialect, SQL_dialect);
 			break;
 
 		case isc_info_db_read_only:
-			if (db_read_only = (USHORT) isc_vax_integer(d, length))
+			if (db_read_only = (USHORT) gds__vax_integer(d, length))
 				put_int32(att_db_read_only, db_read_only);
 			break;
 
 		default:
-			BURP_error_redirect(status_vector, 31);
+			BURP_error_redirect(&status_vector, 31);
 			// msg 31 isc_database_info failed
 			break;
 		}
@@ -2781,7 +2690,7 @@ void write_exceptions()
  *
  **************************************/
 	TEXT temp[GDS_NAME_LEN];
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -2845,7 +2754,7 @@ void write_field_dimensions()
  *	each array field dimension.
  *
  **************************************/
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -2880,7 +2789,7 @@ void write_filters()
  *
  **************************************/
 	TEXT temp[GDS_NAME_LEN];
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -2922,7 +2831,7 @@ void write_functions()
  **************************************/
 	GDS_NAME func;
 	TEXT temp[GDS_NAME_LEN * 2];
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -3176,7 +3085,7 @@ void write_generators()
  *	Write any defined generators.
  *
  **************************************/
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 	TEXT temp[GDS_NAME_LEN];
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
@@ -3285,7 +3194,7 @@ void write_global_fields()
  *
  **************************************/
 	TEXT temp[GDS_NAME_LEN];
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -3516,7 +3425,7 @@ void write_packages()
  *
  **************************************/
 	TEXT temp[GDS_NAME_LEN];
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -3583,7 +3492,7 @@ void write_procedures()
  **************************************/
 	GDS_NAME proc;
 	TEXT temp[GDS_NAME_LEN * 2];
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -3773,7 +3682,7 @@ void write_ref_constraints()
  *	each referential constraint.
  *
  **************************************/
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -3809,7 +3718,7 @@ void write_rel_constraints()
  *
  **************************************/
 	TEXT temp[GDS_NAME_LEN];
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -3853,7 +3762,7 @@ void write_relations()
  *
  **************************************/
 	TEXT temp[GDS_NAME_LEN];
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -3983,7 +3892,7 @@ void write_relations()
 void write_secclasses()
 {
 	TEXT temp[GDS_NAME_LEN];
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -4019,7 +3928,7 @@ void write_shadow_files()
  *
  **************************************/
 	BASED ON RDB$FILES.RDB$FILE_NAME temp;
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -4060,7 +3969,7 @@ void write_sql_roles()
  *	each SQL roles.
  *
  **************************************/
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 	TEXT temp[GDS_NAME_LEN];
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
@@ -4129,7 +4038,7 @@ void write_mapping()
  *	each names mapping.
  *
  **************************************/
-	isc_req_handle req_handle = 0;
+	Firebird::IRequest* req_handle = nullptr;
 	TEXT temp[GDS_NAME_LEN];
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
@@ -4212,7 +4121,7 @@ void write_triggers()
  *
  **************************************/
 	TEXT temp[GDS_NAME_LEN];
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -4329,7 +4238,7 @@ void write_trigger_messages()
  *
  **************************************/
 	TEXT temp[GDS_NAME_LEN];
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -4368,7 +4277,7 @@ void write_types()
  *	each type.
  *
  **************************************/
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
@@ -4408,7 +4317,7 @@ void write_user_privileges()
  *
  **************************************/
 	TEXT temp[GDS_NAME_LEN];
-	isc_req_handle req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 

--- a/src/burp/backup.epp
+++ b/src/burp/backup.epp
@@ -1089,7 +1089,7 @@ void put_array( burp_fld* field, burp_rel* relation, ISC_QUAD* blob_id)
 			lstring xdr_slice;
 			xdr_slice.lstr_allocated = xdr_slice.lstr_length = return_length;
 			xdr_slice.lstr_address = slice;
-			return_length = CAN_slice(&xdr_buffer, &xdr_slice, TRUE, /*blr_length,*/ blr_buffer);
+			return_length = CAN_slice(&xdr_buffer, &xdr_slice, true, blr_buffer);
 			put(tdgbl, att_xdr_array);
 			put(tdgbl, (UCHAR) (return_length));
 			put(tdgbl, (UCHAR) (return_length >> 8));
@@ -1678,7 +1678,7 @@ void put_data(burp_rel* relation)
 		const UCHAR* p;
 		if (tdgbl->gbl_sw_transportable)
 		{
-			record_length = CAN_encode_decode(relation, &xdr_buffer, buffer, TRUE);
+			record_length = CAN_encode_decode(relation, &xdr_buffer, buffer, true);
 			put_int32(att_xdr_length, record_length);
 			p = xdr_buffer.lstr_address;
 		}

--- a/src/burp/burp.cpp
+++ b/src/burp/burp.cpp
@@ -2600,3 +2600,21 @@ UnicodeCollationHolder::~UnicodeCollationHolder()
 	// cs should be deleted by texttype_fn_destroy call above
 	delete tt;
 }
+
+void BURP_makeSymbol(BurpGlobals* tdgbl, Firebird::string& name)		// add double quotes to string
+{
+	if (tdgbl->gbl_dialect < SQL_DIALECT_V6)
+		return;
+
+	const char dq = '"';
+	for (unsigned p = 0; p < name.length(); ++p)
+	{
+		if (name[p] == dq)
+		{
+			name.insert(p, 1, dq);
+			++p;
+		}
+	}
+	name.insert(0u, 1, dq);
+	name += dq;
+}

--- a/src/burp/burp.cpp
+++ b/src/burp/burp.cpp
@@ -368,8 +368,8 @@ static int svc_api_gbak(Firebird::UtilSvc* uSvc, const Switches& switches)
 		const UCHAR* sl;
 		do {
 			svc_handle->query(&status, 0, NULL,
-								  sizeof(sendbuf), sendbuf,
-								  sizeof(respbuf), respbuf);
+							  sizeof(sendbuf), sendbuf,
+							  sizeof(respbuf), respbuf);
 			if (!status.isSuccess())
 			{
 				BURP_print_status(true, &status);

--- a/src/burp/burp.cpp
+++ b/src/burp/burp.cpp
@@ -65,6 +65,7 @@
 #include <ctype.h>
 #endif
 #include "../common/utils_proto.h"
+#include "../common/status.h"
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -82,6 +83,7 @@
 #endif
 
 using MsgFormat::SafeArg;
+using Firebird::FbLocalStatus;
 
 const char* fopen_write_type = "w";
 const char* fopen_read_type	 = "r";
@@ -102,7 +104,7 @@ enum gbak_action
 	//FDESC	=	3 // CVC: Unused
 };
 
-static void close_out_transaction(gbak_action, isc_tr_handle*);
+static void close_out_transaction(gbak_action, Firebird::ITransaction**);
 //static void enable_signals();
 //static void excp_handler();
 static SLONG get_number(const SCHAR*);
@@ -272,8 +274,8 @@ static int svc_api_gbak(Firebird::UtilSvc* uSvc, const Switches& switches)
 
 	const Firebird::string* dbName = flag_restore ? &files[1] : &files[0];
 
-	ISC_STATUS_ARRAY status;
-	FB_API_HANDLE svc_handle = 0;
+	FbLocalStatus status;
+	Firebird::IService* svc_handle = nullptr;
 
 	try
 	{
@@ -317,21 +319,22 @@ static int svc_api_gbak(Firebird::UtilSvc* uSvc, const Switches& switches)
 
 		spb.insertString(isc_spb_command_line, options);
 
-		if (isc_service_attach(status, 0, service.c_str(), &svc_handle,
-							   spb.getBufferLength(), reinterpret_cast<const char*>(spb.getBuffer())))
+		svc_handle = Firebird::DispatcherPtr()->attachServiceManager(&status, service.c_str(),
+			spb.getBufferLength(), spb.getBuffer());
+		if (!status.isSuccess())
 		{
-			BURP_print_status(true, status);
+			BURP_print_status(true, &status);
 			BURP_print(true, 83);
 			// msg 83 Exiting before completion due to errors
 			return FINI_ERROR;
 		}
 
-		char thd[10];
+		UCHAR thd[10];
 		// 'isc_action_svc_restore/isc_action_svc_backup'
 		// 'isc_spb_verbose'
 		// 'isc_spb_verbint'
 
-		char* thd_ptr = thd;
+		UCHAR* thd_ptr = thd;
 		if (flag_restore)
 			*thd_ptr++ = isc_action_svc_restore;
 		else
@@ -344,41 +347,43 @@ static int svc_api_gbak(Firebird::UtilSvc* uSvc, const Switches& switches)
 		{
 			*thd_ptr++ = isc_spb_verbint;
 			//stream verbint_val into a SPB
-			put_vax_long(reinterpret_cast<UCHAR*>(thd_ptr), verbint_val);
+			put_vax_long(thd_ptr, verbint_val);
 			thd_ptr += sizeof(SLONG);
 		}
 
 		const USHORT thdlen = thd_ptr - thd;
 		fb_assert(thdlen <= sizeof(thd));
 
-		if (isc_service_start(status, &svc_handle, NULL, thdlen, thd))
+		svc_handle->start(&status, thdlen, thd);
+		if (!status.isSuccess())
 		{
-			BURP_print_status(true, status);
-			isc_service_detach(status, &svc_handle);
+			BURP_print_status(true, &status);
+			svc_handle->release();
 			BURP_print(true, 83);	// msg 83 Exiting before completion due to errors
 			return FINI_ERROR;
 		}
 
-		const char sendbuf[] = { isc_info_svc_line };
-		char respbuf[1024];
-		const char* sl;
+		const UCHAR sendbuf[] = { isc_info_svc_line };
+		UCHAR respbuf[1024];
+		const UCHAR* sl;
 		do {
-			if (isc_service_query(status, &svc_handle, NULL, 0, NULL,
+			svc_handle->query(&status, 0, NULL,
 								  sizeof(sendbuf), sendbuf,
-								  sizeof(respbuf), respbuf))
+								  sizeof(respbuf), respbuf);
+			if (!status.isSuccess())
 			{
-				BURP_print_status(true, status);
-				isc_service_detach(status, &svc_handle);
+				BURP_print_status(true, &status);
+				svc_handle->release();
 				BURP_print(true, 83);	// msg 83 Exiting before completion due to errors
 				return FINI_ERROR;
 			}
 
-			char* p = respbuf;
+			UCHAR* p = respbuf;
 			sl = p;
 
 			if (*p++ == isc_info_svc_line)
 			{
-				const ISC_USHORT len = (ISC_USHORT) isc_vax_integer(p, sizeof(ISC_USHORT));
+				const ISC_USHORT len = (ISC_USHORT) gds__vax_integer(p, sizeof(ISC_USHORT));
 				p += sizeof(ISC_USHORT);
 				if (!len)
 				{
@@ -395,18 +400,16 @@ static int svc_api_gbak(Firebird::UtilSvc* uSvc, const Switches& switches)
 			}
 		} while (*sl == isc_info_svc_line);
 
-		isc_service_detach(status, &svc_handle);
+		svc_handle->release();
 		return FINI_OK;
 	}
 	catch (const Firebird::Exception& e)
 	{
-		Firebird::StaticStatusVector s;
-		e.stuffException(s);
-		BURP_print_status(true, s.begin());
+		FbLocalStatus s;
+		e.stuffException(&s);
+		BURP_print_status(true, &s);
 		if (svc_handle)
-		{
-			isc_service_detach(status, &svc_handle);
-		}
+			svc_handle->release();
 		BURP_print(true, 83);	// msg 83 Exiting before completion due to errors
 		return FINI_ERROR;
 	}
@@ -1285,10 +1288,8 @@ int gbak(Firebird::UtilSvc* uSvc)
 	{
 		// Non-burp exception was caught
 		tdgbl->burp_throw = false;
-		Firebird::StaticStatusVector s;
-		e.stuffException(s);
-		fb_utils::copyStatus(tdgbl->status_vector, ISC_STATUS_LENGTH, s.begin(), s.getCount());
-		BURP_print_status(true, tdgbl->status_vector);
+		e.stuffException(&tdgbl->status_vector);
+		BURP_print_status(true, &tdgbl->status_vector);
 		if (! tdgbl->uSvc->isService())
 		{
 			BURP_print(true, 83);	// msg 83 Exiting before completion due to errors
@@ -1319,9 +1320,10 @@ int gbak(Firebird::UtilSvc* uSvc)
 	{
 		close_out_transaction(action, &tdgbl->tr_handle);
 		close_out_transaction(action, &tdgbl->global_trans);
-		if (isc_detach_database(tdgbl->status_vector, &tdgbl->db_handle))
+		tdgbl->db_handle->detach(&tdgbl->status_vector);
+		if (tdgbl->status_vector->getState() & Firebird::IStatus::STATE_ERRORS)
 		{
-			BURP_print_status(true, tdgbl->status_vector);
+			BURP_print_status(true, &tdgbl->status_vector);
 		}
 	}
 
@@ -1428,7 +1430,7 @@ void BURP_error(USHORT errcode, bool abort, const char* str)
 }
 
 
-void BURP_error_redirect(const ISC_STATUS* status_vector, USHORT errcode, const SafeArg& arg)
+void BURP_error_redirect(Firebird::IStatus* status_vector, USHORT errcode, const SafeArg& arg)
 {
 /**************************************
  *
@@ -1516,25 +1518,23 @@ void BURP_msg_get(USHORT number, TEXT* output_msg, const SafeArg& arg)
 	strcpy(output_msg, buffer);
 }
 
-
-void BURP_output_version(void* arg1, const TEXT* arg2)
+void OutputVersion::callback(Firebird::CheckStatusWrapper* status, const char* text)
 {
 /**************************************
  *
- *	B U R P _ o u t p u t _ v e r s i o n
+ *	O u t p u t V e r s i o n :: c a l l b a c k
  *
  **************************************
  *
  * Functional description
  *	Callback routine for access method
- *	printing (specifically show version);
+ *	printing (specifically show version)
  *	will accept.
  *
  **************************************/
 
-	burp_output(false, static_cast<const char*>(arg1), arg2);
+	burp_output(false, format, text);
 }
-
 
 void BURP_print(bool err, USHORT number, const SafeArg& arg)
 {
@@ -1577,7 +1577,7 @@ void BURP_print(bool err, USHORT number, const char* str)
 }
 
 
-void BURP_print_status(bool err, const ISC_STATUS* status_vector)
+void BURP_print_status(bool err, Firebird::IStatus* status_vector)
 {
 /**************************************
  *
@@ -1592,7 +1592,7 @@ void BURP_print_status(bool err, const ISC_STATUS* status_vector)
  **************************************/
 	if (status_vector)
 	{
-		const ISC_STATUS* vector = status_vector;
+		const ISC_STATUS* vector = status_vector->getErrors();
 
 		if (err)
 		{
@@ -1622,7 +1622,7 @@ void BURP_print_status(bool err, const ISC_STATUS* status_vector)
 }
 
 
-void BURP_print_warning(const ISC_STATUS* status_vector)
+void BURP_print_warning(Firebird::IStatus* status)
 {
 /**************************************
  *
@@ -1635,14 +1635,10 @@ void BURP_print_warning(const ISC_STATUS* status_vector)
  *	to allow redirecting output.
  *
  **************************************/
-	if (status_vector)
+	if (status && (status->getState() & Firebird::IStatus::STATE_WARNINGS))
 	{
-		// skip the error, assert that one does not exist
-		fb_assert(status_vector[0] == isc_arg_gds);
-		fb_assert(status_vector[1] == 0);
-
 		// print the warning message
-		const ISC_STATUS* vector = &status_vector[2];
+		const ISC_STATUS* vector = status->getWarnings();
 		SCHAR s[1024];
 
 		if (fb_interpret(s, sizeof(s), &vector))
@@ -1716,7 +1712,7 @@ void BURP_verbose(USHORT number, const char* str)
 }
 
 
-static void close_out_transaction(gbak_action action, isc_tr_handle* handle)
+static void close_out_transaction(gbak_action action, Firebird::ITransaction** tPtr)
 {
 /**************************************
  *
@@ -1731,31 +1727,38 @@ static void close_out_transaction(gbak_action action, isc_tr_handle* handle)
  *	returned to the system.
  *
  **************************************/
-	if (*handle != 0)
+	if (*tPtr)
 	{
-		ISC_STATUS_ARRAY status_vector;
+		FbLocalStatus status_vector;
 		if (action == RESTORE)
 		{
 			// Even if the restore failed, commit the transaction so that
 			// a partial database is at least recovered.
-			isc_commit_transaction(status_vector, handle);
-			if (status_vector[1])
+			(*tPtr)->commit(&status_vector);
+			if (!status_vector.isSuccess())
 			{
 				// If we can't commit - have to roll it back, as
 				// we need to close all outstanding transactions before
 				// we can detach from the database.
-				isc_rollback_transaction(status_vector, handle);
-				if (status_vector[1])
-					BURP_print_status(false, status_vector);
+				(*tPtr)->rollback(&status_vector);
+				if (!status_vector.isSuccess())
+					BURP_print_status(false, &status_vector);
+				else
+					*tPtr = nullptr;
 			}
+			else
+				*tPtr = nullptr;
 		}
 		else
 		{
 			// A backup shouldn't touch any data - we ensure that
 			// by never writing data during a backup, but let's double
 			// ensure it by doing a rollback
-			if (isc_rollback_transaction(status_vector, handle))
-				BURP_print_status(false, status_vector);
+			(*tPtr)->rollback(&status_vector);
+			if (!status_vector.isSuccess())
+				BURP_print_status(false, &status_vector);
+			else
+				*tPtr = nullptr;
 		}
 	}
 }
@@ -1810,38 +1813,37 @@ static gbak_action open_files(const TEXT* file1,
  *
  **************************************/
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
-	ISC_STATUS_ARRAY temp_status;
-	ISC_STATUS* status_vector = temp_status;
+	FbLocalStatus temp_status;
+	Firebird::CheckStatusWrapper* status_vector = &temp_status;
 
 	// try to attach the database using the first file_name
 
 	if (sw_replace != IN_SW_BURP_C && sw_replace != IN_SW_BURP_R)
 	{
-		if (!isc_attach_database(status_vector,
-								  (SSHORT) 0, file1,
-								  &tdgbl->db_handle,
-								  dpb.getBufferLength(),
-								  reinterpret_cast<const char*>(dpb.getBuffer())))
+		tdgbl->db_handle = Firebird::DispatcherPtr()->attachDatabase(status_vector, file1,
+			dpb.getBufferLength(), dpb.getBuffer());
+		if (!status_vector->hasData())
 		{
 			if (sw_replace != IN_SW_BURP_B)
 			{
 				// msg 13 REPLACE specified, but the first file %s is a database
 				BURP_error(13, true, file1);
-				if (isc_detach_database(status_vector, &tdgbl->db_handle)) {
+				tdgbl->db_handle->detach(status_vector);
+				if (status_vector->hasData())
 					BURP_print_status(true, status_vector);
-				}
 				return QUIT;
 			}
 			if (tdgbl->gbl_sw_version)
 			{
 				// msg 139 Version(s) for database "%s"
 				BURP_print(false, 139, file1);
-				isc_version(&tdgbl->db_handle, BURP_output_version, (void*) "\t%s\n");
+				OutputVersion outputVersion("\t%s\n");
+				Firebird::UtilInterfacePtr()->getFbVersion(status_vector, tdgbl->db_handle, &outputVersion);
 			}
 			BURP_verbose(166, file1); // msg 166: readied database %s for backup
 		}
 		else if (sw_replace == IN_SW_BURP_B ||
-			(status_vector[1] != isc_io_error && status_vector[1] != isc_bad_db_format))
+			(status_vector->getErrors()[1] != isc_io_error && status_vector->getErrors()[1] != isc_bad_db_format))
 		{
 			BURP_print_status(true, status_vector);
 			return QUIT;
@@ -1965,10 +1967,9 @@ static gbak_action open_files(const TEXT* file1,
 		}
 		else
 		{
-			if (isc_detach_database(status_vector, &tdgbl->db_handle))
-			{
-				BURP_print_status(false, status_vector);
-			}
+			tdgbl->db_handle->detach(status_vector);
+			if (status_vector->hasData())
+				BURP_print_status(true, status_vector);
 		}
 
 		return flag;
@@ -2139,49 +2140,45 @@ static gbak_action open_files(const TEXT* file1,
 		BURP_error(262, true, *file2);
 		// msg 262 size specification either missing or incorrect for file %s
 
-	if ((sw_replace == IN_SW_BURP_C || sw_replace == IN_SW_BURP_R) &&
-		!isc_attach_database(status_vector,
-							 (SSHORT) 0, *file2,
-							 &tdgbl->db_handle,
-							 dpb.getBufferLength(),
-							 reinterpret_cast<const char*>(dpb.getBuffer())))
+	if (sw_replace == IN_SW_BURP_C || sw_replace == IN_SW_BURP_R)
 	{
-		if (sw_replace == IN_SW_BURP_C)
+		tdgbl->db_handle = Firebird::DispatcherPtr()->attachDatabase(status_vector, *file2,
+			dpb.getBufferLength(), dpb.getBuffer());
+		if (status_vector->isEmpty())
 		{
-			if (isc_detach_database(status_vector, &tdgbl->db_handle)) {
-				BURP_print_status(true, status_vector);
-			}
-			BURP_error(14, true, *file2);
-			// msg 14 database %s already exists.  To replace it, use the -R switch
-		}
-		else
-		{
-			isc_drop_database(status_vector, &tdgbl->db_handle);
-			if (tdgbl->db_handle)
+			if (sw_replace == IN_SW_BURP_C)
 			{
-				ISC_STATUS_ARRAY status_vector2;
-				if (isc_detach_database(status_vector2, &tdgbl->db_handle)) {
-					BURP_print_status(false, status_vector2);
-				}
+				tdgbl->db_handle->detach(status_vector);
+				if (status_vector->hasData())
+					BURP_print_status(true, status_vector);
+				BURP_error(14, true, *file2);
+				// msg 14 database %s already exists.  To replace it, use the -R switch
+			}
+			else
+			{
+				tdgbl->db_handle->dropDatabase(status_vector);
+				if (status_vector->hasData())
+				{
+					Firebird::FbLocalStatus status2;
+					tdgbl->db_handle->detach(&status2);
+					if (!status2.isSuccess())
+						BURP_print_status(true, &status2);
 
-				// Complain only if the drop database entrypoint is available.
-				// If it isn't, the database will simply be overwritten.
-
-				if (status_vector[1] != isc_unavailable)
 					BURP_error(233, true, *file2);
-				// msg 233 Cannot drop database %s, might be in use
+					// msg 233 Cannot drop database %s, might be in use
+				}
 			}
 		}
-	}
-	if (sw_replace == IN_SW_BURP_R && status_vector[1] == isc_adm_task_denied)
-	{
-		// if we got an error from attach database and we have replace switch set
-		// then look for error from attach returned due to not owner, if we are
-		// not owner then return the error status back up
+		else if (sw_replace == IN_SW_BURP_R && status_vector->getErrors()[1] == isc_adm_task_denied)
+		{
+			// if we got an error from attach database and we have replace switch set
+			// then look for error from attach returned due to not owner, if we are
+			// not owner then return the error status back up
 
-		BURP_error(274, true);
-		// msg # 274 : Cannot restore over current database, must be sysdba
-		// or owner of the existing database.
+			BURP_error(274, true);
+			// msg # 274 : Cannot restore over current database, must be sysdba
+			// or owner of the existing database.
+		}
 	}
 
 	// check the file size specification
@@ -2458,18 +2455,18 @@ void BurpGlobals::read_stats(SINT64* stats)
 	if (!db_handle)
 		return;
 
-	const char info[] =
+	const UCHAR info[] =
 	{
 		isc_info_reads,
 		isc_info_writes
 	};
 
-	ISC_STATUS_ARRAY status = {0};
-	char buffer[sizeof(info) * (1 + 2 + 8) + 2];
+	FbLocalStatus status;
+	UCHAR buffer[sizeof(info) * (1 + 2 + 8) + 2];
 
-	isc_database_info(status, &db_handle, sizeof(info), info, sizeof(buffer), buffer);
+	db_handle->getInfo(&status, sizeof(info), info, sizeof(buffer), buffer);
 
-	char* p = buffer, *const e = buffer + sizeof(buffer);
+	UCHAR* p = buffer, *const e = buffer + sizeof(buffer);
 	while (p < e)
 	{
 		int flag = -1;
@@ -2490,7 +2487,7 @@ void BurpGlobals::read_stats(SINT64* stats)
 
 		if (flag != -1)
 		{
-			const int len = isc_vax_integer(p + 1, 2);
+			const int len = gds__vax_integer(p + 1, 2);
 			stats[flag] = isc_portable_integer((ISC_UCHAR*) p + 1 + 2, len);
 			p += len + 3;
 		}

--- a/src/burp/burp.h
+++ b/src/burp/burp.h
@@ -664,12 +664,14 @@ struct burp_fld
 	SSHORT		fld_type;
 	SSHORT		fld_sub_type;
 	FLD_LENGTH	fld_length;
+	FLD_LENGTH	fld_total_len;	// including additional 2 bytes for VARYING CHAR
 	SSHORT		fld_scale;
 	SSHORT		fld_position;
 	SSHORT		fld_parameter;
 	SSHORT		fld_missing_parameter;
 	SSHORT		fld_id;
 	RCRD_OFFSET	fld_offset;
+	RCRD_OFFSET	fld_missing_offset;
 	RCRD_OFFSET	fld_old_offset;
 	SSHORT		fld_number;
 	SSHORT		fld_system_flag;
@@ -698,6 +700,8 @@ struct burp_fld
 	ISC_QUAD	fld_default_source;
 	SSHORT		fld_character_set_id;
 	SSHORT		fld_collation_id;
+	RCRD_OFFSET	fld_sql;
+	RCRD_OFFSET	fld_null;
 };
 
 enum fld_flags_vals {
@@ -958,6 +962,7 @@ public:
 	bool		gbl_sw_deactivate_indexes;
 	bool		gbl_sw_kill;
 	USHORT		gbl_sw_blk_factor;
+	USHORT		gbl_dialect;
 	const SCHAR*	gbl_sw_fix_fss_data;
 	USHORT			gbl_sw_fix_fss_data_id;
 	const SCHAR*	gbl_sw_fix_fss_metadata;
@@ -976,6 +981,7 @@ public:
 	burp_fil*	gbl_sw_files;
 	burp_fil*	gbl_sw_backup_files;
 	gfld*		gbl_global_fields;
+	unsigned	gbl_network_protocol;
 	burp_act*	action;
 	ULONG		io_buffer_size;
 	redirect_vals	sw_redirect;

--- a/src/burp/burp.h
+++ b/src/burp/burp.h
@@ -31,6 +31,8 @@
 
 #include <stdio.h>
 #include "../jrd/ibase.h"
+#include "firebird/Interface.h"
+#include "firebird/Message.h"
 #include "../common/dsc.h"
 #include "../burp/misc_proto.h"
 #include "../yvalve/gds_proto.h"
@@ -40,6 +42,8 @@
 #include "../common/classes/fb_pair.h"
 #include "../common/classes/MetaName.h"
 #include "../../jrd/SimilarToMatcher.h"
+#include "../common/status.h"
+#include "../common/classes/ImplementHelper.h"
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -928,7 +932,6 @@ public:
 		// this is VERY dirty hack to keep current behaviour
 		memset (&gbl_database_file_name, 0,
 			&veryEnd - reinterpret_cast<char*>(&gbl_database_file_name));
-		memset(status_vector, 0, sizeof(status_vector));
 
 		gbl_stat_flags = 0;
 		gbl_stat_header = false;
@@ -1001,11 +1004,10 @@ public:
 	SCHAR		mvol_old_file [MAX_FILE_NAME_SIZE];
 	int			mvol_volume_count;
 	bool		mvol_empty_file;
-	isc_db_handle	db_handle;
-	isc_tr_handle	tr_handle;
-	isc_tr_handle	global_trans;
+	Firebird::IAttachment*	db_handle;
+	Firebird::ITransaction*	tr_handle;
+	Firebird::ITransaction*	global_trans;
 	DESC		file_desc;
-	ISC_STATUS_ARRAY status_vector;
 	int			exit_code;
 	UCHAR*		head_of_mem_list;
 	FILE*		output_file;
@@ -1015,59 +1017,59 @@ public:
 	// burp_fld*	v3_cvt_fld_list;
 
 	// The handles_get... are for restore.
-	isc_req_handle	handles_get_character_sets_req_handle1;
-	isc_req_handle	handles_get_chk_constraint_req_handle1;
-	isc_req_handle	handles_get_collation_req_handle1;
-	isc_req_handle	handles_get_exception_req_handle1;
-	isc_req_handle	handles_get_field_dimensions_req_handle1;
-	isc_req_handle	handles_get_field_req_handle1;
-	isc_req_handle	handles_get_fields_req_handle1;
-	isc_req_handle	handles_get_fields_req_handle2;
-	isc_req_handle	handles_get_fields_req_handle3;
-	isc_req_handle	handles_get_fields_req_handle4;
-	isc_req_handle	handles_get_fields_req_handle5;
-	isc_req_handle	handles_get_fields_req_handle6;
-	isc_req_handle	handles_get_files_req_handle1;
-	isc_req_handle	handles_get_filter_req_handle1;
-	isc_req_handle	handles_get_function_arg_req_handle1;
-	isc_req_handle	handles_get_function_req_handle1;
-	isc_req_handle	handles_get_global_field_req_handle1;
-	isc_req_handle	handles_get_index_req_handle1;
-	isc_req_handle	handles_get_index_req_handle2;
-	isc_req_handle	handles_get_index_req_handle3;
-	isc_req_handle	handles_get_index_req_handle4;
-	isc_req_handle	handles_get_package_req_handle1;
-	isc_req_handle	handles_get_procedure_prm_req_handle1;
-	isc_req_handle	handles_get_procedure_req_handle1;
-	isc_req_handle	handles_get_ranges_req_handle1;
-	isc_req_handle	handles_get_ref_constraint_req_handle1;
-	isc_req_handle	handles_get_rel_constraint_req_handle1;
-	isc_req_handle	handles_get_relation_req_handle1;
-	isc_req_handle	handles_get_security_class_req_handle1;
-	isc_req_handle	handles_get_sql_roles_req_handle1;
-	isc_req_handle	handles_get_mapping_req_handle1;
-	isc_req_handle	handles_get_trigger_message_req_handle1;
-	isc_req_handle	handles_get_trigger_message_req_handle2;
-	isc_req_handle	handles_get_trigger_old_req_handle1;
-	isc_req_handle	handles_get_trigger_req_handle1;
-	isc_req_handle	handles_get_type_req_handle1;
-	isc_req_handle	handles_get_user_privilege_req_handle1;
-	isc_req_handle	handles_get_view_req_handle1;
+	Firebird::IRequest*	handles_get_character_sets_req_handle1;
+	Firebird::IRequest*	handles_get_chk_constraint_req_handle1;
+	Firebird::IRequest*	handles_get_collation_req_handle1;
+	Firebird::IRequest*	handles_get_exception_req_handle1;
+	Firebird::IRequest*	handles_get_field_dimensions_req_handle1;
+	Firebird::IRequest*	handles_get_field_req_handle1;
+	Firebird::IRequest*	handles_get_fields_req_handle1;
+	Firebird::IRequest*	handles_get_fields_req_handle2;
+	Firebird::IRequest*	handles_get_fields_req_handle3;
+	Firebird::IRequest*	handles_get_fields_req_handle4;
+	Firebird::IRequest*	handles_get_fields_req_handle5;
+	Firebird::IRequest*	handles_get_fields_req_handle6;
+	Firebird::IRequest*	handles_get_files_req_handle1;
+	Firebird::IRequest*	handles_get_filter_req_handle1;
+	Firebird::IRequest*	handles_get_function_arg_req_handle1;
+	Firebird::IRequest*	handles_get_function_req_handle1;
+	Firebird::IRequest*	handles_get_global_field_req_handle1;
+	Firebird::IRequest*	handles_get_index_req_handle1;
+	Firebird::IRequest*	handles_get_index_req_handle2;
+	Firebird::IRequest*	handles_get_index_req_handle3;
+	Firebird::IRequest*	handles_get_index_req_handle4;
+	Firebird::IRequest*	handles_get_package_req_handle1;
+	Firebird::IRequest*	handles_get_procedure_prm_req_handle1;
+	Firebird::IRequest*	handles_get_procedure_req_handle1;
+	Firebird::IRequest*	handles_get_ranges_req_handle1;
+	Firebird::IRequest*	handles_get_ref_constraint_req_handle1;
+	Firebird::IRequest*	handles_get_rel_constraint_req_handle1;
+	Firebird::IRequest*	handles_get_relation_req_handle1;
+	Firebird::IRequest*	handles_get_security_class_req_handle1;
+	Firebird::IRequest*	handles_get_sql_roles_req_handle1;
+	Firebird::IRequest*	handles_get_mapping_req_handle1;
+	Firebird::IRequest*	handles_get_trigger_message_req_handle1;
+	Firebird::IRequest*	handles_get_trigger_message_req_handle2;
+	Firebird::IRequest*	handles_get_trigger_old_req_handle1;
+	Firebird::IRequest*	handles_get_trigger_req_handle1;
+	Firebird::IRequest*	handles_get_type_req_handle1;
+	Firebird::IRequest*	handles_get_user_privilege_req_handle1;
+	Firebird::IRequest*	handles_get_view_req_handle1;
 	// The handles_put.. are for backup.
-	isc_req_handle	handles_put_index_req_handle1;
-	isc_req_handle	handles_put_index_req_handle2;
-	isc_req_handle	handles_put_index_req_handle3;
-	isc_req_handle	handles_put_index_req_handle4;
-	isc_req_handle	handles_put_index_req_handle5;
-	isc_req_handle	handles_put_index_req_handle6;
-	isc_req_handle	handles_put_index_req_handle7;
-	isc_req_handle	handles_put_relation_req_handle1;
-	isc_req_handle	handles_put_relation_req_handle2;
-	isc_req_handle	handles_store_blr_gen_id_req_handle1;
-	isc_req_handle	handles_write_function_args_req_handle1;
-	isc_req_handle	handles_write_function_args_req_handle2;
-	isc_req_handle	handles_write_procedure_prms_req_handle1;
-	isc_req_handle	handles_fix_security_class_name_req_handle1;
+	Firebird::IRequest*	handles_put_index_req_handle1;
+	Firebird::IRequest*	handles_put_index_req_handle2;
+	Firebird::IRequest*	handles_put_index_req_handle3;
+	Firebird::IRequest*	handles_put_index_req_handle4;
+	Firebird::IRequest*	handles_put_index_req_handle5;
+	Firebird::IRequest*	handles_put_index_req_handle6;
+	Firebird::IRequest*	handles_put_index_req_handle7;
+	Firebird::IRequest*	handles_put_relation_req_handle1;
+	Firebird::IRequest*	handles_put_relation_req_handle2;
+	Firebird::IRequest*	handles_store_blr_gen_id_req_handle1;
+	Firebird::IRequest*	handles_write_function_args_req_handle1;
+	Firebird::IRequest*	handles_write_function_args_req_handle2;
+	Firebird::IRequest*	handles_write_procedure_prms_req_handle1;
+	Firebird::IRequest*	handles_fix_security_class_name_req_handle1;
 	bool			hdr_forced_writes;
 	TEXT			database_security_class[GDS_NAME_LEN]; // To save database security class for deferred update
 
@@ -1088,6 +1090,9 @@ public:
 
 	char veryEnd;
 	//starting after this members must be initialized in constructor explicitly
+
+	Firebird::FbLocalStatus status_vector;
+	Firebird::ThrowLocalStatus throwStatus;
 
 	Firebird::Array<Firebird::Pair<Firebird::NonPooled<Firebird::MetaName, Firebird::MetaName> > >
 		defaultCollations;
@@ -1161,5 +1166,52 @@ enum burp_messages_vals {
 
 // BLOB buffer
 typedef Firebird::HalfStaticArray<UCHAR, 1024> BlobBuffer;
+
+class BurpSql : public Firebird::AutoStorage
+{
+public:
+	BurpSql(BurpGlobals* g, const char* sql)
+		: Firebird::AutoStorage(),
+		  tdgbl(g), stmt(nullptr)
+	{
+		stmt = tdgbl->db_handle->prepare(&tdgbl->throwStatus, tdgbl->tr_handle, 0, sql, 3, 0);
+	}
+
+	template <typename M>
+	void singleSelect(Firebird::ITransaction* trans, M* msg)
+	{
+		stmt->execute(&tdgbl->throwStatus, tdgbl->tr_handle, nullptr, nullptr, msg->getMetadata(), msg->getData());
+	}
+
+	template <typename M>
+	void execute(Firebird::ITransaction* trans, M* msg)
+	{
+		stmt->execute(&tdgbl->throwStatus, tdgbl->tr_handle, msg->getMetadata(), msg->getData(), nullptr, nullptr);
+	}
+
+	void execute(Firebird::ITransaction* trans)
+	{
+		stmt->execute(&tdgbl->throwStatus, tdgbl->tr_handle, nullptr, nullptr, nullptr, nullptr);
+	}
+
+private:
+	BurpGlobals* tdgbl;
+	Firebird::IStatement* stmt;
+};
+
+class OutputVersion : public Firebird::IVersionCallbackImpl<OutputVersion, Firebird::CheckStatusWrapper>
+{
+public:
+	OutputVersion(const char* printFormat)
+		: format(printFormat)
+	{ }
+
+	void callback(Firebird::CheckStatusWrapper* status, const char* text);
+
+private:
+	const char* format;
+};
+
+
 
 #endif // BURP_BURP_H

--- a/src/burp/burp.h
+++ b/src/burp/burp.h
@@ -1061,6 +1061,7 @@ public:
 	Firebird::IRequest*	handles_get_type_req_handle1;
 	Firebird::IRequest*	handles_get_user_privilege_req_handle1;
 	Firebird::IRequest*	handles_get_view_req_handle1;
+
 	// The handles_put.. are for backup.
 	Firebird::IRequest*	handles_put_index_req_handle1;
 	Firebird::IRequest*	handles_put_index_req_handle2;
@@ -1076,6 +1077,7 @@ public:
 	Firebird::IRequest*	handles_write_function_args_req_handle2;
 	Firebird::IRequest*	handles_write_procedure_prms_req_handle1;
 	Firebird::IRequest*	handles_fix_security_class_name_req_handle1;
+
 	bool			hdr_forced_writes;
 	TEXT			database_security_class[GDS_NAME_LEN]; // To save database security class for deferred update
 
@@ -1217,7 +1219,5 @@ public:
 private:
 	const char* format;
 };
-
-
 
 #endif // BURP_BURP_H

--- a/src/burp/burp_proto.h
+++ b/src/burp/burp_proto.h
@@ -34,7 +34,7 @@ int		gbak(Firebird::UtilSvc*);
 void	BURP_abort();
 void	BURP_error(USHORT, bool, const MsgFormat::SafeArg& arg = MsgFormat::SafeArg());
 void	BURP_error(USHORT, bool, const char* str);
-void	BURP_error_redirect(const ISC_STATUS*, USHORT, const MsgFormat::SafeArg& arg = MsgFormat::SafeArg());
+void	BURP_error_redirect(Firebird::IStatus*, USHORT, const MsgFormat::SafeArg& arg = MsgFormat::SafeArg());
 void	BURP_msg_partial(bool, USHORT, const MsgFormat::SafeArg& arg = MsgFormat::SafeArg());
 void	BURP_msg_put(bool, USHORT, const MsgFormat::SafeArg& arg);
 const int BURP_MSG_GET_SIZE = 128; // Use it for buffers passed to this function.
@@ -42,8 +42,8 @@ void	BURP_msg_get(USHORT, TEXT*, const MsgFormat::SafeArg& arg = MsgFormat::Safe
 void	BURP_output_version(void*, const TEXT*);
 void	BURP_print(bool err, USHORT, const MsgFormat::SafeArg& arg = MsgFormat::SafeArg());
 void	BURP_print(bool err, USHORT, const char* str);
-void	BURP_print_status(bool err, const ISC_STATUS* status);
-void	BURP_print_warning(const ISC_STATUS*);
+void	BURP_print_status(bool err, Firebird::IStatus* status);
+void	BURP_print_warning(Firebird::IStatus* status);
 void	BURP_verbose(USHORT, const MsgFormat::SafeArg& arg = MsgFormat::SafeArg());
 void	BURP_verbose(USHORT, const char* str);
 

--- a/src/burp/burp_proto.h
+++ b/src/burp/burp_proto.h
@@ -26,7 +26,10 @@
 
 #include "../common/ThreadData.h"
 #include "../common/classes/MsgPrint.h"
+#include "../common/classes/fb_string.h"
 #include "../common/UtilSvc.h"
+
+class BurpGlobals;
 
 int		BURP_main(Firebird::UtilSvc*);
 int		gbak(Firebird::UtilSvc*);
@@ -35,6 +38,7 @@ void	BURP_abort();
 void	BURP_error(USHORT, bool, const MsgFormat::SafeArg& arg = MsgFormat::SafeArg());
 void	BURP_error(USHORT, bool, const char* str);
 void	BURP_error_redirect(Firebird::IStatus*, USHORT, const MsgFormat::SafeArg& arg = MsgFormat::SafeArg());
+void	BURP_makeSymbol(BurpGlobals*, Firebird::string&);
 void	BURP_msg_partial(bool, USHORT, const MsgFormat::SafeArg& arg = MsgFormat::SafeArg());
 void	BURP_msg_put(bool, USHORT, const MsgFormat::SafeArg& arg);
 const int BURP_MSG_GET_SIZE = 128; // Use it for buffers passed to this function.

--- a/src/burp/canon_proto.h
+++ b/src/burp/canon_proto.h
@@ -24,8 +24,8 @@
 #ifndef BURP_CANON_PROTO_H
 #define BURP_CANON_PROTO_H
 
-ULONG	CAN_encode_decode (burp_rel*, lstring*, UCHAR*, int);
-ULONG	CAN_slice (lstring*, lstring*, int, /*USHORT,*/ UCHAR*);
+ULONG	CAN_encode_decode (burp_rel* relation, lstring* buffer, UCHAR* data, bool direction, bool useMissingOffset = false);
+ULONG	CAN_slice (lstring* buffer, lstring* slice, bool direction, UCHAR* sdl);
 
 #endif	// BURP_CANON_PROTO_H
 

--- a/src/burp/canonical.cpp
+++ b/src/burp/canonical.cpp
@@ -63,7 +63,7 @@ static xdr_t::xdr_ops burp_ops =
 const int increment = 1024;
 
 
-ULONG CAN_encode_decode(burp_rel* relation, lstring* buffer, UCHAR* data, bool_t direction)
+ULONG CAN_encode_decode(burp_rel* relation, lstring* buffer, UCHAR* data, bool direction, bool useMissingOffset)
 {
 /**************************************
  *
@@ -203,17 +203,21 @@ ULONG CAN_encode_decode(burp_rel* relation, lstring* buffer, UCHAR* data, bool_t
 	{
 		if (field->fld_flags & FLD_computed)
 			continue;
-		offset = FB_ALIGN(offset, sizeof(SSHORT));
-		UCHAR* p = data + offset;
+		UCHAR* p = data + field->fld_missing_offset;
+		if (!useMissingOffset)
+		{
+			offset = FB_ALIGN(offset, sizeof(SSHORT));
+			p = data + offset;
+			offset += sizeof(SSHORT);
+		}
 		if (!xdr_short(xdrs, (SSHORT*) p))
 			return FALSE;
-		offset += sizeof(SSHORT);
 	}
 	return (xdrs->x_private - xdrs->x_base);
 }
 
 
-ULONG CAN_slice(lstring* buffer, lstring* slice, bool_t direction, /*USHORT sdl_length,*/ UCHAR* sdl)
+ULONG CAN_slice(lstring* buffer, lstring* slice, bool direction, UCHAR* sdl)
 {
 /**************************************
  *

--- a/src/burp/misc.cpp
+++ b/src/burp/misc.cpp
@@ -119,12 +119,12 @@ void MISC_free_burp( void *free)
 // in a function visible to all gbak components.
 // Given a request, if it's non-zero (compiled), deallocate it but
 // without caring about a possible error.
-void MISC_release_request_silent(isc_req_handle& req_handle)
+void MISC_release_request_silent(Firebird::IRequest*& req_handle)
 {
 	if (req_handle)
 	{
-		ISC_STATUS_ARRAY req_status;
-		isc_release_request(req_status, &req_handle);
+		req_handle->release();
+		req_handle = nullptr;
 	}
 }
 

--- a/src/burp/misc_proto.h
+++ b/src/burp/misc_proto.h
@@ -26,7 +26,7 @@
 
 UCHAR*	MISC_alloc_burp(ULONG);
 void	MISC_free_burp(void*);
-void	MISC_release_request_silent(isc_req_handle& req_handle);
+void	MISC_release_request_silent(Firebird::IRequest*& req_handle);
 int		MISC_symbol_length(const TEXT*, ULONG);
 void	MISC_terminate(const TEXT*, TEXT*, ULONG, ULONG);
 

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -2842,6 +2842,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 
 	if (tdgbl->gbl_network_protocol == 0)
 	{
+//		bool sysDomFlag = true;		// Debug !!!!!!!!!!!!!!
 		bool sysDomFlag = false;
 
 		for (field = relation->rel_fields; field && !sysDomFlag; field = field->fld_next)
@@ -2886,8 +2887,10 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 
 	try
 	{
+		Firebird::string name(relation->rel_name);
+		BURP_makeSymbol(tdgbl, name);
 		Firebird::string sqlStatement;
-		sqlStatement.printf("insert into %s(", relation->rel_name);
+		sqlStatement.printf("insert into %s(", name.c_str());
 
 		Firebird::RefPtr<Firebird::IMetadataBuilder> builder(Firebird::REF_NO_INCR,
 			Firebird::MasterInterfacePtr()->getMetadataBuilder(fbStatus, count));
@@ -2944,7 +2947,9 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 			builder->setScale(&tdgbl->throwStatus, count, sqlScale);
 			builder->setCharSet(&tdgbl->throwStatus, count, characterSetId);
 
-			sqlStatement += field->fld_name;
+			name = field->fld_name;
+			BURP_makeSymbol(tdgbl, name);
+			sqlStatement += name;
 			sqlStatement += ", ";
 
 			field->fld_parameter = count++;
@@ -3006,7 +3011,6 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 			// Possible reason of fail - use of keywords as fields in old backup
 			// Try to roll back to use of old version (fieldnames independent)
 			BURP_print(false, 27/*, sqlStatement.c_str()*/);	// msg 27 isc_compile_request failed     !!!!!!!! new WARNING
-			BURP_print_warning(fbStatus);
 			return get_data_old(tdgbl, relation);
 		}
 

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -2721,7 +2721,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 	// Start by counting the interesting fields
 
 	RCRD_OFFSET offset = 0;
-	ULONG length = 0;
+	RCRD_LENGTH length = 0;
 	USHORT count = 0;
 
 	burp_fld* field;
@@ -2942,7 +2942,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 	{
 		if (get(tdgbl) != att_data_length)
 			BURP_error_redirect(NULL, 39); // msg 39 expected record length
-		USHORT len = (USHORT) get_int32(tdgbl);
+		RCRD_LENGTH len = get_int32(tdgbl);
 		if (!tdgbl->gbl_sw_transportable && len != length)
 		{
 #ifdef sparc

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -2002,24 +2002,24 @@ void get_blob(BurpGlobals* tdgbl, Firebird::IBatch* batch, const burp_fld* field
 
 	// Eat up blob segments
 
-	for (; segments > 0; --segments )
+	for (; segments > 0; --segments)
 	{
 		USHORT length = get(tdgbl);
 		length |= get(tdgbl) << 8;
 		if (length)
-		{
 			get_block(tdgbl, buffer, length);
-		}
 
 		if (first)
 			batch->addBlob(&status_vector, length, buffer, blob_id, sizeof(blob_desc), blob_desc);
 		else
 			batch->appendBlobData(&status_vector, length, buffer);
+
 		if (status_vector->hasData())
 		{
 			BURP_error_redirect(&status_vector, 38);		// !!!!!!!!! new message
 			// msg 38 isc_put_segment failed
 		}
+
 		first = false;
 	}
 }
@@ -2049,6 +2049,7 @@ void get_blob_old(BurpGlobals* tdgbl, const burp_fld* fields, UCHAR* record_buff
 	att_type	attribute;
 	scan_attr_t	scan_next_attr;
 	skip_init(&scan_next_attr);
+
 	while (skip_scan(&scan_next_attr), get_attribute(&attribute, tdgbl) != att_blob_data)
 	{
 		switch (attribute)
@@ -2842,7 +2843,8 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 	if (tdgbl->gbl_network_protocol == 0)
 	{
 		bool sysDomFlag = false;
-		for (field = relation->rel_fields; field && (!sysDomFlag); field = field->fld_next)
+
+		for (field = relation->rel_fields; field && !sysDomFlag; field = field->fld_next)
 		{
 			if (field->fld_flags & FLD_computed)
 				continue;
@@ -3011,7 +3013,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 		UCHAR* buffer = NULL;
 		Firebird::Array<UCHAR> requestBuffer;
 
-		BURP_verbose (124, relation->rel_name); // msg 124  restoring data for relation %s
+		BURP_verbose(124, relation->rel_name); // msg 124  restoring data for relation %s
 
 		lstring data;
 		data.lstr_allocated = 0;
@@ -3072,9 +3074,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 			if (tdgbl->gbl_sw_compress)
 				decompress (tdgbl, p, len);
 			else
-			{
 				get_block(tdgbl, p, len);
-			}
 
 			if (old_length)
 				realign (tdgbl, buffer, relation);
@@ -3082,7 +3082,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 			if (tdgbl->gbl_sw_transportable)
 			{
 				buffer = sql;
-				CAN_encode_decode (relation, &data, buffer, false, true);
+				CAN_encode_decode(relation, &data, buffer, false, true);
 			}
 
 			if ((++records % tdgbl->verboseInterval) == 0)
@@ -3133,8 +3133,10 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 			if (tdgbl->throwStatus->getState() & Firebird::IStatus::STATE_WARNINGS)
 				BURP_print_warning(&tdgbl->throwStatus);
 
-			for (unsigned pos = 0; pos = cs->findError(&tdgbl->throwStatus, pos),
-				pos != Firebird::IBatchCompletionState::NO_MORE_ERRORS; ++pos)
+			for (unsigned pos = 0;
+				 pos = cs->findError(&tdgbl->throwStatus, pos),
+					pos != Firebird::IBatchCompletionState::NO_MORE_ERRORS;
+				 ++pos)
 			{
 				Firebird::LocalStatus status_vector;
 				cs->getStatus(&tdgbl->throwStatus, &status_vector, pos);
@@ -3185,7 +3187,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 				break;
 		} // while (true)
 	}
-	catch(const Firebird::FbException& ex)
+	catch (const Firebird::FbException& ex)
 	{
 		BURP_print_status (true, ex.getStatus());
 		BURP_abort();
@@ -3193,7 +3195,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 
 	if (tdgbl->gbl_sw_incremental)
 	{
-		BURP_verbose (72, relation->rel_name);
+		BURP_verbose(72, relation->rel_name);
 		// msg 72  committing data for relation %s
 		COMMIT
 		// existing ON_ERROR continues past error, beck
@@ -3215,10 +3217,13 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 				{
 					case isc_sort_mem_err:
 					case isc_no_dup:
-						strcpy(index_name, (TEXT *)tdgbl->status_vector[3]);
+						strcpy(index_name, (TEXT*) tdgbl->status_vector[3]);
 						BURP_print_status(false, &tdgbl->status_vector);
+
 						FOR (REQUEST_HANDLE req_handle)
-						 IDX IN RDB$INDICES WITH IDX.RDB$INDEX_NAME EQ index_name
+							IDX IN RDB$INDICES
+							WITH IDX.RDB$INDEX_NAME EQ index_name
+						{
 							MODIFY IDX USING
 								IDX.RDB$INDEX_INACTIVE = TRUE;
 								BURP_print(false, 240, index_name);
@@ -3240,6 +3245,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 								BURP_print(false, 243, index_name);
 								// msg 243 ALTER INDEX \"%s\" ACTIVE
 							END_MODIFY;
+						}
 						END_FOR;
 						// commit one more time
 						COMMIT
@@ -3248,12 +3254,12 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 						END_ERROR
 						break;
 					default:
-						BURP_print (false, 69, relation->rel_name);
+						BURP_print(false, 69, relation->rel_name);
 						// msg 69 commit failed on relation %s
 						BURP_print_status (false, &tdgbl->status_vector);
 						ROLLBACK;
 						ON_ERROR
-							general_on_error ();
+							general_on_error();
 						END_ERROR;
 						break;
 				} // end of switch
@@ -3264,7 +3270,8 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 		if (gds_status->hasData())
 			EXEC SQL SET TRANSACTION;
 	}
-	BURP_verbose (107, SafeArg() << records);
+
+	BURP_verbose(107, SafeArg() << records);
 	// msg 107 %ld records restored
 
 	return record;
@@ -3291,6 +3298,7 @@ void fix_exception(BurpGlobals* tdgbl, const char* exc_name, scan_attr_t& scan_n
 			bad_attribute(scan_next_attr, failed_attrib, 287);
 			return;
 		}
+
 		const unsigned int remaining = FIELD_LIMIT - l2;
 
 		*msg_ptr++ = char(attribute); // (1)
@@ -3317,7 +3325,7 @@ rec_type get_data_old(BurpGlobals* tdgbl, burp_rel* relation)
 {
 /**************************************
  *
- *	g e t _ d a t a
+ *	g e t _ d a t a _ o l d
  *
  **************************************
  *
@@ -3541,7 +3549,9 @@ rec_type get_data_old(BurpGlobals* tdgbl, burp_rel* relation)
 	{
 		if (get(tdgbl) != att_data_length)
 			BURP_error_redirect(NULL, 39); // msg 39 expected record length
+
 		RCRD_LENGTH len = get_int32(tdgbl);
+
 		if (!tdgbl->gbl_sw_transportable && len != length)
 		{
 #ifdef sparc
@@ -3554,9 +3564,9 @@ rec_type get_data_old(BurpGlobals* tdgbl, burp_rel* relation)
 				// msg 40 wrong length record, expected %ld encountered %ld
 			}
 		}
-		if (!buffer) {
+
+		if (!buffer)
 			buffer = (SSHORT *) BURP_alloc (MAX (length, len));
-		}
 
 		UCHAR* p;
 		if (tdgbl->gbl_sw_transportable)
@@ -3574,26 +3584,26 @@ rec_type get_data_old(BurpGlobals* tdgbl, burp_rel* relation)
 						BURP_free (data.lstr_address);
 					data.lstr_address = BURP_alloc(data.lstr_allocated);
 				}
+
 				p = data.lstr_address;
 			}
 		}
 		else
 			p = reinterpret_cast<UCHAR*>(buffer);
+
 		if (get(tdgbl) != att_data_data)
 			BURP_error_redirect(NULL, 41); // msg 41 expected data attribute
 
 		if (tdgbl->gbl_sw_compress)
 			decompress (tdgbl, p, len);
 		else
-		{
 			get_block(tdgbl, p, len);
-		}
 
 		if (old_length)
 			realign (tdgbl, (UCHAR*) buffer, relation);
 
 		if (tdgbl->gbl_sw_transportable)
-			CAN_encode_decode (relation, &data, (UCHAR *)buffer, false);
+			CAN_encode_decode(relation, &data, (UCHAR *)buffer, false);
 
 		records++;
 
@@ -3617,9 +3627,9 @@ rec_type get_data_old(BurpGlobals* tdgbl, burp_rel* relation)
 		while (record == rec_blob || record == rec_array)
 		{
 			if (record == rec_blob)
-				get_blob_old (tdgbl, relation->rel_fields, (UCHAR *) buffer);
+				get_blob_old(tdgbl, relation->rel_fields, (UCHAR *) buffer);
 			else if (record == rec_array)
-				get_array (tdgbl, relation, (UCHAR *) buffer);
+				get_array(tdgbl, relation, (UCHAR *) buffer);
 			get_record(&record, tdgbl);
 		}
 
@@ -3636,6 +3646,7 @@ rec_type get_data_old(BurpGlobals* tdgbl, burp_rel* relation)
 		{
 			resync = true;
 			ISC_STATUS code = status_vector->getErrors()[1];
+
 			if (code == isc_not_valid)
 			{
 				if (tdgbl->gbl_sw_incremental)
@@ -3670,8 +3681,7 @@ rec_type get_data_old(BurpGlobals* tdgbl, burp_rel* relation)
 					BURP_print_status (false, &status_vector);
 				}
 				else
-					BURP_error_redirect(&status_vector, 48);
-					// msg 48 isc_send failed
+					BURP_error_redirect(&status_vector, 48);	// msg 48 isc_send failed
 			}
 
 			records--;
@@ -3686,6 +3696,7 @@ rec_type get_data_old(BurpGlobals* tdgbl, burp_rel* relation)
 		BURP_free (data.lstr_address);
 
 	request->release();
+
 	if (tdgbl->gbl_sw_incremental)
 	{
 		BURP_verbose (72, relation->rel_name);
@@ -3742,7 +3753,7 @@ rec_type get_data_old(BurpGlobals* tdgbl, burp_rel* relation)
 					default:
 						BURP_print (false, 69, relation->rel_name);
 						// msg 69 commit failed on relation %s
-						BURP_print_status (false, &tdgbl->status_vector);
+						BURP_print_status(false, &tdgbl->status_vector);
 						ROLLBACK;
 						ON_ERROR
 							general_on_error ();
@@ -9080,7 +9091,7 @@ bool get_trigger_old (BurpGlobals* tdgbl, burp_rel* relation)
 		ON_ERROR
 			BURP_print (false, 94, name);
 			// msg 94 trigger %s is invalid
-			BURP_print_status (false, &tdgbl->status_vector);
+			BURP_print_status(false, &tdgbl->status_vector);
 			ROLLBACK;
 			ON_ERROR
 				general_on_error ();
@@ -9396,7 +9407,7 @@ bool get_trigger(BurpGlobals* tdgbl)
 		ON_ERROR
 			BURP_print (false, 94, name);
 			// msg 94 trigger %s is invalid
-			BURP_print_status (false, &tdgbl->status_vector);
+			BURP_print_status(false, &tdgbl->status_vector);
 			ROLLBACK;
 			ON_ERROR
 				general_on_error ();
@@ -9492,7 +9503,7 @@ bool get_trigger_message(BurpGlobals* tdgbl)
 		ON_ERROR
 			BURP_print (false, 94, name);
 			// msg 94 trigger %s is invalid
-			BURP_print_status (false, &tdgbl->status_vector);
+			BURP_print_status(false, &tdgbl->status_vector);
 			ROLLBACK;
 			ON_ERROR
 				general_on_error ();
@@ -10355,7 +10366,7 @@ bool restore(BurpGlobals* tdgbl, const TEXT* file_name, const TEXT* database_nam
 	// msg 129 started transaction
 
 	att_type	attribute;
-	Firebird::IRequest* req_handle2 =nullptr;
+	Firebird::IRequest* req_handle2 = nullptr;
 	Firebird::IRequest* req_handle3 = nullptr;
 	Firebird::IRequest* req_handle4 = nullptr;
 	Firebird::IRequest* req_handle5 = nullptr;

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -776,6 +776,38 @@ void bad_attribute(scan_attr_t scan_next_attr, att_type bad_attr, USHORT type)
 	}
 }
 
+namespace {
+
+// Used to make sure that local calls to print stuff go to isqlGlob.Out
+// and not to stdout if IUtil::version gets called
+
+class ProtocolVersion :
+	public Firebird::AutoIface<Firebird::IVersionCallbackImpl<ProtocolVersion, Firebird::CheckStatusWrapper> >
+{
+public:
+	ProtocolVersion(unsigned* v)
+		: version(v)
+	{
+		*version = 0;
+	}
+
+	// IVersionCallback implementation
+	void callback(Firebird::CheckStatusWrapper*, const char* text)
+	{
+		const char* pm = ")/P";
+		const char* pp = strstr(text, pm);
+		if (pp)
+		{
+			pp += strlen(pm);
+			*version = atoi(pp);
+		}
+	}
+
+private:
+	unsigned* version;
+};
+
+} // anonymous namespace
 
 void create_database(BurpGlobals* tdgbl, const TEXT* file_name)
 {
@@ -964,7 +996,10 @@ void create_database(BurpGlobals* tdgbl, const TEXT* file_name)
 		// msg 33 failed to create database %s
 	}
 
-	tdgbl->gbl_network_protocol = DB->getRemoteProtocolVersion(&status_vector);
+	// get remote protocol version
+	ProtocolVersion pv(&tdgbl->gbl_network_protocol);
+	Firebird::UtilInterfacePtr()->getFbVersion(&status_vector, DB, &pv);
+
 	// treat errors as old provider missing new calls
 	if (status_vector->hasData())
 	{

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -2842,7 +2842,6 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 
 	if (tdgbl->gbl_network_protocol == 0)
 	{
-//		bool sysDomFlag = true;		// Debug !!!!!!!!!!!!!!
 		bool sysDomFlag = false;
 
 		for (field = relation->rel_fields; field && !sysDomFlag; field = field->fld_next)
@@ -3518,10 +3517,9 @@ rec_type get_data_old(BurpGlobals* tdgbl, burp_rel* relation)
 	fb_print_blr(blr_buffer, blr_length, NULL, NULL, 0);
 #endif
 
-	Firebird::IRequest* request = nullptr;
 	FbLocalStatus status_vector;
-
-	request = DB->compileRequest(&status_vector, blr_length, blr_buffer);
+	Firebird::RefPtr<Firebird::IRequest> request(Firebird::REF_NO_INCR,
+		DB->compileRequest(&status_vector, blr_length, blr_buffer));
 	if (status_vector->hasData())
 	{
 		fb_print_blr(blr_buffer, blr_length, NULL, NULL, 0);
@@ -3699,7 +3697,7 @@ rec_type get_data_old(BurpGlobals* tdgbl, burp_rel* relation)
 	if (data.lstr_address)
 		BURP_free (data.lstr_address);
 
-	request->release();
+	request = nullptr;
 
 	if (tdgbl->gbl_sw_incremental)
 	{
@@ -11012,7 +11010,6 @@ void store_blr_gen_id(BurpGlobals* tdgbl, const TEXT* gen_name, SINT64 value, SI
 	}
 
 
-	Firebird::IRequest* gen_id_reqh = nullptr;
 	UCHAR blr_buffer[100];  // enough to fit blr
 	UCHAR* blr = blr_buffer;
 
@@ -11069,7 +11066,8 @@ void store_blr_gen_id(BurpGlobals* tdgbl, const TEXT* gen_name, SINT64 value, SI
 	fb_assert(blr_length <= sizeof(blr_buffer));
 
 	FbLocalStatus status_vector;
-	gen_id_reqh = DB->compileRequest(&status_vector, blr_length, blr_buffer);
+	Firebird::RefPtr<Firebird::IRequest> gen_id_reqh(Firebird::REF_NO_INCR,
+		DB->compileRequest(&status_vector, blr_length, blr_buffer));
 	if (status_vector->hasData())
 	{
 		fb_print_blr(blr_buffer, blr_length, NULL, NULL, 0);
@@ -11085,8 +11083,6 @@ void store_blr_gen_id(BurpGlobals* tdgbl, const TEXT* gen_name, SINT64 value, SI
 
 	BURP_verbose (185, SafeArg() << gen_name << value);
 	// msg 185 restoring generator %s value: %ld
-
-	gen_id_reqh->release();
 }
 
 

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -49,7 +49,7 @@
 #include "../common/prett_proto.h"
 #endif
 #include "../common/classes/ClumpletWriter.h"
-#include "../common/classes/UserBlob.h"
+#include "../common/classes/BlobWrapper.h"
 #include "../common/classes/SafeArg.h"
 #include "../common/utils_proto.h"
 #include "memory_routines.h"
@@ -57,6 +57,7 @@
 #include "../auth/trusted/AuthSspi.h"
 
 using MsgFormat::SafeArg;
+using Firebird::FbLocalStatus;
 
 
 //  For service APIs the follow DB handle is a value stored
@@ -67,8 +68,11 @@ using MsgFormat::SafeArg;
 DATABASE DB = STATIC FILENAME "yachts.lnk";
 
 #define DB			tdgbl->db_handle
+#define fbTrans		tdgbl->tr_handle
 #define gds_trans	tdgbl->tr_handle
-#define isc_status	tdgbl->status_vector
+#define fbStatus	(&tdgbl->status_vector)
+#define isc_status	(&tdgbl->status_vector)
+#define gds_status	(&tdgbl->status_vector)
 
 
 namespace // unnamed, private
@@ -267,7 +271,9 @@ int RESTORE_restore (const TEXT* file_name, const TEXT* database_name)
  *	Recreate a database from a backup.
  *
  **************************************/
-	isc_req_handle  req_handle1 = 0, req_handle3 = 0, req_handle5 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
+	Firebird::IRequest* req_handle3 = nullptr;
+	Firebird::IRequest* req_handle5 = nullptr;
 	BASED_ON RDB$INDICES.RDB$INDEX_NAME index_name;
 
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
@@ -304,7 +310,7 @@ int RESTORE_restore (const TEXT* file_name, const TEXT* database_name)
 				case isc_sort_mem_err:
 				case isc_no_dup:
 					strcpy(index_name, (TEXT *)tdgbl->status_vector[3]);
-					BURP_print_status(false, tdgbl->status_vector);
+					BURP_print_status(false, &tdgbl->status_vector);
 					FOR (REQUEST_HANDLE req_handle3)
 						IDX IN RDB$INDICES WITH IDX.RDB$INDEX_NAME EQ index_name
 
@@ -353,7 +359,7 @@ int RESTORE_restore (const TEXT* file_name, const TEXT* database_name)
 		// Always try to activate deferred indices - it helps for some broken backups,
 		// and in normal cases doesn't take much time to look for such indices. AP-2008.
 		EXEC SQL SET TRANSACTION ISOLATION LEVEL READ COMMITTED NO_AUTO_UNDO;
-		if (gds_status[1])
+		if (gds_status->hasData())
 			EXEC SQL SET TRANSACTION;
 
 		// Activate first indexes that are not foreign keys
@@ -397,7 +403,7 @@ int RESTORE_restore (const TEXT* file_name, const TEXT* database_name)
 		END_ERROR;
 
 		EXEC SQL SET TRANSACTION ISOLATION LEVEL READ COMMITTED NO_AUTO_UNDO;
-		if (gds_status[1])
+		if (gds_status->hasData())
 			EXEC SQL SET TRANSACTION;
 
 		// Only activate Foreign keys that have been marked for deferred
@@ -423,9 +429,8 @@ int RESTORE_restore (const TEXT* file_name, const TEXT* database_name)
 			// activating and creating deferred index %s
 
 			bool fError = false;
-			isc_tr_handle activateIndexTran = 0;
-			ISC_STATUS_ARRAY local_status_vector;
-			ISC_STATUS* local_status = local_status_vector;
+			Firebird::ITransaction* activateIndexTran = nullptr;
+			FbLocalStatus local_status_vector;
 
 			START_TRANSACTION activateIndexTran;
 			FOR (TRANSACTION_HANDLE activateIndexTran REQUEST_HANDLE req_handle5)
@@ -436,7 +441,7 @@ int RESTORE_restore (const TEXT* file_name, const TEXT* database_name)
 			END_FOR;
 			ON_ERROR
 				fError = true;
-				memcpy(local_status, isc_status, sizeof (ISC_STATUS_ARRAY));
+				fb_utils::copyStatus(&local_status_vector, isc_status);
 			END_ERROR;
 			MISC_release_request_silent(req_handle5);
 
@@ -445,7 +450,7 @@ int RESTORE_restore (const TEXT* file_name, const TEXT* database_name)
 				COMMIT activateIndexTran;
 				ON_ERROR
 					fError = true;
-					memcpy(local_status, isc_status, sizeof (ISC_STATUS_ARRAY));
+					fb_utils::copyStatus(&local_status_vector, isc_status);
 				END_ERROR;
 			}
 			if (fError)
@@ -455,7 +460,7 @@ int RESTORE_restore (const TEXT* file_name, const TEXT* database_name)
 					general_on_error ();
 				END_ERROR;
 				BURP_print (false, 173, index_name);
-				BURP_print_status(false, local_status);
+				BURP_print_status(false, &local_status_vector);
 				tdgbl->flag_on_line = false;
 			}
 		END_FOR;
@@ -474,17 +479,17 @@ int RESTORE_restore (const TEXT* file_name, const TEXT* database_name)
 		BURP_verbose (68);
 		// msg 68 committing meta data
 		EXEC SQL COMMIT TRANSACTION tdgbl->global_trans;
-		if (gds_status[1])
+		if (gds_status->hasData())
 			general_on_error ();
 		// Check to see if there is a warning
-		if (gds_status[0] == isc_arg_gds && gds_status[1] == 0 && gds_status[2] != isc_arg_end)
+		if (gds_status->getState() && Firebird::IStatus::STATE_WARNINGS)
 		{
 			BURP_print_warning(gds_status);
 		}
 	}
 
 	EXEC SQL SET TRANSACTION ISOLATION LEVEL READ COMMITTED NO_AUTO_UNDO;
-	if (gds_status[1])
+	if (gds_status->hasData())
 		EXEC SQL SET TRANSACTION;
 
 	// AB: Recalculate RDB$DBKEY_LENGTH for VIEWS
@@ -532,7 +537,7 @@ int RESTORE_restore (const TEXT* file_name, const TEXT* database_name)
 	END_ERROR;
 
 	// Check to see if there is a warning
-	if (gds_status[0] == isc_arg_gds && gds_status[1] == 0 && gds_status[2] != isc_arg_end)
+	if (gds_status->getState() && Firebird::IStatus::STATE_WARNINGS)
 	{
 		BURP_print_warning(gds_status);
 	}
@@ -568,13 +573,12 @@ int RESTORE_restore (const TEXT* file_name, const TEXT* database_name)
 	// set forced writes to the value which was in the header
 	dpb.insertByte(isc_dpb_force_write, tdgbl->hdr_forced_writes ? 1 : 0);
 
-	FB_API_HANDLE db_handle = 0;
-	if (isc_attach_database(tdgbl->status_vector, 0, database_name, &db_handle,
-							dpb.getBufferLength(), reinterpret_cast<const SCHAR*>(dpb.getBuffer())))
-	{
+	Firebird::IAttachment* db_handle = Firebird::DispatcherPtr()->attachDatabase(&tdgbl->status_vector, database_name,
+		dpb.getBufferLength(), dpb.getBuffer());
+	if (tdgbl->status_vector->hasData())
 		general_on_error();
-	}
-	if (isc_detach_database (tdgbl->status_vector, &db_handle))
+	db_handle->detach(&tdgbl->status_vector);
+	if (tdgbl->status_vector->hasData())
 		general_on_error();
 
 	if (!tdgbl->flag_on_line)
@@ -597,12 +601,12 @@ int RESTORE_restore (const TEXT* file_name, const TEXT* database_name)
 
 		dpb.insertByte(isc_dpb_set_db_readonly, 1);
 
-		if (isc_attach_database(tdgbl->status_vector, 0, database_name, &db_handle,
-								dpb.getBufferLength(), reinterpret_cast<const SCHAR*>(dpb.getBuffer())))
-		{
+		db_handle = Firebird::DispatcherPtr()->attachDatabase(&tdgbl->status_vector, database_name,
+			dpb.getBufferLength(), dpb.getBuffer());
+		if (tdgbl->status_vector->hasData())
 			general_on_error();
-		}
-		if (isc_detach_database (tdgbl->status_vector, &db_handle))
+		db_handle->detach(&tdgbl->status_vector);
+		if (tdgbl->status_vector->hasData())
 			general_on_error();
 
 	}
@@ -652,7 +656,7 @@ void add_files(BurpGlobals* tdgbl, const char* file_name)
  *	addresses & commit this much.
  *
  **************************************/
-	isc_req_handle  req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	// store the RDB$FILES records
 
@@ -703,7 +707,7 @@ void add_files(BurpGlobals* tdgbl, const char* file_name)
 		ON_ERROR
 			BURP_print (false, 174);
 			// msg 174 cannot commit files
-			BURP_print_status (false, tdgbl->status_vector);
+			BURP_print_status (false, &tdgbl->status_vector);
 			ROLLBACK;
 			ON_ERROR
 				general_on_error ();
@@ -711,7 +715,7 @@ void add_files(BurpGlobals* tdgbl, const char* file_name)
 		END_ERROR;
 
 		EXEC SQL SET TRANSACTION NO_AUTO_UNDO;
-		if (gds_status[1])
+		if (gds_status->hasData())
 			EXEC SQL SET TRANSACTION;
 	}
 }
@@ -844,7 +848,7 @@ void create_database(BurpGlobals* tdgbl, const TEXT* file_name)
 	}
 
 	if (record != rec_database)
-		BURP_error_redirect (NULL, 32);
+		BURP_error_redirect(NULL, 32);
 		// msg 32 Expected database description record
 
 	if (tdgbl->gbl_sw_page_size)
@@ -936,7 +940,7 @@ void create_database(BurpGlobals* tdgbl, const TEXT* file_name)
 
 	dpb.insertByte(isc_dpb_no_db_triggers, 1);
 
-	ISC_STATUS_ARRAY status_vector;
+	FbLocalStatus status_vector;
 
 	if (tdgbl->gbl_sw_fix_fss_metadata)
 	{
@@ -944,11 +948,11 @@ void create_database(BurpGlobals* tdgbl, const TEXT* file_name)
 			fb_strlen(tdgbl->gbl_sw_fix_fss_metadata));
 	}
 
-	if (isc_create_database(status_vector, 0, file_name, &DB,
-							dpb.getBufferLength(), reinterpret_cast<const SCHAR*>(dpb.getBuffer()),
-							0))
+	DB = Firebird::DispatcherPtr()->createDatabase(&status_vector, file_name,
+							dpb.getBufferLength(), dpb.getBuffer());
+	if (status_vector->hasData())
 	{
-		BURP_error_redirect (status_vector, 33, SafeArg() << file_name);
+		BURP_error_redirect(&status_vector, 33, SafeArg() << file_name);
 		// msg 33 failed to create database %s
 	}
 
@@ -956,7 +960,8 @@ void create_database(BurpGlobals* tdgbl, const TEXT* file_name)
 	{
 		BURP_print(false, 139, file_name);
 		// msg 139 Version(s) for database "%s"
-		isc_version(&DB, BURP_output_version, (void*)"\t%s\n");
+		OutputVersion outputVersion("\t%s\n");
+		Firebird::UtilInterfacePtr()->getFbVersion(&status_vector, DB, &outputVersion);
 	}
 
 	BURP_verbose (74, SafeArg() << file_name << page_size);
@@ -1010,7 +1015,7 @@ void decompress(BurpGlobals* tdgbl, UCHAR* buffer, USHORT length)
 	}
 
 	if (p > end) {
-		BURP_error_redirect (NULL, 34); // msg 34 RESTORE: decompression length error
+		BURP_error_redirect(NULL, 34); // msg 34 RESTORE: decompression length error
 	}
 }
 
@@ -1080,7 +1085,7 @@ burp_rel* find_relation(BurpGlobals* tdgbl, const TEXT* name)
 		}
 	}
 
-	BURP_error_redirect (NULL, 35, SafeArg() << name);
+	BURP_error_redirect(NULL, 35, SafeArg() << name);
 	// msg 35 can't find relation %s
 
 	return NULL;
@@ -1109,9 +1114,9 @@ void fix_security_class_name(BurpGlobals* tdgbl, TEXT* sec_class, bool is_field)
 	if (tdgbl->runtimeODS < DB_VERSION_DDL11_2)
 		return;
 
-	ISC_STATUS_ARRAY status_vector;
+	FbLocalStatus status_vector;
 
-	isc_req_handle& handle = tdgbl->handles_fix_security_class_name_req_handle1;
+	Firebird::IRequest*& handle = tdgbl->handles_fix_security_class_name_req_handle1;
 
 	if (!handle)
 	{
@@ -1153,25 +1158,27 @@ void fix_security_class_name(BurpGlobals* tdgbl, TEXT* sec_class, bool is_field)
 		const USHORT blr_length = blr - blr_buffer;
 		fb_assert(blr_length <= sizeof(blr_buffer));
 
-		if (isc_compile_request(status_vector, &DB, &handle,
-							    blr_length, (const SCHAR*) blr_buffer))
+		handle = DB->compileRequest(&status_vector, blr_length, blr_buffer);
+		if (status_vector->hasData())
 		{
-			BURP_error_redirect(status_vector, 316);
+			BURP_error_redirect(&status_vector, 316);
 			// msg 316 Failed while fixing the security class name
 		}
 	}
 
-	if (isc_start_request(status_vector, &handle, &gds_trans, 0))
+	handle->start(&status_vector, gds_trans, 0);
+	if (status_vector->hasData())
 	{
-		BURP_error_redirect(status_vector, 316);
+		BURP_error_redirect(&status_vector, 316);
 		// msg 316 Failed while fixing the security class name
 	}
 
 	SINT64 id = 0;
 
-	if (isc_receive(status_vector, &handle, 0, sizeof(SINT64), &id, 0))
+	handle->receive(&status_vector, 0, 0, sizeof(SINT64), &id);
+	if (status_vector->hasData())
 	{
-		BURP_error_redirect(status_vector, 316);
+		BURP_error_redirect(&status_vector, 316);
 		// msg 316 Failed while fixing the security class name
 	}
 
@@ -1194,7 +1201,7 @@ void general_on_error()
  **************************************/
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
-	if (isc_status[1] == isc_malformed_string)
+	if (isc_status->getErrors()[1] == isc_malformed_string)
 	{
 		Firebird::Arg::StatusVector oldVector(isc_status);
 		Firebird::Arg::Gds newVector(isc_gbak_invalid_metadata);
@@ -1239,20 +1246,20 @@ bool get_acl(BurpGlobals* tdgbl, const TEXT* owner_nm, ISC_QUAD* blob_id, ISC_QU
 
 	// Open the blob and get it's vital statistics
 
-	ISC_STATUS_ARRAY status_vector;
-	UserBlob blob(status_vector);
+	FbLocalStatus status_vector;
+	BlobWrapper blob(&status_vector);
 
 	if (! blob.open(DB, gds_trans, *blob_id))
 	{
 		// msg 24 isc_open_blob failed
-		BURP_error_redirect (status_vector, 24);
+		BURP_error_redirect(&status_vector, 24);
 	}
 
 	UCHAR blob_info[32];
 	if (!blob.getInfo(sizeof(blr_items), blr_items, sizeof(blob_info), blob_info))
 	{
 		// msg 20 isc_blob_info failed
-		BURP_error_redirect (status_vector, 20);
+		BURP_error_redirect(&status_vector, 20);
 	}
 
 	ULONG length = 0;
@@ -1296,7 +1303,7 @@ bool get_acl(BurpGlobals* tdgbl, const TEXT* owner_nm, ISC_QUAD* blob_id, ISC_QU
 			// CVC: do you return, without closing the blob, dear function???
 			if (!blob.close())
 			{
-				BURP_error_redirect (status_vector, 23);
+				BURP_error_redirect(&status_vector, 23);
 				// msg 23 isc_close_blob failed
 			}
 			return false;
@@ -1307,7 +1314,7 @@ bool get_acl(BurpGlobals* tdgbl, const TEXT* owner_nm, ISC_QUAD* blob_id, ISC_QU
 	{
 		if (!blob.close())
 		{
-			BURP_error_redirect (status_vector, 23);
+			BURP_error_redirect(&status_vector, 23);
 			// msg 23 isc_close_blob failed
 		}
 		return false;
@@ -1329,7 +1336,7 @@ bool get_acl(BurpGlobals* tdgbl, const TEXT* owner_nm, ISC_QUAD* blob_id, ISC_QU
 	if (!blob.getData(length, buffer, return_length))
 	{
 		// msg 22 gds_$get_segment failed
-		BURP_error_redirect (status_vector, 22);
+		BURP_error_redirect(&status_vector, 22);
 	}
 	// protect ourselves
 	length = return_length;
@@ -1337,7 +1344,7 @@ bool get_acl(BurpGlobals* tdgbl, const TEXT* owner_nm, ISC_QUAD* blob_id, ISC_QU
 	if (!blob.close())
 	{
 		// msg 23 isc_close_blob failed
-		BURP_error_redirect (status_vector, 23);
+		BURP_error_redirect(&status_vector, 23);
 	}
 
 	const UCHAR* from = buffer + 3; // skip ACL_version, ACL_id_list, and id_person
@@ -1378,19 +1385,19 @@ bool get_acl(BurpGlobals* tdgbl, const TEXT* owner_nm, ISC_QUAD* blob_id, ISC_QU
 	if (!blob.create(DB, gds_trans, *new_blob_id))
 	{
 		// msg 37 isc_create_blob failed
-		BURP_error_redirect (status_vector, 37);
+		BURP_error_redirect(&status_vector, 37);
 	}
 
 	if (!blob.putData(new_len, new_buffer))
 	{
 		// msg 38 isc_put_segment failed
-		BURP_error_redirect (status_vector, 38);
+		BURP_error_redirect(&status_vector, 38);
 	}
 
 	if (!blob.close())
 	{
 		// msg 23 isc_close_blob failed
-		BURP_error_redirect (status_vector, 23);
+		BURP_error_redirect(&status_vector, 23);
 	}
 
 	return true;
@@ -1410,7 +1417,7 @@ void get_array(BurpGlobals* tdgbl, burp_rel* relation, UCHAR* record_buffer)
  *
  **************************************/
 	burp_fld*		field = NULL;
-	ISC_STATUS_ARRAY	status_vector;
+	FbLocalStatus	status_vector;
 	USHORT		count, field_number, field_length = 0;
 	UCHAR*		buffer = NULL;
 	UCHAR*		p = NULL;
@@ -1442,7 +1449,7 @@ void get_array(BurpGlobals* tdgbl, burp_rel* relation, UCHAR* record_buffer)
 					break;
 			}
 			if (!field) {
-				BURP_error_redirect (NULL, 36);	// msg 36 Can't find field for blob
+				BURP_error_redirect(NULL, 36);	// msg 36 Can't find field for blob
 			}
 
 			field_length = field->fld_length;
@@ -1727,7 +1734,7 @@ void get_array(BurpGlobals* tdgbl, burp_rel* relation, UCHAR* record_buffer)
 					if (get_attribute(&attribute, tdgbl) != att_xdr_array)
 					{
 						// msg 55 Expected XDR record length
-						BURP_error_redirect (NULL, 55);
+						BURP_error_redirect(NULL, 55);
 					}
 					else
 					{
@@ -1755,15 +1762,14 @@ void get_array(BurpGlobals* tdgbl, burp_rel* relation, UCHAR* record_buffer)
 					CAN_slice (&xdr_buffer, &xdr_slice, FALSE, /*blr_length,*/ blr_buffer);
 			}
 
-			if (isc_put_slice(status_vector, &DB, &gds_trans,
-							  blob_id, blr_length, reinterpret_cast<const char*>(blr_buffer),
-							  0,	// param length for subset of an array handling
-							  NULL,	// param for subset of an array handling
-							  elements_written * field->fld_length, buffer + data_at))
+			DB->putSlice(&status_vector, gds_trans, blob_id, blr_length, blr_buffer,
+						 0, NULL,	// parameters for subset of an array handling
+						 elements_written * field->fld_length, buffer + data_at);
+			if (status_vector->hasData())
 			{
 				BURP_print (false, 81, field->fld_name);
 				// msg 81 error accessing blob field %s -- continuing
-				BURP_print_status (true, status_vector);
+				BURP_print_status (true, &status_vector);
 #ifdef DEBUG
 				PRETTY_print_sdl (blr_buffer, NULL, NULL, 0);
 #endif
@@ -1853,7 +1859,7 @@ void get_array(BurpGlobals* tdgbl, burp_rel* relation, UCHAR* record_buffer)
 		{
 			if (get_attribute(&attribute, tdgbl) != att_xdr_array)
 			{
-				BURP_error_redirect (NULL, 55);
+				BURP_error_redirect(NULL, 55);
 				// msg 55 Expected XDR record length
 			}
 			else
@@ -1882,16 +1888,14 @@ void get_array(BurpGlobals* tdgbl, burp_rel* relation, UCHAR* record_buffer)
 			CAN_slice (&xdr_buffer, &xdr_slice, FALSE, /*blr_length,*/ blr_buffer);
 
 
-		if (isc_put_slice(status_vector, &DB, &gds_trans,
-						  blob_id, blr_length,
-						  reinterpret_cast<const char*>(blr_buffer),
-						  0,	  // param length for subset of an array handling
-						  NULL,  // param for subset of an array handling
-						  return_length, buffer))
+		DB->putSlice(&status_vector, gds_trans, blob_id, blr_length, blr_buffer,
+					 0, NULL,	// parameters for subset of an array handling
+					 return_length, buffer);
+		if (status_vector->hasData())
 		{
 			BURP_print (false, 81, field->fld_name);
 			// msg 81 error accessing blob field %s -- continuing
-			BURP_print_status (false, status_vector);
+			BURP_print_status (false, &status_vector);
 #ifdef DEBUG
 			PRETTY_print_sdl (blr_buffer, NULL, NULL, 0);
 #endif
@@ -1965,20 +1969,20 @@ void get_blob(BurpGlobals* tdgbl, const burp_fld* fields, UCHAR* record_buffer)
 
 	if (!field)
 	{
-		BURP_error_redirect (NULL, 36);
+		BURP_error_redirect(NULL, 36);
 		// msg 36 Can't find field for blob
 	}
 
 	// Create new blob
 
 	ISC_QUAD* blob_id = (ISC_QUAD*) ((UCHAR*) record_buffer + field->fld_offset);
-	ISC_STATUS_ARRAY status_vector;
-	UserBlob blob(status_vector);
+	FbLocalStatus status_vector;
+	BlobWrapper blob(&status_vector);
 	const UCHAR blob_desc[] = {isc_bpb_version1, isc_bpb_type, 1, blob_type};
 
 	if (!blob.create(DB, gds_trans, *blob_id, sizeof(blob_desc), blob_desc))
 	{
-		BURP_error_redirect (status_vector, 37);
+		BURP_error_redirect(&status_vector, 37);
 		// msg 37 isc_create_blob failed
 	}
 
@@ -1998,13 +2002,13 @@ void get_blob(BurpGlobals* tdgbl, const burp_fld* fields, UCHAR* record_buffer)
 		}
 		if (!blob.putSegment(length, buffer))
 		{
-			BURP_error_redirect (status_vector, 38);
+			BURP_error_redirect(&status_vector, 38);
 			// msg 38 isc_put_segment failed
 		}
 	}
 
 	if (!blob.close())
-		BURP_error_redirect (status_vector, 23);
+		BURP_error_redirect(&status_vector, 23);
 		// msg 23 isc_close_blob failed
 }
 
@@ -2027,17 +2031,13 @@ void get_blr_blob(BurpGlobals* tdgbl, ISC_QUAD& blob_id, bool glb_trans)
 
 	// Create new blob
 
-	isc_tr_handle local_trans;
-	if (glb_trans && tdgbl->global_trans)
-		local_trans = tdgbl->global_trans;
-	else
-		local_trans = gds_trans;
+	Firebird::ITransaction* local_trans = (glb_trans && tdgbl->global_trans) ? tdgbl->global_trans : gds_trans;
 
-	ISC_STATUS_ARRAY	status_vector;
-	UserBlob blob(status_vector);
+	FbLocalStatus	status_vector;
+	BlobWrapper blob(&status_vector);
 	if (!blob.create(DB, local_trans, blob_id))
 	{
-		BURP_error_redirect (status_vector, 37);
+		BURP_error_redirect(&status_vector, 37);
 		// msg 37 isc_create_blob failed
 	}
 
@@ -2057,12 +2057,12 @@ void get_blr_blob(BurpGlobals* tdgbl, ISC_QUAD& blob_id, bool glb_trans)
 
 	if (!blob.putData(length, buffer))
 	{
-		BURP_error_redirect (status_vector, 38);
+		BURP_error_redirect(&status_vector, 38);
 		// msg 38 isc_put_segment failed
 	}
 
 	if (!blob.close())
-		BURP_error_redirect (status_vector, 23);
+		BURP_error_redirect(&status_vector, 23);
 		// msg 23 isc_close_blob failed
 }
 
@@ -2710,7 +2710,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
  *	Write data records for a relation.
  *
  **************************************/
-	isc_req_handle  req_handle = 0;
+	Firebird::IRequest* req_handle = 0;
 	BASED_ON RDB$INDICES.RDB$INDEX_NAME index_name;
 
 	// If we're only doing meta-data, ignore data records
@@ -2907,18 +2907,18 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 	fb_print_blr(blr_buffer, blr_length, NULL, NULL, 0);
 #endif
 
-	FB_API_HANDLE request = 0;
-	ISC_STATUS_ARRAY status_vector;
+	Firebird::IRequest* request = nullptr;
+	FbLocalStatus status_vector;
 
-	if (isc_compile_request (status_vector, &DB, &request,
-							 blr_length, reinterpret_cast<const char*>(blr_buffer)))
+	request = DB->compileRequest(&status_vector, blr_length, blr_buffer);
+	if (status_vector->hasData())
 	{
 		fb_print_blr(blr_buffer, blr_length, NULL, NULL, 0);
 		if (!tdgbl->gbl_sw_incremental)
-			BURP_error_redirect (status_vector, 27); // msg 27 isc_compile_request failed
+			BURP_error_redirect(&status_vector, 27); // msg 27 isc_compile_request failed
 		else
 		{
-			BURP_print_status (false, status_vector);
+			BURP_print_status (false, &status_vector);
 			BURP_free (blr_buffer);
 			return ignore_data(tdgbl, relation);
 		}
@@ -2941,7 +2941,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 	while (true)
 	{
 		if (get(tdgbl) != att_data_length)
-			BURP_error_redirect (NULL, 39); // msg 39 expected record length
+			BURP_error_redirect(NULL, 39); // msg 39 expected record length
 		USHORT len = (USHORT) get_int32(tdgbl);
 		if (!tdgbl->gbl_sw_transportable && len != length)
 		{
@@ -2963,7 +2963,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 		if (tdgbl->gbl_sw_transportable)
 		{
 			if (get(tdgbl) != att_xdr_length)
-				BURP_error_redirect (NULL, 55);
+				BURP_error_redirect(NULL, 55);
 				// msg 55 Expected XDR record length
 			else
 			{
@@ -2981,7 +2981,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 		else
 			p = reinterpret_cast<UCHAR*>(buffer);
 		if (get(tdgbl) != att_data_data)
-			BURP_error_redirect (NULL, 41); // msg 41 expected data attribute
+			BURP_error_redirect(NULL, 41); // msg 41 expected data attribute
 
 		if (tdgbl->gbl_sw_compress)
 			decompress (tdgbl, p, len);
@@ -3024,43 +3024,43 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 			get_record(&record, tdgbl);
 		}
 
-		ISC_STATUS s;
-
 		// ASF: Preferable we should call isc_start_and_send only when records == 1, but this leaks
 		// memory when there are blobs and arrays fields - CORE-3802.
 		if (resync || records % 1000 == 1)
-			s = isc_start_and_send(status_vector, &request, &gds_trans, 0, (USHORT) length, buffer, 0);
+			request->startAndSend(&status_vector, gds_trans, 0, 0, length, buffer);
 		else
-			s = isc_send(status_vector, &request, 0, (USHORT) length, buffer, 0);
+			request->send(&status_vector, 0, 0, length, buffer);
 
-		resync = (s != 0);
+		resync = false;
 
-		if (s)
+		if (status_vector->hasData())
 		{
-			if (status_vector[1] == isc_not_valid)
+			resync = true;
+			ISC_STATUS code = status_vector->getErrors()[1];
+			if (code == isc_not_valid)
 			{
 				if (tdgbl->gbl_sw_incremental)
 				{
 					BURP_print (false, 138, relation->rel_name);
 					// msg 138 validation error on field in relation %s
-					BURP_print_status (false, status_vector);
+					BURP_print_status (false, &status_vector);
 				}
 				else
-					BURP_error_redirect (status_vector, 47);
+					BURP_error_redirect(&status_vector, 47);
 					// msg 47 warning -- record could not be restored
 			}
-			else if (status_vector[1] == isc_malformed_string)
+			else if (code == isc_malformed_string)
 			{
 				if (tdgbl->gbl_sw_incremental)
 				{
 					// msg 114 restore failed for record in relation %s
 					BURP_print(false, 114, relation->rel_name);
 
-					BURP_print_status(false, status_vector);
+					BURP_print_status(false, &status_vector);
 					BURP_print(false, 342);	// isc_gbak_invalid_data
 				}
 				else
-					BURP_error_redirect(status_vector, 342);	// isc_gbak_invalid_data
+					BURP_error_redirect(&status_vector, 342);	// isc_gbak_invalid_data
 			}
 			else
 			{
@@ -3068,10 +3068,10 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 				{
 					BURP_print (false, 114, relation->rel_name);
 					// msg 114 restore failed for record in relation %s
-					BURP_print_status (false, status_vector);
+					BURP_print_status (false, &status_vector);
 				}
 				else
-					BURP_error_redirect (status_vector, 48);
+					BURP_error_redirect(&status_vector, 48);
 					// msg 48 isc_send failed
 			}
 
@@ -3086,7 +3086,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 	if (data.lstr_address)
 		BURP_free (data.lstr_address);
 
-	isc_release_request(status_vector, &request);
+	request->release();
 	if (tdgbl->gbl_sw_incremental)
 	{
 		BURP_verbose (72, relation->rel_name);
@@ -3109,7 +3109,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 					case isc_sort_mem_err:
 					case isc_no_dup:
 						strcpy(index_name, (TEXT *)tdgbl->status_vector[3]);
-						BURP_print_status(false, tdgbl->status_vector);
+						BURP_print_status(false, &tdgbl->status_vector);
 						FOR (REQUEST_HANDLE req_handle)
 						 IDX IN RDB$INDICES WITH IDX.RDB$INDEX_NAME EQ index_name
 							MODIFY IDX USING
@@ -3143,7 +3143,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 					default:
 						BURP_print (false, 69, relation->rel_name);
 						// msg 69 commit failed on relation %s
-						BURP_print_status (false, tdgbl->status_vector);
+						BURP_print_status (false, &tdgbl->status_vector);
 						ROLLBACK;
 						ON_ERROR
 							general_on_error ();
@@ -3154,7 +3154,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 		END_ERROR;
 
 		EXEC SQL SET TRANSACTION NO_AUTO_UNDO;
-		if (gds_status[1])
+		if (gds_status->hasData())
 			EXEC SQL SET TRANSACTION;
 	}
 	BURP_verbose (107, SafeArg() << records);
@@ -3544,7 +3544,7 @@ burp_fld* get_field(BurpGlobals* tdgbl, burp_rel* relation)
 
 	// If it is a view and there is a global transaction then use it
 	bool global_tr = false;
-	isc_tr_handle local_trans;
+	Firebird::ITransaction* local_trans;
 	if ((relation->rel_flags & REL_view) && tdgbl->global_trans)
 	{
 		local_trans = tdgbl->global_trans;
@@ -4385,7 +4385,7 @@ bool get_function(BurpGlobals* tdgbl)
 			strcpy(function_name, X.RDB$FUNCTION_NAME);
 		END_STORE;
 		ON_ERROR
-			if (gds_status[1] != isc_no_dup)
+			if (gds_status->getErrors()[1] != isc_no_dup)
 				general_on_error ();
 			else
 				existFlag = true;
@@ -4512,7 +4512,7 @@ bool get_function(BurpGlobals* tdgbl)
 
 		END_STORE;
 		ON_ERROR
-			if (gds_status[1] != isc_no_dup)
+			if (gds_status->getErrors()[1] != isc_no_dup)
 				general_on_error ();
 			else
 				existFlag = true;
@@ -6461,22 +6461,22 @@ void get_misc_blob(BurpGlobals* tdgbl, ISC_QUAD& blob_id, bool glb_trans)
  *	shiney, new blob.
  *
  **************************************/
-	ISC_STATUS_ARRAY	status_vector;
+	FbLocalStatus	status_vector;
 
 	const FB_SIZE_T length = get_int32(tdgbl);
 
 	// Create new blob
 
-	isc_tr_handle	local_trans;
+	Firebird::ITransaction* local_trans;
 	if (glb_trans && tdgbl->global_trans)
 		local_trans = tdgbl->global_trans;
 	else
 		local_trans = gds_trans;
 
-	UserBlob blob(status_vector);
+	BlobWrapper blob(&status_vector);
 	if (!blob.create(DB, local_trans, blob_id))
 	{
-		BURP_error_redirect (status_vector, 37);
+		BURP_error_redirect(&status_vector, 37);
 		// msg 37 isc_create_blob failed
 	}
 
@@ -6491,12 +6491,12 @@ void get_misc_blob(BurpGlobals* tdgbl, ISC_QUAD& blob_id, bool glb_trans)
 
 	if (!blob.putData(length, buffer))
 	{
-		BURP_error_redirect (status_vector, 38);
+		BURP_error_redirect(&status_vector, 38);
 		// msg 38 isc_put_segment failed
 	}
 
 	if (!blob.close())
-		BURP_error_redirect (status_vector, 23);
+		BURP_error_redirect(&status_vector, 23);
 		// msg 23 isc_close_blob failed
 }
 
@@ -6566,7 +6566,7 @@ bool get_package(BurpGlobals* tdgbl)
 	if (tdgbl->RESTORE_format < 10)
 		return false;
 
-	isc_tr_handle local_trans = tdgbl->global_trans ? tdgbl->global_trans : gds_trans;
+	Firebird::ITransaction* local_trans = tdgbl->global_trans ? tdgbl->global_trans : gds_trans;
 
 	burp_pkg* package = (burp_pkg*) BURP_alloc_zero(sizeof(burp_pkg));
 	package->pkg_next = tdgbl->packages;
@@ -6673,7 +6673,7 @@ bool get_procedure(BurpGlobals* tdgbl)
 	SSHORT		l;
 	scan_attr_t		scan_next_attr;
 
-	isc_tr_handle local_trans = tdgbl->global_trans ? tdgbl->global_trans : gds_trans;
+	Firebird::ITransaction* local_trans = tdgbl->global_trans ? tdgbl->global_trans : gds_trans;
 
 	burp_prc* procedure = (burp_prc*) BURP_alloc_zero (sizeof(burp_prc));
 	procedure->prc_next = tdgbl->procedures;
@@ -7017,7 +7017,7 @@ bool get_procedure_prm (BurpGlobals* tdgbl, GDS_NAME package_name, GDS_NAME proc
 	TEXT		temp[GDS_NAME_LEN];
 	scan_attr_t		scan_next_attr;
 
-	isc_tr_handle local_trans = tdgbl->global_trans ? tdgbl->global_trans : gds_trans;
+	Firebird::ITransaction* local_trans = tdgbl->global_trans ? tdgbl->global_trans : gds_trans;
 
 	if (tdgbl->runtimeODS >= DB_VERSION_DDL11_1)
 	{
@@ -7337,8 +7337,8 @@ bool get_relation(BurpGlobals* tdgbl)
  **************************************/
 	SLONG		rel_flags = 0, sys_flag = fb_sysflag_user, type = rel_persistent;
 	bool		rel_flags_null = true;
-	ISC_QUAD	view_blr = isc_blob_null, view_src = isc_blob_null,
-				rel_desc = isc_blob_null, ext_desc = isc_blob_null;
+	ISC_QUAD	view_blr = fbBlobNull, view_src = fbBlobNull,
+				rel_desc = fbBlobNull, ext_desc = fbBlobNull;
 	bool		view_blr_null = true, view_src_null = true, rel_desc_null = true,
 				ext_desc_null = true;
 	FB_BOOLEAN	sql_security = FB_FALSE;
@@ -7366,7 +7366,7 @@ bool get_relation(BurpGlobals* tdgbl)
 		END_ERROR;
 
 		EXEC SQL SET TRANSACTION NO_AUTO_UNDO;
-		if (gds_status[1])
+		if (gds_status->hasData())
 			EXEC SQL SET TRANSACTION;
 	}
 
@@ -7490,7 +7490,7 @@ bool get_relation(BurpGlobals* tdgbl)
 	}
 
 	// If this is a view and there is a global transaction then use it
-	isc_tr_handle local_trans;
+	Firebird::ITransaction* local_trans;
 	if (view_blr_null || !tdgbl->global_trans)
 		local_trans = gds_trans;
 	else
@@ -7585,14 +7585,14 @@ bool get_relation(BurpGlobals* tdgbl)
 				ON_ERROR
 					BURP_print (false, 171, relation->rel_name);
 					// msg 171: error committing metadata for relation %s
-					BURP_print_status (false, tdgbl->status_vector);
+					BURP_print_status (false, &tdgbl->status_vector);
 					ROLLBACK;
 					ON_ERROR
 						general_on_error ();
 					END_ERROR;
 				END_ERROR;
 				EXEC SQL SET TRANSACTION NO_AUTO_UNDO;
-				if (gds_status[1])
+				if (gds_status->hasData())
 					EXEC SQL SET TRANSACTION;
 			}
 			return true;
@@ -7629,7 +7629,7 @@ bool get_relation(BurpGlobals* tdgbl)
 	END_ERROR;
 
 	EXEC SQL SET TRANSACTION NO_AUTO_UNDO;
-	if (gds_status[1])
+	if (gds_status->hasData())
 		EXEC SQL SET TRANSACTION;
 
 	get_data(tdgbl, relation, tdgbl->skipRelation(rel_name));
@@ -7748,7 +7748,7 @@ bool get_relation_data(BurpGlobals* tdgbl)
 	}
 
 	if (!relation)
-		BURP_error_redirect (NULL, 49);
+		BURP_error_redirect(NULL, 49);
 	// msg 49 no relation name for data
 
 	// Eat up misc. records
@@ -8147,10 +8147,14 @@ bool get_mapping(BurpGlobals* tdgbl)
 			"UPDATE OR INSERT INTO RDB$ROLES(RDB$ROLE_NAME, RDB$SYSTEM_FLAG) VALUES",
 			ADMIN_ROLE, 6,		// constant 6 turns on auto admin mapping in FB 2.5
 			"MATCHING (RDB$ROLE_NAME)");
-		isc_dsql_execute_immediate(tdgbl->status_vector, &tdgbl->db_handle, &tdgbl->tr_handle,
-								   sql.length(), sql.c_str(), 1, NULL);
-		if (tdgbl->status_vector[1])
+		try
 		{
+			BurpSql mapRole(tdgbl, sql.c_str());
+			mapRole.execute(tdgbl->tr_handle);
+		}
+		catch (const Firebird::FbException& ex)
+		{
+			fb_utils::copyStatus(&tdgbl->status_vector, ex.getStatus());
 			general_on_error ();
 		}
 	}
@@ -8280,14 +8284,14 @@ void get_source_blob(BurpGlobals* tdgbl, ISC_QUAD& blob_id, bool glb_trans)
  *	input file to nice, shiney, new blob.
  *
  **************************************/
-	ISC_STATUS_ARRAY	status_vector;
+	FbLocalStatus	status_vector;
 
 	SLONG length = get_int32(tdgbl);
 
 	// Create new blob
 
-	UserBlob blob(status_vector);
-	isc_tr_handle	local_trans;
+	BlobWrapper blob(&status_vector);
+	Firebird::ITransaction* local_trans;
 	if (glb_trans && tdgbl->global_trans)
 		local_trans = tdgbl->global_trans;
 	else
@@ -8325,7 +8329,7 @@ void get_source_blob(BurpGlobals* tdgbl, ISC_QUAD& blob_id, bool glb_trans)
 
 	if (!ok)
 	{
-		BURP_error_redirect (status_vector, 37);
+		BURP_error_redirect(&status_vector, 37);
 		// msg 37 isc_create_blob failed
 	}
 
@@ -8344,13 +8348,13 @@ void get_source_blob(BurpGlobals* tdgbl, ISC_QUAD& blob_id, bool glb_trans)
 
 		if (!blob.putSegment(seg_len, buffer))
 		{
-			BURP_error_redirect (status_vector, 38);
+			BURP_error_redirect(&status_vector, 38);
 			// msg 38 isc_put_segment failed
 		}
 	}
 
 	if (!blob.close())
-		BURP_error_redirect (status_vector, 23);
+		BURP_error_redirect(&status_vector, 23);
 		// msg 23 isc_close_blob failed
 }
 
@@ -8369,7 +8373,7 @@ USHORT get_text(BurpGlobals* tdgbl, TEXT* text, ULONG length)
 	const ULONG l = get(tdgbl);
 
 	if (length <= l)
-		BURP_error_redirect (NULL, 46);
+		BURP_error_redirect(NULL, 46);
 		// msg 46 string truncated
 
 	if (l)
@@ -8398,7 +8402,7 @@ USHORT get_text2(BurpGlobals* tdgbl, TEXT* text, ULONG length)
 
 	if (length <= len)
 	{
-		BURP_error_redirect (NULL, 46);
+		BURP_error_redirect(NULL, 46);
 		// msg 46 string truncated
 	}
 
@@ -8518,14 +8522,14 @@ bool get_trigger_old (BurpGlobals* tdgbl, burp_rel* relation)
 		ON_ERROR
 			BURP_print (false, 94, name);
 			// msg 94 trigger %s is invalid
-			BURP_print_status (false, tdgbl->status_vector);
+			BURP_print_status (false, &tdgbl->status_vector);
 			ROLLBACK;
 			ON_ERROR
 				general_on_error ();
 			END_ERROR;
 		END_ERROR;
 		EXEC SQL SET TRANSACTION NO_AUTO_UNDO;
-		if (gds_status[1])
+		if (gds_status->hasData())
 			EXEC SQL SET TRANSACTION;
 	}
 
@@ -8548,7 +8552,7 @@ bool get_trigger(BurpGlobals* tdgbl)
 	BASED_ON RDB$TRIGGERS.RDB$TRIGGER_NAME name;
 	scan_attr_t		scan_next_attr;
 
-	isc_tr_handle local_trans = tdgbl->global_trans ? tdgbl->global_trans : gds_trans;
+	Firebird::ITransaction* local_trans = tdgbl->global_trans ? tdgbl->global_trans : gds_trans;
 
 	if (tdgbl->runtimeODS >= DB_VERSION_DDL11_1)
 	{
@@ -8834,14 +8838,14 @@ bool get_trigger(BurpGlobals* tdgbl)
 		ON_ERROR
 			BURP_print (false, 94, name);
 			// msg 94 trigger %s is invalid
-			BURP_print_status (false, tdgbl->status_vector);
+			BURP_print_status (false, &tdgbl->status_vector);
 			ROLLBACK;
 			ON_ERROR
 				general_on_error ();
 			END_ERROR;
 		END_ERROR;
 		EXEC SQL SET TRANSACTION NO_AUTO_UNDO;
-		if (gds_status[1])
+		if (gds_status->hasData())
 			EXEC SQL SET TRANSACTION;
 	}
 
@@ -8910,7 +8914,7 @@ bool get_trigger_message(BurpGlobals* tdgbl)
 	if (tdgbl->runtimeODS < DB_VERSION_DDL11)
 		message[78] = 0;
 
-	isc_tr_handle local_trans = tdgbl->global_trans ? tdgbl->global_trans : gds_trans;
+	Firebird::ITransaction* local_trans = tdgbl->global_trans ? tdgbl->global_trans : gds_trans;
 
 	STORE (TRANSACTION_HANDLE local_trans
 			REQUEST_HANDLE tdgbl->handles_get_trigger_message_req_handle2)
@@ -8930,14 +8934,14 @@ bool get_trigger_message(BurpGlobals* tdgbl)
 		ON_ERROR
 			BURP_print (false, 94, name);
 			// msg 94 trigger %s is invalid
-			BURP_print_status (false, tdgbl->status_vector);
+			BURP_print_status (false, &tdgbl->status_vector);
 			ROLLBACK;
 			ON_ERROR
 				general_on_error ();
 			END_ERROR;
 		END_ERROR;
 		EXEC SQL SET TRANSACTION NO_AUTO_UNDO;
-		if (gds_status[1])
+		if (gds_status->hasData())
 			EXEC SQL SET TRANSACTION;
 	}
 
@@ -9106,7 +9110,7 @@ bool get_user_privilege(BurpGlobals* tdgbl)
 	}
 
 	// Check if object exists
-	isc_tr_handle	local_trans = 0;
+	Firebird::ITransaction*	local_trans = nullptr;
 	bool exists = false;
 	// if grantor is not set than it's system privilege which should not be restored
 	if (grantor[0])
@@ -9286,7 +9290,7 @@ bool get_view(BurpGlobals* tdgbl, burp_rel* relation)
 
 	// If there is a global transaction then use it
 
-	isc_tr_handle local_trans = tdgbl->global_trans ? tdgbl->global_trans : gds_trans;
+	Firebird::ITransaction* local_trans = tdgbl->global_trans ? tdgbl->global_trans : gds_trans;
 
 	if (tdgbl->runtimeODS >= DB_VERSION_DDL12)
 	{
@@ -9445,7 +9449,7 @@ void ignore_array(BurpGlobals* tdgbl, burp_rel* relation)
 					break;
 			}
 			if (!field)
-				BURP_error_redirect (NULL, 36);
+				BURP_error_redirect(NULL, 36);
 				// msg 36 Can't find field for blob
 			break;
 
@@ -9483,7 +9487,7 @@ void ignore_array(BurpGlobals* tdgbl, burp_rel* relation)
 	if (tdgbl->gbl_sw_transportable)
 	{
 		if (get_attribute(&attribute, tdgbl) != att_xdr_array)
-			BURP_error_redirect (NULL, 55);
+			BURP_error_redirect(NULL, 55);
 			// msg 55 Expected XDR record length
 		else
 		{
@@ -9578,19 +9582,19 @@ rec_type ignore_data(BurpGlobals* tdgbl, burp_rel* relation)
 	while (true)
 	{
 		if (get(tdgbl) != att_data_length)
-			BURP_error_redirect (NULL, 39);
+			BURP_error_redirect(NULL, 39);
 			// msg 39 expected record length
 		USHORT len = (USHORT) get_int32(tdgbl);
 		if (tdgbl->gbl_sw_transportable)
 		{
 			if (get(tdgbl) != att_xdr_length)
-				BURP_error_redirect (NULL, 55);
+				BURP_error_redirect(NULL, 55);
 				// msg 55 Expected XDR record length
 			else
 				len = (USHORT) get_int32(tdgbl);
 		}
 		if (get(tdgbl) != att_data_data)
-			BURP_error_redirect (NULL, 41);
+			BURP_error_redirect(NULL, 41);
 			// msg 41 expected data attribute
 		if (len)
 		{
@@ -9783,7 +9787,7 @@ bool restore(BurpGlobals* tdgbl, const TEXT* file_name, const TEXT* database_nam
 	create_database(tdgbl, database_name);
 
 	EXEC SQL SET TRANSACTION NO_AUTO_UNDO;
-	if (gds_status[1])
+	if (gds_status->hasData())
 		EXEC SQL SET TRANSACTION;
 
 	// For V4.0, start a read commited transaction.  This will be used
@@ -9803,7 +9807,10 @@ bool restore(BurpGlobals* tdgbl, const TEXT* file_name, const TEXT* database_nam
 	// msg 129 started transaction
 
 	att_type	attribute;
-	isc_req_handle  req_handle2 = 0, req_handle3 = 0, req_handle4 = 0, req_handle5 = 0;
+	Firebird::IRequest* req_handle2 =nullptr;
+	Firebird::IRequest* req_handle3 = nullptr;
+	Firebird::IRequest* req_handle4 = nullptr;
+	Firebird::IRequest* req_handle5 = nullptr;
 
 	while (get_attribute(&attribute, tdgbl) != att_end)
 	{
@@ -10092,7 +10099,7 @@ bool restore(BurpGlobals* tdgbl, const TEXT* file_name, const TEXT* database_nam
 					general_on_error ();
 				END_ERROR;
 				EXEC SQL SET TRANSACTION NO_AUTO_UNDO;
-				if (gds_status[1])
+				if (gds_status->hasData())
 					EXEC SQL SET TRANSACTION;
 				flag = false;
 			}
@@ -10151,7 +10158,7 @@ bool restore(BurpGlobals* tdgbl, const TEXT* file_name, const TEXT* database_nam
 
 	if (tdgbl->defaultCollations.getCount() > 0)
 	{
-		isc_req_handle req_handle5 = 0;
+		Firebird::IRequest* req_handle5 = nullptr;
 
 		FOR (REQUEST_HANDLE req_handle5)
 			CS IN RDB$CHARACTER_SETS
@@ -10195,7 +10202,7 @@ bool restore(BurpGlobals* tdgbl, const TEXT* file_name, const TEXT* database_nam
 			general_on_error ();
 		END_ERROR;
 		EXEC SQL SET TRANSACTION NO_AUTO_UNDO;
-		if (gds_status[1])
+		if (gds_status->hasData())
 			EXEC SQL SET TRANSACTION;
 	}
 
@@ -10207,7 +10214,7 @@ bool restore(BurpGlobals* tdgbl, const TEXT* file_name, const TEXT* database_nam
 
 	if (tdgbl->gbl_sw_kill)
 	{
-		isc_req_handle req_handle5 = 0;
+		Firebird::IRequest* req_handle5 = nullptr;
 
 		FOR (REQUEST_HANDLE req_handle5)
 			FIL IN RDB$FILES WITH FIL.RDB$SHADOW_NUMBER NOT MISSING
@@ -10225,7 +10232,7 @@ bool restore(BurpGlobals* tdgbl, const TEXT* file_name, const TEXT* database_nam
 	}
 
 	// update statistics for system indices
-	isc_req_handle req_handle6 = 0;
+	Firebird::IRequest* req_handle6 = nullptr;
 
 	FOR (REQUEST_HANDLE req_handle6)
 		IND IN RDB$INDICES WITH IND.RDB$SYSTEM_FLAG EQ 1
@@ -10258,7 +10265,7 @@ void restore_security_class(BurpGlobals* tdgbl, const TEXT* owner_nm, const TEXT
  *	restore the ownership of the relation in the ACL list
  *
  **************************************/
-	isc_req_handle  req_handle2 = 0;
+	Firebird::IRequest* req_handle2 = nullptr;
 
 	//isc_tr_handle local_trans = gds_trans;
 
@@ -10315,7 +10322,7 @@ USHORT get_view_base_relation_count(BurpGlobals* tdgbl,
 		return 0;
 	}
 
-	isc_req_handle  req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	USHORT result = 0;
 
@@ -10442,7 +10449,7 @@ void store_blr_gen_id(BurpGlobals* tdgbl, const TEXT* gen_name, SINT64 value, SI
 	}
 
 
-	FB_API_HANDLE gen_id_reqh = 0;
+	Firebird::IRequest* gen_id_reqh = nullptr;
 	UCHAR blr_buffer[100];  // enough to fit blr
 	UCHAR* blr = blr_buffer;
 
@@ -10498,26 +10505,25 @@ void store_blr_gen_id(BurpGlobals* tdgbl, const TEXT* gen_name, SINT64 value, SI
 	const USHORT blr_length = blr - blr_buffer;
 	fb_assert(blr_length <= sizeof(blr_buffer));
 
-	ISC_STATUS_ARRAY status_vector;
-	if (isc_compile_request (status_vector, &DB, &gen_id_reqh,
-							 blr_length, (const SCHAR*) blr_buffer))
+	FbLocalStatus status_vector;
+	gen_id_reqh = DB->compileRequest(&status_vector, blr_length, blr_buffer);
+	if (status_vector->hasData())
 	{
 		fb_print_blr(blr_buffer, blr_length, NULL, NULL, 0);
-		BURP_error_redirect (status_vector, 42); // msg 42 Failed in store_blr_gen_id
+		BURP_error_redirect(&status_vector, 42); // msg 42 Failed in store_blr_gen_id
 	}
 
-	if (isc_start_request (status_vector, &gen_id_reqh,
-						   &gds_trans, // use the same one generated by gpre
-						   0))
+	gen_id_reqh->start(&status_vector, gds_trans, 0);
+	if (status_vector->hasData())
 	{
 		fb_print_blr(blr_buffer, blr_length, NULL, NULL, 0);
-		BURP_error_redirect (status_vector, 42); // msg 42 Failed in store_blr_gen_id
+		BURP_error_redirect(&status_vector, 42); // msg 42 Failed in store_blr_gen_id
 	}
 
 	BURP_verbose (185, SafeArg() << gen_name << value);
 	// msg 185 restoring generator %s value: %ld
 
-	isc_release_request (status_vector, &gen_id_reqh);
+	gen_id_reqh->release();
 }
 
 
@@ -10534,7 +10540,7 @@ void update_global_field(BurpGlobals* tdgbl)
  *	The blobs have been created already.
  *
  **************************************/
-	isc_req_handle  req_handle1 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
 
 	for (gfld* gfield = tdgbl->gbl_global_fields; gfield; )
 	{
@@ -10599,7 +10605,9 @@ void update_global_field(BurpGlobals* tdgbl)
 
 void update_ownership(BurpGlobals* tdgbl)
 {
-	isc_req_handle req_handle2 = 0, req_handle4 = 0, req_handle6 = 0;
+	Firebird::IRequest* req_handle2 = nullptr;
+	Firebird::IRequest* req_handle4 = nullptr;
+	Firebird::IRequest* req_handle6 = nullptr;
 	BURP_verbose(358);
 
 	// Change ownership of any packages
@@ -10739,7 +10747,7 @@ void update_view_dbkey_lengths(BurpGlobals* tdgbl)
  *  numeric overflow, or string truncation" error.
  *
  **************************************/
-	isc_req_handle  req_handle2 = 0;
+	Firebird::IRequest* req_handle2 = nullptr;
 
 	BURP_verbose(357);
 
@@ -10783,7 +10791,8 @@ void fix_missing_privileges(BurpGlobals* tdgbl)
 	BURP_verbose(359);
 
 	GDS_NAME owner_name;
-	isc_req_handle req_handle1 = 0, req_handle2 = 0;
+	Firebird::IRequest* req_handle1 = nullptr;
+	Firebird::IRequest* req_handle2 = nullptr;
 
 	FOR (REQUEST_HANDLE req_handle1)
 		REL IN RDB$RELATIONS
@@ -10885,8 +10894,16 @@ void fix_generator(BurpGlobals* tdgbl, const FixGenerator* g)
 			   /* SELECT 2 */ g->name,
 			   /* SET GEN  */ g->name);
 
-	if (isc_execute_immediate(isc_status, &DB, &gds_trans, 0, sql.c_str()) != 0)
-		general_on_error();
+	try
+	{
+		BurpSql fixGen(tdgbl, sql.c_str());
+		fixGen.execute(gds_trans);
+	}
+	catch (const Firebird::FbException& ex)
+	{
+		fb_utils::copyStatus(&tdgbl->status_vector, ex.getStatus());
+		general_on_error ();
+	}
 }
 
 static const FixGenerator genToFix[] =

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -30,6 +30,10 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#ifdef HAVE_CTYPE_H
+#include <ctype.h>
+#endif
+
 #include "../burp/burp.h"
 #include "../jrd/align.h"
 #include "../jrd/flags.h"
@@ -55,6 +59,7 @@
 #include "memory_routines.h"
 #include "../burp/OdsDetection.h"
 #include "../auth/trusted/AuthSspi.h"
+#include "../common/dsc_proto.h"
 
 using MsgFormat::SafeArg;
 using Firebird::FbLocalStatus;
@@ -111,12 +116,14 @@ void	fix_security_class_name(BurpGlobals* tdgbl, TEXT* sec_class, bool is_field)
 // returned value is not checked by the caller!
 bool	get_acl(BurpGlobals* tdgbl, const TEXT*, ISC_QUAD*, ISC_QUAD*);
 void	get_array(BurpGlobals* tdgbl, burp_rel*, UCHAR*);
-void	get_blob(BurpGlobals* tdgbl, const burp_fld*, UCHAR*);
+void	get_blob(BurpGlobals* tdgbl, Firebird::IBatch* batch, const burp_fld*, UCHAR*);
+void	get_blob_old(BurpGlobals* tdgbl, const burp_fld*, UCHAR*);
 void	get_blr_blob(BurpGlobals* tdgbl, ISC_QUAD&, bool);
 bool	get_character_set(BurpGlobals* tdgbl);
 bool	get_chk_constraint(BurpGlobals* tdgbl);
 bool	get_collation(BurpGlobals* tdgbl);
 rec_type	get_data(BurpGlobals* tdgbl, burp_rel*, bool);
+rec_type	get_data_old(BurpGlobals* tdgbl, burp_rel*);
 bool	get_exception(BurpGlobals* tdgbl);
 burp_fld*	get_field(BurpGlobals* tdgbl, burp_rel*);
 bool	get_field_dimensions(BurpGlobals* tdgbl);
@@ -930,7 +937,8 @@ void create_database(BurpGlobals* tdgbl, const TEXT* file_name)
 	// When we restore backup files that came from prior
 	// to V6, we force the SQL database dialect to 1
 
-	dpb.insertByte(isc_dpb_sql_dialect, SQL_dialect_flag ? SQL_dialect : SQL_DIALECT_V5);
+	tdgbl->gbl_dialect = SQL_dialect_flag ? SQL_dialect : SQL_DIALECT_V5;
+	dpb.insertByte(isc_dpb_sql_dialect, tdgbl->gbl_dialect);
 
 	// start database up shut down,
 	// use single-user mode to avoid conflicts during restore process
@@ -954,6 +962,14 @@ void create_database(BurpGlobals* tdgbl, const TEXT* file_name)
 	{
 		BURP_error_redirect(&status_vector, 33, SafeArg() << file_name);
 		// msg 33 failed to create database %s
+	}
+
+	tdgbl->gbl_network_protocol = DB->getRemoteProtocolVersion(&status_vector);
+	// treat errors as old provider missing new calls
+	if (status_vector->hasData())
+	{
+		status_vector->init();
+		tdgbl->gbl_network_protocol = 1;
 	}
 
 	if (tdgbl->gbl_sw_version && !tdgbl->uSvc->isService())
@@ -1759,7 +1775,7 @@ void get_array(BurpGlobals* tdgbl, burp_rel* relation, UCHAR* record_buffer)
 					get_block(tdgbl, p, lcount);
 
 				if (tdgbl->gbl_sw_transportable)
-					CAN_slice (&xdr_buffer, &xdr_slice, FALSE, /*blr_length,*/ blr_buffer);
+					CAN_slice (&xdr_buffer, &xdr_slice, false, blr_buffer);
 			}
 
 			DB->putSlice(&status_vector, gds_trans, blob_id, blr_length, blr_buffer,
@@ -1885,7 +1901,7 @@ void get_array(BurpGlobals* tdgbl, burp_rel* relation, UCHAR* record_buffer)
 			get_block(tdgbl, p, lcount);
 
 		if (tdgbl->gbl_sw_transportable)
-			CAN_slice (&xdr_buffer, &xdr_slice, FALSE, /*blr_length,*/ blr_buffer);
+			CAN_slice (&xdr_buffer, &xdr_slice, false, blr_buffer);
 
 
 		DB->putSlice(&status_vector, gds_trans, blob_id, blr_length, blr_buffer,
@@ -1908,7 +1924,108 @@ void get_array(BurpGlobals* tdgbl, burp_rel* relation, UCHAR* record_buffer)
 		BURP_free (xdr_buffer.lstr_address);
 }
 
-void get_blob(BurpGlobals* tdgbl, const burp_fld* fields, UCHAR* record_buffer)
+void get_blob(BurpGlobals* tdgbl, Firebird::IBatch* batch, const burp_fld* fields, UCHAR* record_buffer)
+{
+/**************************************
+ *
+ *	g e t _ b l o b
+ *
+ **************************************
+ *
+ * Functional description
+ *	Read blob attributes and copy data from input file to nice,
+ *	shiny, new blob.
+ *
+ **************************************/
+
+	// Pick up attributes
+
+	ULONG segments = 0;
+	USHORT field_number = MAX_USHORT;
+	USHORT max_segment = 0;
+	UCHAR blob_type = 0;
+
+	att_type	attribute;
+	scan_attr_t	scan_next_attr;
+	skip_init(&scan_next_attr);
+	while (skip_scan(&scan_next_attr), get_attribute(&attribute, tdgbl) != att_blob_data)
+	{
+		switch (attribute)
+		{
+		case att_blob_field_number:
+			field_number = (USHORT) get_int32(tdgbl);
+			break;
+
+		case att_blob_max_segment:
+			max_segment = (USHORT) get_int32(tdgbl);
+			break;
+
+		case att_blob_number_segments:
+			segments = get_int32(tdgbl);
+			break;
+
+		case att_blob_type:
+			blob_type = (UCHAR) get_int32(tdgbl);
+			break;
+
+		default:
+			bad_attribute(scan_next_attr, attribute, 64);
+			// msg 64 blob
+			break;
+		}
+	}
+
+	// Find the field associated with the blob
+	const burp_fld* field;
+	for (field = fields; field; field = field->fld_next)
+	{
+		if (field->fld_number == field_number)
+			break;
+	}
+
+	if (!field)
+	{
+		BURP_error_redirect(NULL, 36);
+		// msg 36 Can't find field for blob
+	}
+
+	// Create new blob
+
+	ISC_QUAD* blob_id = (ISC_QUAD*) ((UCHAR*) record_buffer + field->fld_offset);
+	const UCHAR blob_desc[] = {isc_bpb_version1, isc_bpb_type, 1, blob_type};
+
+	BlobBuffer local_buffer;
+	UCHAR* const buffer = local_buffer.getBuffer(max_segment);
+
+	FbLocalStatus status_vector;
+	bool first = true;
+
+	// Eat up blob segments
+
+	for (; segments > 0; --segments )
+	{
+		USHORT length = get(tdgbl);
+		length |= get(tdgbl) << 8;
+		if (length)
+		{
+			get_block(tdgbl, buffer, length);
+		}
+
+		if (first)
+			batch->addBlob(&status_vector, length, buffer, blob_id, sizeof(blob_desc), blob_desc);
+		else
+			batch->appendBlobData(&status_vector, length, buffer);
+		if (status_vector->hasData())
+		{
+			BURP_error_redirect(&status_vector, 38);		// !!!!!!!!! new message
+			// msg 38 isc_put_segment failed
+		}
+		first = false;
+	}
+}
+
+
+void get_blob_old(BurpGlobals* tdgbl, const burp_fld* fields, UCHAR* record_buffer)
 {
 /**************************************
  *
@@ -2710,13 +2827,506 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
  *	Write data records for a relation.
  *
  **************************************/
-	Firebird::IRequest* req_handle = 0;
-	BASED_ON RDB$INDICES.RDB$INDEX_NAME index_name;
+	ULONG records = 0;
+	rec_type record;
+	burp_fld* field;
 
 	// If we're only doing meta-data, ignore data records
 
 	if (tdgbl->gbl_sw_meta || skip_relation)
 		return ignore_data(tdgbl, relation);
+
+	// For old versions and embedded connections switch to old style method
+	// Avoid if possible switch to old style when system domains are used in a table
+
+	if (tdgbl->gbl_network_protocol == 0)
+	{
+		bool sysDomFlag = false;
+		for (field = relation->rel_fields; field && (!sysDomFlag); field = field->fld_next)
+		{
+			if (field->fld_flags & FLD_computed)
+				continue;
+
+			const char* dom = field->fld_source;
+			if (strncmp(dom, "RDB$", 4) != 0)
+				continue;
+
+			for (dom += 4; *dom; ++dom)
+			{
+#ifdef HAVE_CTYPE_H
+				if (!isdigit(*dom))
+#else
+				if (*dom < '0' || *dom > '9')
+#endif
+				{
+					sysDomFlag = true;
+					break;
+				}
+			}
+		}
+
+		if (!sysDomFlag)
+			return get_data_old(tdgbl, relation);
+	}
+	else if (tdgbl->gbl_network_protocol < 16)
+		return get_data_old(tdgbl, relation);
+
+	// Number of fields in a message
+
+	unsigned count = 0;
+	for (field = relation->rel_fields; field; field = field->fld_next)
+	{
+		if (!(field->fld_flags & FLD_computed))
+			++count;
+	}
+
+	// Time to generate SQL and message metadata to store data.  Whoppee.
+
+	try
+	{
+		Firebird::string sqlStatement;
+		sqlStatement.printf("insert into %s(", relation->rel_name);
+
+		Firebird::RefPtr<Firebird::IMetadataBuilder> builder(Firebird::REF_NO_INCR,
+			Firebird::MasterInterfacePtr()->getMetadataBuilder(fbStatus, count));
+		if (fbStatus->hasData())
+			general_on_error();
+
+		RCRD_OFFSET offset = 0;
+		count = 0;
+		for (field = relation->rel_fields; field; field = field->fld_next)
+		{
+			if (field->fld_flags & FLD_computed)
+				continue;
+
+			USHORT dtype = field->fld_type;
+
+			// arrays are of various fld_types but are really blobs
+
+			if (field->fld_flags & FLD_array)
+				dtype = blr_blob;
+
+			DSC desc;
+			if (!DSC_make_descriptor(&desc, dtype, field->fld_scale, field->fld_length,
+				field->fld_sub_type, field->fld_character_set_id, field->fld_collation_id))
+			{
+				BURP_error(26, true, SafeArg() << dtype);
+				// msg 26 datatype %ld not understood
+			}
+
+			SSHORT alignment = type_alignments[desc.dsc_dtype];
+			if (alignment)
+				offset = FB_ALIGN(offset, alignment);
+			field->fld_offset = offset;
+			offset += field->fld_total_len = desc.dsc_length;
+
+			SLONG sqlLength, sqlSubType, sqlScale, sqlType;
+			desc.getSqlInfo(&sqlLength, &sqlSubType, &sqlScale, &sqlType);
+			SLONG characterSetId = field->fld_character_set_id;
+
+			if (tdgbl->gbl_sw_fix_fss_data && field->fld_character_set_id == CS_UNICODE_FSS &&
+				((sqlType == SQL_BLOB && field->fld_sub_type == isc_blob_text && !(field->fld_flags & FLD_array)) ||
+				 sqlType == SQL_TEXT || sqlType == SQL_VARYING))
+			{
+				characterSetId = tdgbl->gbl_sw_fix_fss_data_id;
+			}
+			else if (field->fld_flags & FLD_array)
+			{
+				sqlType = SQL_QUAD;
+				sqlScale = 0;
+			}
+
+			builder->setType(&tdgbl->throwStatus, count, sqlType);
+			builder->setSubType(&tdgbl->throwStatus, count, sqlSubType);
+			builder->setLength(&tdgbl->throwStatus, count, sqlLength);
+			builder->setScale(&tdgbl->throwStatus, count, sqlScale);
+			builder->setCharSet(&tdgbl->throwStatus, count, characterSetId);
+
+			sqlStatement += field->fld_name;
+			sqlStatement += ", ";
+
+			field->fld_parameter = count++;
+		}
+
+		fb_assert(sqlStatement.end()[-2] == ',');
+		sqlStatement.end()[-2] = ')';
+
+		Firebird::RefPtr<Firebird::IMessageMetadata> meta(Firebird::REF_NO_INCR,
+			builder->getMetadata(&tdgbl->throwStatus));
+		builder = nullptr;
+
+		sqlStatement += "values (";
+
+		count = 0;
+		for (field = relation->rel_fields; field; field = field->fld_next)
+		{
+			if (field->fld_flags & FLD_computed)
+				continue;
+
+			offset = FB_ALIGN(offset, sizeof(SSHORT));
+			field->fld_missing_parameter = count;
+			field->fld_missing_offset = offset;
+			offset += sizeof(SSHORT);
+
+			field->fld_sql = meta->getOffset(&tdgbl->throwStatus, count);
+			field->fld_null = meta->getNullOffset(&tdgbl->throwStatus, count);
+
+			if (tdgbl->gbl_sw_transportable)
+			{
+				field->fld_offset = field->fld_sql;
+				field->fld_missing_offset = field->fld_null;
+			}
+
+			sqlStatement += "?, ";
+			++count;
+		}
+
+		fb_assert(sqlStatement.end()[-2] == ',');
+		sqlStatement.end()[-2] = ')';
+
+		RCRD_LENGTH length = offset;
+
+		// Create batch
+
+		const int GBAK_BATCH_STEP = 1000;
+		Firebird::AutoDispose<Firebird::IXpbBuilder> pb(Firebird::UtilInterfacePtr()->
+			getXpbBuilder(&tdgbl->throwStatus, Firebird::IXpbBuilder::BATCH, NULL, 0));
+		pb->insertInt(&tdgbl->throwStatus, Firebird::IBatch::TAG_MULTIERROR, 1);
+		pb->insertInt(&tdgbl->throwStatus, Firebird::IBatch::TAG_BLOB_POLICY, Firebird::IBatch::BLOB_ID_ENGINE);
+		pb->insertInt(&tdgbl->throwStatus, Firebird::IBatch::TAG_DETAILED_ERRORS, GBAK_BATCH_STEP);
+		pb->insertInt(&tdgbl->throwStatus, Firebird::IBatch::TAG_BUFFER_BYTES_SIZE, 0);
+
+		Firebird::RefPtr<Firebird::IBatch> batch(DB->
+			createBatch(fbStatus, gds_trans, sqlStatement.length(), sqlStatement.c_str(), tdgbl->gbl_dialect,
+				meta, pb->getBufferLength(&tdgbl->throwStatus), pb->getBuffer(&tdgbl->throwStatus)));
+		if (fbStatus->hasData())
+		{
+			// Possible reason of fail - use of keywords as fields in old backup
+			// Try to roll back to use of old version (fieldnames independent)
+			BURP_print(false, 27/*, sqlStatement.c_str()*/);	// msg 27 isc_compile_request failed     !!!!!!!! new WARNING
+			BURP_print_warning(fbStatus);
+			return get_data_old(tdgbl, relation);
+		}
+
+		UCHAR* buffer = NULL;
+		Firebird::Array<UCHAR> requestBuffer;
+
+		BURP_verbose (124, relation->rel_name); // msg 124  restoring data for relation %s
+
+		lstring data;
+		data.lstr_allocated = 0;
+		data.lstr_address = NULL;
+		Firebird::Array<UCHAR> dataBuffer;
+		RCRD_LENGTH old_length = 0;
+
+		Firebird::Array<UCHAR> sqlBuffer;
+		UCHAR* sql = sqlBuffer.getBuffer(meta->getMessageLength(&tdgbl->throwStatus));
+
+		while (true)
+		{
+			if (get(tdgbl) != att_data_length)
+				BURP_error_redirect(NULL, 39); // msg 39 expected record length
+			RCRD_LENGTH len = get_int32(tdgbl);
+
+			if (!tdgbl->gbl_sw_transportable && len != length)
+			{
+#ifdef sparc
+				if (!old_length)
+					old_length = recompute_length(tdgbl, relation);
+#endif
+				if (len != old_length)
+				{
+					BURP_error(40, true, SafeArg() << length << len);
+					// msg 40 wrong length record, expected %ld encountered %ld
+				}
+			}
+
+			if (!buffer)
+				buffer = requestBuffer.getBuffer(MAX (length, len));
+
+			UCHAR* p;
+			if (tdgbl->gbl_sw_transportable)
+			{
+				if (get(tdgbl) != att_xdr_length)
+				{
+					BURP_error_redirect(NULL, 55);
+					// msg 55 Expected XDR record length
+				}
+				else
+				{
+					data.lstr_length = len = get_int32(tdgbl);
+					if (len > data.lstr_allocated)
+					{
+						data.lstr_allocated = len;
+						data.lstr_address = dataBuffer.getBuffer(data.lstr_allocated);
+					}
+					p = data.lstr_address;
+				}
+			}
+			else
+				p = buffer;
+
+			if (get(tdgbl) != att_data_data)
+				BURP_error_redirect(NULL, 41); // msg 41 expected data attribute
+
+			if (tdgbl->gbl_sw_compress)
+				decompress (tdgbl, p, len);
+			else
+			{
+				get_block(tdgbl, p, len);
+			}
+
+			if (old_length)
+				realign (tdgbl, buffer, relation);
+
+			if (tdgbl->gbl_sw_transportable)
+			{
+				buffer = sql;
+				CAN_encode_decode (relation, &data, buffer, false, true);
+			}
+
+			if ((++records % tdgbl->verboseInterval) == 0)
+				BURP_verbose(107, SafeArg() << records);
+
+			for (field = relation->rel_fields; field; field = field->fld_next)
+			{
+				if (!(field->fld_flags & FLD_computed))
+				{
+					if (field->fld_type == blr_blob || (field->fld_flags & FLD_array))
+					{
+						ISC_QUAD* blob_id = (ISC_QUAD*) &buffer[field->fld_offset];
+						blob_id->gds_quad_high = 0;
+						blob_id->gds_quad_low = 0;
+					}
+				}
+			}
+
+			get_record(&record, tdgbl);
+			while (record == rec_blob || record == rec_array)
+			{
+				if (record == rec_blob)
+					get_blob (tdgbl, batch, relation->rel_fields, buffer);
+				else if (record == rec_array)
+					get_array (tdgbl, relation, buffer);
+				get_record(&record, tdgbl);
+			}
+
+			if (!tdgbl->gbl_sw_transportable)
+			{
+				for (field = relation->rel_fields; field; field = field->fld_next)
+				{
+					if (field->fld_flags & FLD_computed)
+						continue;
+
+					// convert record to SQL format
+
+					memcpy(&sql[field->fld_sql], &buffer[field->fld_offset], field->fld_total_len);
+					memcpy(&sql[field->fld_null], &buffer[field->fld_missing_offset], sizeof(SSHORT));
+				}
+			}
+
+			batch->add(&tdgbl->throwStatus, 1, sql);
+			if ((records % 1000 != 0) && (record == rec_data))
+				continue;
+
+			Firebird::AutoDispose<Firebird::IBatchCompletionState> cs(batch->execute(&tdgbl->throwStatus, gds_trans));
+			if (tdgbl->throwStatus->getState() && Firebird::IStatus::STATE_WARNINGS)
+				BURP_print_warning(&tdgbl->throwStatus);
+
+			for (unsigned pos = 0; pos = cs->findError(&tdgbl->throwStatus, pos),
+				pos != Firebird::IBatchCompletionState::NO_MORE_ERRORS; ++pos)
+			{
+				Firebird::LocalStatus status_vector;
+				cs->getStatus(&tdgbl->throwStatus, &status_vector, pos);
+				ISC_STATUS code = status_vector.getErrors()[1];
+
+				if (code == isc_not_valid)
+				{
+					if (tdgbl->gbl_sw_incremental)
+					{
+						BURP_print (false, 138, relation->rel_name);
+						// msg 138 validation error on field in relation %s
+						BURP_print_status (false, &status_vector);
+					}
+					else
+						BURP_error_redirect(&status_vector, 47);
+						// msg 47 warning -- record could not be restored
+				}
+				else if (code == isc_malformed_string)
+				{
+					if (tdgbl->gbl_sw_incremental)
+					{
+						// msg 114 restore failed for record in relation %s
+						BURP_print(false, 114, relation->rel_name);
+
+						BURP_print_status(false, &status_vector);
+						BURP_print(false, 342);	// isc_gbak_invalid_data
+					}
+					else
+						BURP_error_redirect(&status_vector, 342);	// isc_gbak_invalid_data
+				}
+				else
+				{
+					if (tdgbl->gbl_sw_incremental)
+					{
+						BURP_print (false, 114, relation->rel_name);
+						// msg 114 restore failed for record in relation %s
+						BURP_print_status (false, &status_vector);
+					}
+					else
+						BURP_error_redirect(&status_vector, 48);
+						// msg 48 isc_send failed
+				}
+
+				records--;
+			}
+
+			if (record != rec_data)
+				break;
+		} // while (true)
+	}
+	catch(const Firebird::FbException& ex)
+	{
+		BURP_print_status (true, ex.getStatus());
+		BURP_abort();
+	}
+
+	if (tdgbl->gbl_sw_incremental)
+	{
+		BURP_verbose (72, relation->rel_name);
+		// msg 72  committing data for relation %s
+		COMMIT
+		// existing ON_ERROR continues past error, beck
+		ON_ERROR
+
+			// Fix for bug_no 8055:
+			// don't throw away the database just because an index
+			// could not be made
+
+			// don't bring the database on-line
+			tdgbl->flag_on_line = false;
+			ISC_STATUS error_code;
+			while (error_code = tdgbl->status_vector[1])
+			{
+				BASED_ON RDB$INDICES.RDB$INDEX_NAME index_name;
+				Firebird::IRequest* req_handle = 0;
+
+				switch (error_code)
+				{
+					case isc_sort_mem_err:
+					case isc_no_dup:
+						strcpy(index_name, (TEXT *)tdgbl->status_vector[3]);
+						BURP_print_status(false, &tdgbl->status_vector);
+						FOR (REQUEST_HANDLE req_handle)
+						 IDX IN RDB$INDICES WITH IDX.RDB$INDEX_NAME EQ index_name
+							MODIFY IDX USING
+								IDX.RDB$INDEX_INACTIVE = TRUE;
+								BURP_print(false, 240, index_name);
+								// msg 240 Index \"%s\" failed to activate because:
+								if ( error_code == isc_no_dup )
+								{
+									BURP_print(false, 241);
+									// msg 241 The unique index has duplicate values or NULLs
+									BURP_print(false, 242);
+									// msg 242 Delete or Update duplicate values or NULLs, and activate index with
+								}
+								else
+								{
+									BURP_print(false, 244);
+									// msg 244 Not enough disk space to create the sort file for an index
+									BURP_print(false, 245);
+									// msg 245 Set the TMP environment variable to a directory on a filesystem that does have enough space, and activate index with
+								}
+								BURP_print(false, 243, index_name);
+								// msg 243 ALTER INDEX \"%s\" ACTIVE
+							END_MODIFY;
+						END_FOR;
+						// commit one more time
+						COMMIT
+						ON_ERROR
+							continue;
+						END_ERROR
+						break;
+					default:
+						BURP_print (false, 69, relation->rel_name);
+						// msg 69 commit failed on relation %s
+						BURP_print_status (false, &tdgbl->status_vector);
+						ROLLBACK;
+						ON_ERROR
+							general_on_error ();
+						END_ERROR;
+						break;
+				} // end of switch
+			} // end of while
+		END_ERROR;
+
+		EXEC SQL SET TRANSACTION NO_AUTO_UNDO;
+		if (gds_status->hasData())
+			EXEC SQL SET TRANSACTION;
+	}
+	BURP_verbose (107, SafeArg() << records);
+	// msg 107 %ld records restored
+
+	return record;
+}
+
+// We have a corrupt backup, save the restore process from becoming useless.
+void fix_exception(BurpGlobals* tdgbl, const char* exc_name, scan_attr_t& scan_next_attr,
+	const att_type attribute, att_type& failed_attrib, UCHAR*& msg_ptr, ULONG& l2, bool& msg_seen)
+{
+	if (msg_seen && (tdgbl->RESTORE_format == 7 || tdgbl->RESTORE_format == 8))
+	{
+		if (!failed_attrib)
+		{
+			failed_attrib = attribute;
+			BURP_print(false, 313, SafeArg() << failed_attrib << exc_name);
+		}
+
+		// Notice we use 1021 instead of 1023 because this is the maximum length
+		// for this field in v2.0 and v2.1 and they produce the corrupt backups.
+		const unsigned int FIELD_LIMIT = 1021;
+
+		if (FIELD_LIMIT < l2 + 1) // not enough space
+		{
+			bad_attribute(scan_next_attr, failed_attrib, 287);
+			return;
+		}
+		const unsigned int remaining = FIELD_LIMIT - l2;
+
+		*msg_ptr++ = char(attribute); // (1)
+
+		UCHAR* rc_ptr = get_block(tdgbl, msg_ptr, MIN(remaining - 1, 255));
+		if (remaining > 1 && rc_ptr == msg_ptr) // we couldn't read anything
+		{
+			bad_attribute(scan_next_attr, failed_attrib, 287);
+			return;
+		}
+
+		l2 += rc_ptr - msg_ptr + 1; // + 1 because (1)
+		msg_ptr = rc_ptr;
+		*msg_ptr = 0;
+
+		if (l2 == FIELD_LIMIT)
+			msg_seen = false;
+	}
+	else
+		bad_attribute(scan_next_attr, attribute, 287); // msg 287 exception
+}
+
+rec_type get_data_old(BurpGlobals* tdgbl, burp_rel* relation)
+{
+/**************************************
+ *
+ *	g e t _ d a t a
+ *
+ **************************************
+ *
+ * Functional description
+ *	Write data records for a relation.
+ *
+ **************************************/
+	Firebird::IRequest* req_handle = 0;
+	BASED_ON RDB$INDICES.RDB$INDEX_NAME index_name;
 
 	// Start by counting the interesting fields
 
@@ -2734,8 +3344,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 		}
 	}
 
-	if (tdgbl->RESTORE_format >= 2)
-		count += count;
+	count += count;
 
 	// Time to generate blr to store data.  Whoppee.
 
@@ -2845,19 +3454,16 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 		offset += length;
 	}
 
-	// If this is format version 2, build fields for null flags
-
-	if (tdgbl->RESTORE_format >= 2)
-		for (field = relation->rel_fields; field; field = field->fld_next)
-		{
-			if (field->fld_flags & FLD_computed)
-				continue;
-			add_byte(blr, blr_short);
-			add_byte(blr, 0);
-			offset = FB_ALIGN(offset, sizeof(SSHORT));
-			field->fld_missing_parameter = count++;
-			offset += sizeof(SSHORT);
-		}
+	for (field = relation->rel_fields; field; field = field->fld_next)
+	{
+		if (field->fld_flags & FLD_computed)
+			continue;
+		add_byte(blr, blr_short);
+		add_byte(blr, 0);
+		offset = FB_ALIGN(offset, sizeof(SSHORT));
+		field->fld_missing_parameter = count++;
+		offset += sizeof(SSHORT);
+	}
 
 	length = offset;
 
@@ -2877,19 +3483,12 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 		if (field->fld_flags & FLD_computed)
 			continue;
 		add_byte(blr, blr_assignment);
-		if (tdgbl->RESTORE_format >= 2)
-		{
-			add_byte(blr, blr_parameter2);
-			add_byte(blr, 0);
-			add_word(blr, field->fld_parameter);
-			add_word(blr, field->fld_missing_parameter);
-		}
-		else
-		{
-			add_byte(blr, blr_parameter);
-			add_byte(blr, 0);
-			add_word(blr, field->fld_parameter);
-		}
+
+		add_byte(blr, blr_parameter2);
+		add_byte(blr, 0);
+		add_word(blr, field->fld_parameter);
+		add_word(blr, field->fld_missing_parameter);
+
 		add_byte(blr, blr_field);
 		add_byte(blr, 0);
 		add_string(blr, field->fld_name);
@@ -2994,7 +3593,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 			realign (tdgbl, (UCHAR*) buffer, relation);
 
 		if (tdgbl->gbl_sw_transportable)
-			CAN_encode_decode (relation, &data, (UCHAR *)buffer, FALSE);
+			CAN_encode_decode (relation, &data, (UCHAR *)buffer, false);
 
 		records++;
 
@@ -3018,7 +3617,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 		while (record == rec_blob || record == rec_array)
 		{
 			if (record == rec_blob)
-				get_blob (tdgbl, relation->rel_fields, (UCHAR *) buffer);
+				get_blob_old (tdgbl, relation->rel_fields, (UCHAR *) buffer);
 			else if (record == rec_array)
 				get_array (tdgbl, relation, (UCHAR *) buffer);
 			get_record(&record, tdgbl);
@@ -3161,49 +3760,6 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 	// msg 107 %ld records restored
 
 	return record;
-}
-
-// We have a corrupt backup, save the restore process from becoming useless.
-void fix_exception(BurpGlobals* tdgbl, const char* exc_name, scan_attr_t& scan_next_attr,
-	const att_type attribute, att_type& failed_attrib, UCHAR*& msg_ptr, ULONG& l2, bool& msg_seen)
-{
-	if (msg_seen && (tdgbl->RESTORE_format == 7 || tdgbl->RESTORE_format == 8))
-	{
-		if (!failed_attrib)
-		{
-			failed_attrib = attribute;
-			BURP_print(false, 313, SafeArg() << failed_attrib << exc_name);
-		}
-
-		// Notice we use 1021 instead of 1023 because this is the maximum length
-		// for this field in v2.0 and v2.1 and they produce the corrupt backups.
-		const unsigned int FIELD_LIMIT = 1021;
-
-		if (FIELD_LIMIT < l2 + 1) // not enough space
-		{
-			bad_attribute(scan_next_attr, failed_attrib, 287);
-			return;
-		}
-		const unsigned int remaining = FIELD_LIMIT - l2;
-
-		*msg_ptr++ = char(attribute); // (1)
-
-		UCHAR* rc_ptr = get_block(tdgbl, msg_ptr, MIN(remaining - 1, 255));
-		if (remaining > 1 && rc_ptr == msg_ptr) // we couldn't read anything
-		{
-			bad_attribute(scan_next_attr, failed_attrib, 287);
-			return;
-		}
-
-		l2 += rc_ptr - msg_ptr + 1; // + 1 because (1)
-		msg_ptr = rc_ptr;
-		*msg_ptr = 0;
-
-		if (l2 == FIELD_LIMIT)
-			msg_seen = false;
-	}
-	else
-		bad_attribute(scan_next_attr, attribute, 287); // msg 287 exception
 }
 
 bool get_exception(BurpGlobals* tdgbl)
@@ -3596,6 +4152,7 @@ burp_fld* get_field(BurpGlobals* tdgbl, burp_rel* relation)
 
 				case att_field_source:
 					GET_TEXT(X.RDB$FIELD_SOURCE);
+					strcpy(field->fld_source, X.RDB$FIELD_SOURCE);
 					break;
 
 				case att_field_security_class:
@@ -3798,6 +4355,7 @@ burp_fld* get_field(BurpGlobals* tdgbl, burp_rel* relation)
 
 				case att_field_source:
 					GET_TEXT(X.RDB$FIELD_SOURCE);
+					strcpy(field->fld_source, X.RDB$FIELD_SOURCE);
 					break;
 
 				case att_field_security_class:
@@ -9670,19 +10228,14 @@ void realign(BurpGlobals* tdgbl, UCHAR* buffer, const burp_rel* relation)
 		}
 	}
 
-	// If this is format version 2 or greater, build fields for null flags
-
-	if (tdgbl->RESTORE_format >= 2)
+	for (const burp_fld* field = relation->rel_fields; field; field = field->fld_next)
 	{
-		for (const burp_fld* field = relation->rel_fields; field; field = field->fld_next)
-		{
-			if (field->fld_flags & FLD_computed)
-				continue;
-			p = FB_ALIGN(p, sizeof(SSHORT));
-			q = FB_ALIGN(q, sizeof(SSHORT));
-			*p++ = *q++;
-			*p++ = *q++;
-		}
+		if (field->fld_flags & FLD_computed)
+			continue;
+		p = FB_ALIGN(p, sizeof(SSHORT));
+		q = FB_ALIGN(q, sizeof(SSHORT));
+		*p++ = *q++;
+		*p++ = *q++;
 	}
 }
 
@@ -9732,17 +10285,12 @@ USHORT recompute_length(BurpGlobals* tdgbl, burp_rel* relation)
 		offset += length;
 	}
 
-	// If this is format version 2, build fields for null flags
-
-	if (tdgbl->RESTORE_format >= 2)
+	for (const burp_fld* field = relation->rel_fields; field; field = field->fld_next)
 	{
-		for (const burp_fld* field = relation->rel_fields; field; field = field->fld_next)
-		{
-			if (field->fld_flags & FLD_computed)
-				continue;
-			offset = FB_ALIGN(offset, sizeof(SSHORT));
-			offset += sizeof(SSHORT);
-		}
+		if (field->fld_flags & FLD_computed)
+			continue;
+		offset = FB_ALIGN(offset, sizeof(SSHORT));
+		offset += sizeof(SSHORT);
 	}
 
 	return offset;
@@ -9776,9 +10324,9 @@ bool restore(BurpGlobals* tdgbl, const TEXT* file_name, const TEXT* database_nam
 
 	// restore only from those backup files created by current or previous GBAK
 
-	if (tdgbl->RESTORE_format < 1 || tdgbl->RESTORE_format > ATT_BACKUP_FORMAT)
+	if (tdgbl->RESTORE_format < 2 || tdgbl->RESTORE_format > ATT_BACKUP_FORMAT)
 	{
-		BURP_error(344, true, SafeArg() << tdgbl->RESTORE_format << 1 << ATT_BACKUP_FORMAT);
+		BURP_error(344, true, SafeArg() << tdgbl->RESTORE_format << 2 << ATT_BACKUP_FORMAT);
 		// msg 44 Expected backup version @2..@3.  Found @1
 	}
 

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -100,7 +100,7 @@ void	add_access_dpb(BurpGlobals* tdgbl, Firebird::ClumpletWriter& dpb);
 void	add_files(BurpGlobals* tdgbl, const char*);
 void	bad_attribute(scan_attr_t, att_type, USHORT);
 void	create_database(BurpGlobals* tdgbl, const TEXT*);
-void	decompress(BurpGlobals* tdgbl, UCHAR*, USHORT);
+void	decompress(BurpGlobals* tdgbl, UCHAR*, ULONG);
 void	eat_blob(BurpGlobals* tdgbl);
 void	eat_text(BurpGlobals* tdgbl);
 void	eat_text2(BurpGlobals* tdgbl);
@@ -968,7 +968,7 @@ void create_database(BurpGlobals* tdgbl, const TEXT* file_name)
 	// msg 74 created database %s, page_size %ld bytes
 }
 
-void decompress(BurpGlobals* tdgbl, UCHAR* buffer, USHORT length)
+void decompress(BurpGlobals* tdgbl, UCHAR* buffer, ULONG length)
 {
 /**************************************
  *
@@ -2901,7 +2901,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 
 	// Compile request
 
-	USHORT blr_length = blr - blr_buffer;
+	ULONG blr_length = blr - blr_buffer;
 
 #ifdef DEBUG
 	fb_print_blr(blr_buffer, blr_length, NULL, NULL, 0);
@@ -2967,7 +2967,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 				// msg 55 Expected XDR record length
 			else
 			{
-				data.lstr_length = len = (USHORT) get_int32(tdgbl);
+				data.lstr_length = len = get_int32(tdgbl);
 				if (len > data.lstr_allocated)
 				{
 					data.lstr_allocated = len;

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -489,7 +489,7 @@ int RESTORE_restore (const TEXT* file_name, const TEXT* database_name)
 		if (gds_status->hasData())
 			general_on_error ();
 		// Check to see if there is a warning
-		if (gds_status->getState() && Firebird::IStatus::STATE_WARNINGS)
+		if (gds_status->getState() & Firebird::IStatus::STATE_WARNINGS)
 		{
 			BURP_print_warning(gds_status);
 		}
@@ -544,7 +544,7 @@ int RESTORE_restore (const TEXT* file_name, const TEXT* database_name)
 	END_ERROR;
 
 	// Check to see if there is a warning
-	if (gds_status->getState() && Firebird::IStatus::STATE_WARNINGS)
+	if (gds_status->getState() & Firebird::IStatus::STATE_WARNINGS)
 	{
 		BURP_print_warning(gds_status);
 	}
@@ -3130,7 +3130,7 @@ rec_type get_data(BurpGlobals* tdgbl, burp_rel* relation, bool skip_relation)
 				continue;
 
 			Firebird::AutoDispose<Firebird::IBatchCompletionState> cs(batch->execute(&tdgbl->throwStatus, gds_trans));
-			if (tdgbl->throwStatus->getState() && Firebird::IStatus::STATE_WARNINGS)
+			if (tdgbl->throwStatus->getState() & Firebird::IStatus::STATE_WARNINGS)
 				BURP_print_warning(&tdgbl->throwStatus);
 
 			for (unsigned pos = 0; pos = cs->findError(&tdgbl->throwStatus, pos),

--- a/src/common/CharSet.h
+++ b/src/common/CharSet.h
@@ -33,21 +33,23 @@
 #include "CsConvert.h"
 #include "IntlUtil.h"
 
+namespace Firebird {
+
+	template <>
+	inline void SimpleDelete<charset>::clear(charset* cs)
+	{
+		Firebird::IntlUtil::finiCharset(cs);
+		delete cs;
+	}
+
+}
+
+
 namespace Jrd {
 
 class CharSet
 {
 public:
-	class Delete
-	{
-	public:
-		static void clear(charset* cs)
-		{
-			Firebird::IntlUtil::finiCharset(cs);
-			delete cs;
-		}
-	};
-
 	static CharSet* createInstance(Firebird::MemoryPool& pool, USHORT id, charset* cs);
 
 protected:

--- a/src/common/classes/BlobWrapper.cpp
+++ b/src/common/classes/BlobWrapper.cpp
@@ -1,0 +1,263 @@
+/*
+ *  The contents of this file are subject to the Initial
+ *  Developer's Public License Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *  http://www.ibphoenix.com/main.nfs?a=ibphoenix&page=ibp_idpl.
+ *
+ *  Software distributed under the License is distributed AS IS,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing rights
+ *  and limitations under the License.
+ *
+ *  The Original Code was created by Claudio Valderrama on 16-Mar-2007
+ *  for the Firebird Open Source RDBMS project.
+ *
+ *  Copyright (c) 2007 Claudio Valderrama
+ *  and all contributors signed below.
+ *
+ *  All Rights Reserved.
+ *  Contributor(s): ______________________________________.
+ *	Alex Peshkoff, 2017
+ *
+ */
+
+#include "firebird.h"
+#include "BlobWrapper.h"
+#include "../jrd/ibase.h"
+#include "firebird/Interface.h"
+
+static const USHORT SEGMENT_LIMIT = 65535;
+
+using namespace Firebird;
+
+bool BlobWrapper::open(IAttachment* db, ITransaction* trans, ISC_QUAD& blobid,
+					USHORT bpb_len, const UCHAR* bpb)
+{
+	if (m_direction != dir_none)
+		return false;
+
+	if (bpb_len > 0 && !bpb || blobIsNull(blobid))
+		return false;
+
+	m_blob = db->openBlob(m_status, trans, &blobid, bpb_len, bpb);
+	if (m_status->isEmpty())
+	{
+		m_direction = dir_read;
+		return true;
+	}
+	return false;
+}
+
+bool BlobWrapper::create(IAttachment* db, ITransaction* trans, ISC_QUAD& blobid,
+			USHORT bpb_len, const UCHAR* bpb)
+{
+	if (m_direction != dir_none)
+		return false;
+
+	if (bpb_len > 0 && !bpb)
+		return false;
+
+	blobid.gds_quad_high = blobid.gds_quad_low = 0;
+	m_blob = db->createBlob(m_status, trans, &blobid, bpb_len, bpb);
+	if (m_status->isEmpty())
+	{
+		m_direction = dir_write;
+		return true;
+	}
+	return false;
+}
+
+bool BlobWrapper::close(bool force_internal_SV)
+{
+	bool rc = false;
+	if (m_blob)
+	{
+		m_blob->close(force_internal_SV ? &m_default_status : m_status);
+		rc = (force_internal_SV ? &m_default_status : m_status)->isEmpty();
+		if (rc)
+			m_blob = nullptr;
+		m_direction = dir_none;
+	}
+	return rc;
+}
+
+bool BlobWrapper::getSegment(FB_SIZE_T len, void* buffer, FB_SIZE_T& real_len)
+{
+	real_len = 0;
+
+	if (!m_blob || m_direction != dir_read)
+		return false;
+
+	if (!len || !buffer)
+		return false;
+
+	unsigned ilen = len > SEGMENT_LIMIT ? SEGMENT_LIMIT : static_cast<unsigned>(len);
+	unsigned olen = 0;
+	bool eof = m_blob->getSegment(m_status, ilen, buffer, &olen) == Firebird::IStatus::RESULT_NO_DATA;
+	if (m_status->isEmpty() && !eof)
+	{
+		real_len = olen;
+		return true;
+	}
+	return false;
+}
+
+bool BlobWrapper::getData(FB_SIZE_T len, void* buffer, FB_SIZE_T& real_len,
+						bool use_sep, const UCHAR separator)
+{
+#ifdef DEV_BUILD
+	if (!m_blob || m_direction != dir_read)
+		return false;
+
+	if (!len || !buffer)
+		return false;
+#endif
+
+	bool rc = false;
+	real_len = 0;
+	char* buf2 = static_cast<char*>(buffer);
+	while (len)
+	{
+		unsigned olen = 0;
+		bool eof = m_blob->getSegment(m_status, len, buf2, &olen) == Firebird::IStatus::RESULT_NO_DATA;
+		if (m_status->isEmpty() && !eof)
+		{
+			len -= olen;
+			buf2 += olen;
+			real_len += olen;
+			if (len && use_sep) // Append the segment separator.
+			{
+				--len;
+				*buf2++ = separator;
+				++real_len;
+			}
+			rc = true;
+		}
+		else
+			break;
+	}
+	return rc;
+}
+
+bool BlobWrapper::putSegment(FB_SIZE_T len, const void* buffer)
+{
+#ifdef DEV_BUILD
+	if (!m_blob || m_direction != dir_write)
+		return false;
+
+	if (len > 0 && !buffer)
+		return false;
+#endif
+
+	unsigned ilen = len > SEGMENT_LIMIT ? SEGMENT_LIMIT : static_cast<unsigned>(len);
+	m_blob->putSegment(m_status, ilen, buffer);
+	return m_status->isEmpty();
+}
+
+bool BlobWrapper::putSegment(FB_SIZE_T len, const void* buffer, FB_SIZE_T& real_len)
+{
+#ifdef DEV_BUILD
+	if (!m_blob || m_direction == dir_read)
+		return false;
+
+	if (len > 0 && !buffer)
+		return false;
+#endif
+
+	real_len = 0;
+	unsigned ilen = len > SEGMENT_LIMIT ? SEGMENT_LIMIT : static_cast<unsigned>(len);
+	m_blob->putSegment(m_status, ilen, buffer);
+	if (!m_status->isEmpty())
+		return false;
+
+	real_len = ilen;
+	return true;
+}
+
+bool BlobWrapper::putData(FB_SIZE_T len, const void* buffer, FB_SIZE_T& real_len)
+{
+	if (!m_blob || m_direction == dir_read)
+		return false;
+
+	if (len > 0 && !buffer)
+		return false;
+
+	real_len = 0;
+	m_blob->putSegment(m_status, len, buffer);
+	if (!m_status->isEmpty())
+		return false;
+
+	real_len = len;
+	return true;
+}
+
+bool BlobWrapper::getInfo(FB_SIZE_T items_size, const UCHAR* items,
+					   FB_SIZE_T info_size, UCHAR* blob_info) const
+{
+	if (!m_blob || m_direction != dir_read)
+		return false;
+
+	m_blob->getInfo(m_status, items_size, items, info_size, blob_info);
+	return m_status->isEmpty();
+}
+
+bool BlobWrapper::getSize(SLONG* size, SLONG* seg_count, SLONG* max_seg) const
+{
+/**************************************
+ *
+ *	g e t B l o b S i z e
+ *
+ **************************************
+ *
+ * Functional description
+ *	Get the size, number of segments, and max
+ *	segment length of a blob.  Return true
+ *	if it happens to succeed.
+ *	This is a clone of gds__blob_size.
+ *
+ **************************************/
+	static const UCHAR blob_items[] =
+	{
+		isc_info_blob_max_segment,
+		isc_info_blob_num_segments,
+		isc_info_blob_total_length
+	};
+
+	UCHAR buffer[64];
+
+	if (!getInfo(sizeof(blob_items), blob_items, sizeof(buffer), buffer))
+		return false;
+
+	const UCHAR* p = buffer;
+	const UCHAR* const end = buffer + sizeof(buffer);
+	for (UCHAR item = *p++; item != isc_info_end && p < end; item = *p++)
+	{
+		const USHORT l = gds__vax_integer(p, 2);
+		p += 2;
+		const SLONG n = gds__vax_integer(p, l);
+		p += l;
+		switch (item)
+		{
+		case isc_info_blob_max_segment:
+			if (max_seg)
+				*max_seg = n;
+			break;
+
+		case isc_info_blob_num_segments:
+			if (seg_count)
+				*seg_count = n;
+			break;
+
+		case isc_info_blob_total_length:
+			if (size)
+				*size = n;
+			break;
+
+		default:
+			return false;
+		}
+	}
+
+	return true;
+}

--- a/src/common/classes/BlobWrapper.cpp
+++ b/src/common/classes/BlobWrapper.cpp
@@ -89,7 +89,7 @@ bool BlobWrapper::getSegment(FB_SIZE_T len, void* buffer, FB_SIZE_T& real_len)
 	if (!m_blob || m_direction != dir_read)
 		return false;
 
-	if (!len || !buffer)
+	if (len && !buffer)
 		return false;
 
 	unsigned ilen = len > SEGMENT_LIMIT ? SEGMENT_LIMIT : static_cast<unsigned>(len);

--- a/src/common/classes/BlobWrapper.cpp
+++ b/src/common/classes/BlobWrapper.cpp
@@ -126,17 +126,20 @@ bool BlobWrapper::getData(FB_SIZE_T len, void* buffer, FB_SIZE_T& real_len,
 			len -= olen;
 			buf2 += olen;
 			real_len += olen;
+
 			if (len && use_sep) // Append the segment separator.
 			{
 				--len;
 				*buf2++ = separator;
 				++real_len;
 			}
+
 			rc = true;
 		}
 		else
 			break;
 	}
+
 	return rc;
 }
 
@@ -168,6 +171,7 @@ bool BlobWrapper::putSegment(FB_SIZE_T len, const void* buffer, FB_SIZE_T& real_
 	real_len = 0;
 	unsigned ilen = len > SEGMENT_LIMIT ? SEGMENT_LIMIT : static_cast<unsigned>(len);
 	m_blob->putSegment(m_status, ilen, buffer);
+
 	if (!m_status->isEmpty())
 		return false;
 
@@ -185,6 +189,7 @@ bool BlobWrapper::putData(FB_SIZE_T len, const void* buffer, FB_SIZE_T& real_len
 
 	real_len = 0;
 	m_blob->putSegment(m_status, len, buffer);
+
 	if (!m_status->isEmpty())
 		return false;
 
@@ -199,6 +204,7 @@ bool BlobWrapper::getInfo(FB_SIZE_T items_size, const UCHAR* items,
 		return false;
 
 	m_blob->getInfo(m_status, items_size, items, info_size, blob_info);
+
 	return m_status->isEmpty();
 }
 
@@ -231,12 +237,14 @@ bool BlobWrapper::getSize(SLONG* size, SLONG* seg_count, SLONG* max_seg) const
 
 	const UCHAR* p = buffer;
 	const UCHAR* const end = buffer + sizeof(buffer);
+
 	for (UCHAR item = *p++; item != isc_info_end && p < end; item = *p++)
 	{
 		const USHORT l = gds__vax_integer(p, 2);
 		p += 2;
 		const SLONG n = gds__vax_integer(p, l);
 		p += l;
+
 		switch (item)
 		{
 		case isc_info_blob_max_segment:

--- a/src/common/classes/BlobWrapper.h
+++ b/src/common/classes/BlobWrapper.h
@@ -1,0 +1,95 @@
+/*
+ *  The contents of this file are subject to the Initial
+ *  Developer's Public License Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *  http://www.ibphoenix.com/main.nfs?a=ibphoenix&page=ibp_idpl.
+ *
+ *  Software distributed under the License is distributed AS IS,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing rights
+ *  and limitations under the License.
+ *
+ *  The Original Code was created by Claudio Valderrama on 16-Mar-2007
+ *  for the Firebird Open Source RDBMS project.
+ *
+ *  Copyright (c) 2007 Claudio Valderrama
+ *  and all contributors signed below.
+ *
+ *  All Rights Reserved.
+ *  Contributor(s): ______________________________________.
+ *	Alex Peshkoff, 2017
+ *
+ */
+
+#ifndef FB_USER_BLOB_H
+#define FB_USER_BLOB_H
+
+#include "firebird/Interface.h"
+#include <memory.h>
+#include "../common/status.h"
+
+class BlobWrapper
+{
+public:
+	explicit BlobWrapper(Firebird::CheckStatusWrapper* status)
+		: m_status(status ? status : &m_default_status), m_blob(nullptr), m_direction(dir_none)
+	{ }
+
+	~BlobWrapper()
+	{
+		close(true);
+	}
+
+	bool open(Firebird::IAttachment* db, Firebird::ITransaction* trans, ISC_QUAD& blobid,
+				USHORT bpb_len = 0, const UCHAR* bpb = nullptr);
+	bool create(Firebird::IAttachment* db, Firebird::ITransaction* trans, ISC_QUAD& blobid,
+				USHORT bpb_len = 0, const UCHAR* bpb = nullptr);
+	bool close(bool force_internal_SV = false);
+	bool getSegment(FB_SIZE_T len, void* buffer, FB_SIZE_T& real_len);
+	bool getData(FB_SIZE_T len, void* buffer, FB_SIZE_T& real_len, bool use_sep = false, const UCHAR separator = '\0');
+	bool putSegment(FB_SIZE_T len, const void* buffer);
+	bool putSegment(FB_SIZE_T len, const void* buffer, FB_SIZE_T& real_len);
+	bool putData(FB_SIZE_T len, const void* buffer, FB_SIZE_T& real_len);
+	bool putData(FB_SIZE_T len, const void* buffer)
+	{
+		FB_SIZE_T dummy;
+		return putData(len, buffer, dummy);
+	}
+
+	bool isOpen() const
+	{
+		return m_blob != 0 && m_direction != dir_none;
+	}
+
+	ISC_STATUS getCode() const
+	{
+		return m_status->getErrors()[1];
+	}
+
+	bool getInfo(FB_SIZE_T items_size, const UCHAR* items, FB_SIZE_T info_size, UCHAR* blob_info) const;
+	bool getSize(SLONG* size, SLONG* seg_count, SLONG* max_seg) const;
+
+	static bool blobIsNull(const ISC_QUAD& blobid)
+	{
+		return blobid.gds_quad_high == 0 && blobid.gds_quad_low == 0;
+	}
+
+private:
+	enum b_direction
+	{
+		dir_none,
+		dir_read,
+		dir_write
+	};
+
+	Firebird::FbLocalStatus m_default_status;
+	Firebird::CheckStatusWrapper* const m_status;
+	Firebird::IBlob* m_blob;
+	b_direction m_direction;
+};
+
+
+
+#endif // FB_USER_BLOB_H
+

--- a/src/common/classes/alloc.h
+++ b/src/common/classes/alloc.h
@@ -224,12 +224,6 @@ public:
 	// previously set group and added to new
 	void setStatsGroup(MemoryStats& stats) FB_NOTHROW;
 
-	// Just a helper for AutoPtr.
-	static void clear(MemoryPool* pool)
-	{
-		deletePool(pool);
-	}
-
 	// Initialize and finalize global memory pool
 	static void init();
 	static void cleanup();
@@ -451,7 +445,14 @@ namespace Firebird
 		explicit AutoStorage(MemoryPool& p) : PermanentStorage(p) { }
 	};
 
-	typedef AutoPtr<MemoryPool, MemoryPool> AutoMemoryPool;
+	template <>
+	inline void SimpleDelete<MemoryPool>::clear(MemoryPool* pool)
+	{
+		if (pool)
+			MemoryPool::deletePool(pool);
+	}
+
+	typedef AutoPtr<MemoryPool> AutoMemoryPool;
 
 } // namespace Firebird
 

--- a/src/common/classes/auto.h
+++ b/src/common/classes/auto.h
@@ -168,6 +168,16 @@ private:
 };
 
 
+template <typename ID>
+class AutoDispose : public AutoPtr<ID, SimpleDispose<ID> >
+{
+public:
+	AutoDispose(ID* v = nullptr)
+		: AutoPtr<ID, SimpleDispose<ID> >(v)
+	{ }
+};
+
+
 template <typename T>
 class AutoSetRestore
 {

--- a/src/common/classes/auto.h
+++ b/src/common/classes/auto.h
@@ -46,6 +46,15 @@ public:
 	}
 };
 
+template <>
+inline void SimpleDelete<FILE>::clear(FILE* f)
+{
+	if (f) {
+		fclose(f);
+	}
+}
+
+
 template <typename What>
 class ArrayDelete
 {
@@ -55,6 +64,7 @@ public:
 		delete[] ptr;
 	}
 };
+
 
 template <typename T>
 class SimpleRelease
@@ -84,24 +94,24 @@ public:
 };
 
 
-template <typename Where, typename Clear = SimpleDelete<Where> >
+template <typename Where, template <typename W> class Clear = SimpleDelete >
 class AutoPtr
 {
 private:
 	Where* ptr;
 public:
-	AutoPtr<Where, Clear>(Where* v = NULL)
+	AutoPtr(Where* v = NULL)
 		: ptr(v)
 	{}
 
 	~AutoPtr()
 	{
-		Clear::clear(ptr);
+		Clear<Where>::clear(ptr);
 	}
 
-	AutoPtr<Where, Clear>& operator= (Where* v)
+	AutoPtr& operator= (Where* v)
 	{
-		Clear::clear(ptr);
+		Clear<Where>::clear(ptr);
 		ptr = v;
 		return *this;
 	}
@@ -157,23 +167,23 @@ public:
 	{
 		if (v != ptr)
 		{
-			Clear::clear(ptr);
+			Clear<Where>::clear(ptr);
 			ptr = v;
 		}
 	}
 
 private:
-	AutoPtr<Where, Clear>(AutoPtr<Where, Clear>&);
-	void operator=(AutoPtr<Where, Clear>&);
+	AutoPtr(AutoPtr&);
+	void operator=(AutoPtr&);
 };
 
 
 template <typename ID>
-class AutoDispose : public AutoPtr<ID, SimpleDispose<ID> >
+class AutoDispose : public AutoPtr<ID, SimpleDispose>
 {
 public:
 	AutoDispose(ID* v = nullptr)
-		: AutoPtr<ID, SimpleDispose<ID> >(v)
+		: AutoPtr<ID, SimpleDispose>(v)
 	{ }
 };
 
@@ -266,19 +276,6 @@ private:
 	T2* pointer;
 	Setter setter;
 	T oldValue;
-};
-
-
-// One more typical class for AutoPtr cleanup
-class FileClose
-{
-public:
-	static void clear(FILE *f)
-	{
-		if (f) {
-			fclose(f);
-		}
-	}
 };
 
 

--- a/src/common/classes/init.cpp
+++ b/src/common/classes/init.cpp
@@ -93,7 +93,7 @@ namespace
 			return;
 
 #ifdef DEBUG_GDS_ALLOC
-		Firebird::AutoPtr<FILE, Firebird::FileClose> file;
+		Firebird::AutoPtr<FILE> file;
 
 		{	// scope
 			Firebird::PathName name = "memdebug.log";

--- a/src/common/classes/vector.h
+++ b/src/common/classes/vector.h
@@ -220,10 +220,10 @@ public:
 };
 
 
-// Templates to allow to iterate thru array\vector of values and process items 
+// Templates to allow to iterate thru array\vector of values and process items
 // in some way. Processed items are marked and skipped at next iteration circle.
-// Idea is to not remove processed items from array and avoid costly memory 
-// moving. Also, iterator is able to move upper and lower bounds of array if 
+// Idea is to not remove processed items from array and avoid costly memory
+// moving. Also, iterator is able to move upper and lower bounds of array if
 // last (or first) items are marked, making next iterations more efficient.
 
 template <typename T>

--- a/src/common/config/config_file.cpp
+++ b/src/common/config/config_file.cpp
@@ -109,7 +109,7 @@ public:
 	}
 
 private:
-	AutoPtr<FILE, FileClose> file;
+	AutoPtr<FILE> file;
 	Firebird::PathName fileName;
 	unsigned int l;
 };

--- a/src/common/status.h
+++ b/src/common/status.h
@@ -1,0 +1,116 @@
+/*
+ *	PROGRAM:		Firebird exceptions classes
+ *	MODULE:			status.h
+ *	DESCRIPTION:	Status vector filling and parsing.
+ *
+ *  The contents of this file are subject to the Initial
+ *  Developer's Public License Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *  http://www.ibphoenix.com/main.nfs?a=ibphoenix&page=ibp_idpl.
+ *
+ *  Software distributed under the License is distributed AS IS,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing rights
+ *  and limitations under the License.
+ *
+ *  The Original Code was created by Mike Nordell
+ *  for the Firebird Open Source RDBMS project.
+ *
+ *  Copyright (c) 2001 Mike Nordell <tamlin at algonet.se>
+ *  and all contributors signed below.
+ *
+ *  All Rights Reserved.
+ *  Contributor(s): ______________________________________.
+ *
+ */
+
+
+#ifndef COMMON_STATUS_H
+#define COMMON_STATUS_H
+
+#include "../common/StatusHolder.h"
+#include "../common/utils_proto.h"
+
+const int MAX_ERRMSG_LEN	= 128;
+const int MAX_ERRSTR_LEN	= 1024;
+
+namespace Firebird
+{
+	template <class SW>
+	class LocalStatusWrapper
+	{
+	public:
+		LocalStatusWrapper()
+			: localStatusVector(&localStatus)
+		{ }
+
+		explicit LocalStatusWrapper(Firebird::MemoryPool& p)
+			: localStatus(p), localStatusVector(&localStatus)
+		{ }
+
+		SW* operator->()
+		{
+			return &localStatusVector;
+		}
+
+		SW* operator&()
+		{
+			return &localStatusVector;
+		}
+
+		ISC_STATUS operator[](unsigned n) const
+		{
+			fb_assert(n < fb_utils::statusLength(localStatusVector.getErrors()));
+			return localStatusVector.getErrors()[n];
+		}
+
+		const SW* operator->() const
+		{
+			return &localStatusVector;
+		}
+
+		const SW* operator&() const
+		{
+			return &localStatusVector;
+		}
+
+		void check() const
+		{
+			if (localStatusVector.isDirty())
+			{
+				if (localStatus.getState() & Firebird::IStatus::STATE_ERRORS)
+					raise();
+			}
+		}
+
+		void copyTo(SW* to) const
+		{
+			fb_utils::copyStatus(to, &localStatusVector);
+		}
+
+		void raise() const
+		{
+			Firebird::status_exception::raise(&localStatus);
+		}
+
+		bool isEmpty() const
+		{
+			return localStatusVector.isEmpty();
+		}
+
+		bool isSuccess() const
+		{
+			return localStatusVector.isEmpty();
+		}
+
+	private:
+		Firebird::LocalStatus localStatus;
+		SW localStatusVector;
+	};
+
+	typedef LocalStatusWrapper<CheckStatusWrapper> FbLocalStatus;
+	typedef LocalStatusWrapper<ThrowStatusWrapper> ThrowLocalStatus;
+}
+
+#endif // COMMON_STATUS_H

--- a/src/dsql/DsqlBatch.cpp
+++ b/src/dsql/DsqlBatch.cpp
@@ -654,7 +654,7 @@ private:
 	fb_assert(req);
 
 	// prepare completion interface
-	AutoPtr<BatchCompletionState, SimpleDispose<BatchCompletionState> > completionState
+	AutoPtr<BatchCompletionState, SimpleDispose> completionState
 		(FB_NEW BatchCompletionState(m_flags & (1 << IBatch::TAG_RECORD_COUNTS), m_detailed));
 	AutoSetRestore<bool> batchFlag(&req->req_batch, true);
 	const dsql_msg* message = m_request->getStatement()->getSendMsg();

--- a/src/dsql/DsqlBatch.cpp
+++ b/src/dsql/DsqlBatch.cpp
@@ -586,6 +586,7 @@ private:
 							bid engineBlobId;
 							blob = blb::create2(tdbb, transaction, &engineBlobId, bpb->getCount(),
 								bpb->begin(), true);
+
 							//DEB_BATCH(fprintf(stderr, "B-ID: (%x,%x)\n", batchBlobId.gds_quad_high, batchBlobId.gds_quad_low));
 							registerBlob(reinterpret_cast<ISC_QUAD*>(&engineBlobId), &batchBlobId);
 						}

--- a/src/dsql/DsqlBatch.h
+++ b/src/dsql/DsqlBatch.h
@@ -107,7 +107,7 @@ private:
 	{
 	public:
 		DataCache(MemoryPool& p)
-			: PermanentStorage(p),
+			: PermanentStorage(p), m_cache(getPool()),
 			  m_used(0), m_got(0), m_limit(0), m_shift(0), m_cacheCapacity(0)
 		{ }
 

--- a/src/dsql/DsqlBatch.h
+++ b/src/dsql/DsqlBatch.h
@@ -108,10 +108,10 @@ private:
 	public:
 		DataCache(MemoryPool& p)
 			: PermanentStorage(p),
-			  m_used(0), m_got(0), m_limit(0), m_shift(0)
+			  m_used(0), m_got(0), m_limit(0), m_shift(0), m_cacheCapacity(0)
 		{ }
 
-		void setBuf(ULONG size);
+		void setBuf(ULONG size, ULONG cacheCapacity);
 
 		void put(const void* data, ULONG dataSize);
 		void put3(const void* data, ULONG dataSize, ULONG offset);
@@ -124,10 +124,10 @@ private:
 		void clear();
 
 	private:
-		typedef Firebird::Vector<UCHAR, DsqlBatch::RAM_BATCH, SINT64> Cache;
-		Firebird::AutoPtr<Cache> m_cache;
+		typedef Firebird::Array<UCHAR> Cache;
+		Cache m_cache;
 		Firebird::AutoPtr<TempSpace> m_space;
-		ULONG m_used, m_got, m_limit, m_shift;
+		ULONG m_used, m_got, m_limit, m_shift, m_cacheCapacity;
 	};
 
 	struct BlobMeta

--- a/src/dsql/Parser.h
+++ b/src/dsql/Parser.h
@@ -266,7 +266,7 @@ private:
 		clause = value;
 	}
 
-	template <typename T, typename Delete>
+	template <typename T, template <typename C> class Delete>
 	void setClause(Firebird::AutoPtr<T, Delete>& clause, const char* duplicateMsg, T* value)
 	{
 		checkDuplicateClause(clause, duplicateMsg);

--- a/src/gpre/obj_cxx.cpp
+++ b/src/gpre/obj_cxx.cpp
@@ -1075,10 +1075,9 @@ static void gen_blob_open( const act* action, USHORT column)
 		endp(column);
 		if (gpreGlob.sw_auto)
 			column -= INDENT;
-		set_sqlcode(action, column);
 		if (action->act_type == ACT_blob_create)
 		{
-			printa(column, "if (!SQLCODE)");
+			printa(column, "if (!(%s->getErrors() & Firebird::IStatus::STATE_ERRORS))", global_status_name);
 			align(column + INDENT);
 			fprintf(gpreGlob.out_file, "%s = %s;", reference->ref_value, s);
 		}
@@ -2235,6 +2234,8 @@ static void gen_finish( const act* action, int column)
 		db = ready->rdy_database;
 		printa(column, "%s->detach(%s);",
 			   db->dbb_name->sym_string, status_vector(action));
+		success(column, true, status_vector(action));
+		printa(column + INDENT, "%s = 0;", db->dbb_name->sym_string);
 	}
 	// no hanbdles, so we finish all known databases
 
@@ -2250,6 +2251,8 @@ static void gen_finish( const act* action, int column)
 				printa(column, "if (%s)", db->dbb_name->sym_string);
 			printa(column + INDENT, "%s->detach(%s);",
 				   db->dbb_name->sym_string, status_vector(action));
+			success(column, true, status_vector(action));
+			printa(column + INDENT, "%s = 0;", db->dbb_name->sym_string);
 		}
 	}
 
@@ -3357,8 +3360,6 @@ static void gen_t_start( const act* action, int column)
 
 		printa(column, "}\t\t// end fbComponents scope\n");
 	}
-
-	set_sqlcode(action, column);
 }
 
 
@@ -3435,9 +3436,10 @@ static void gen_trans( const act* action, int column)
 			   (action->act_type == ACT_commit) ?
 			   		"commit" : (action->act_type == ACT_rollback) ? "rollback" : "prepare",
 				status_vector(action));
+		success(column, true, status_vector(action));
+		printa(column + INDENT, "%s = 0;", tranText);
+		break;
 	}
-
-	set_sqlcode(action, column);
 }
 
 

--- a/src/include/fb_types.h
+++ b/src/include/fb_types.h
@@ -125,6 +125,7 @@ typedef void (*ErrorFunction) (const Firebird::Arg::StatusVector& v);
 typedef void (*FPTR_ERROR) (ISC_STATUS, ...);
 
 typedef ULONG RCRD_OFFSET;
+typedef ULONG RCRD_LENGTH;
 typedef USHORT FLD_LENGTH;
 /* CVC: internal usage. I suspect the only reason to return int is that
 vmslock.cpp:LOCK_convert() calls VMS' sys$enq that may require this signature,

--- a/src/include/firebird/FirebirdInterface.idl
+++ b/src/include/firebird/FirebirdInterface.idl
@@ -514,15 +514,15 @@ interface Pipe : ReferenceCounted
 interface Request : ReferenceCounted
 {
 	void receive(Status status, int level, uint msgType,
-						 uint length, uchar* message);
+						 uint length, void* message);
 	void send(Status status, int level, uint msgType,
-					  uint length, const uchar* message);
+					  uint length, const void* message);
 	void getInfo(Status status, int level,
 						 uint itemsLength, const uchar* items,
 						 uint bufferLength, uchar* buffer);
 	void start(Status status, Transaction tra, int level);
 	void startAndSend(Status status, Transaction tra, int level, uint msgType,
-							  uint length, const uchar* message);
+							  uint length, const void* message);
 	void unwind(Status status, int level);
 	void free(Status status);
 }

--- a/src/include/firebird/FirebirdInterface.idl
+++ b/src/include/firebird/FirebirdInterface.idl
@@ -600,7 +600,6 @@ version:	// 3.0 => 4.0
 	Batch createBatch(Status status, Transaction transaction, uint stmtLength, const string sqlStmt,
 		uint dialect, MessageMetadata inMetadata, uint parLength, const uchar* par);
 
-	uint getRemoteProtocolVersion(Status status);
 	/*
 	Pipe createPipe(Status status, uint stmtLength, const string sqlStmt, uint dialect,
 		Transaction transaction, MessageMetadata inMetadata, void* inBuffer,

--- a/src/include/firebird/FirebirdInterface.idl
+++ b/src/include/firebird/FirebirdInterface.idl
@@ -599,6 +599,8 @@ version:	// 3.0 => 4.0
 	// Batch API
 	Batch createBatch(Status status, Transaction transaction, uint stmtLength, const string sqlStmt,
 		uint dialect, MessageMetadata inMetadata, uint parLength, const uchar* par);
+
+	uint getRemoteProtocolVersion(Status status);
 	/*
 	Pipe createPipe(Status status, uint stmtLength, const string sqlStmt, uint dialect,
 		Transaction transaction, MessageMetadata inMetadata, void* inBuffer,

--- a/src/include/firebird/IdlFbInterfaces.h
+++ b/src/include/firebird/IdlFbInterfaces.h
@@ -2122,7 +2122,6 @@ namespace Firebird
 			unsigned (CLOOP_CARG *getStatementTimeout)(IAttachment* self, IStatus* status) throw();
 			void (CLOOP_CARG *setStatementTimeout)(IAttachment* self, IStatus* status, unsigned timeOut) throw();
 			IBatch* (CLOOP_CARG *createBatch)(IAttachment* self, IStatus* status, ITransaction* transaction, unsigned stmtLength, const char* sqlStmt, unsigned dialect, IMessageMetadata* inMetadata, unsigned parLength, const unsigned char* par) throw();
-			unsigned (CLOOP_CARG *getRemoteProtocolVersion)(IAttachment* self, IStatus* status) throw();
 		};
 
 	protected:
@@ -2338,20 +2337,6 @@ namespace Firebird
 			}
 			StatusType::clearException(status);
 			IBatch* ret = static_cast<VTable*>(this->cloopVTable)->createBatch(this, status, transaction, stmtLength, sqlStmt, dialect, inMetadata, parLength, par);
-			StatusType::checkException(status);
-			return ret;
-		}
-
-		template <typename StatusType> unsigned getRemoteProtocolVersion(StatusType* status)
-		{
-			if (cloopVTable->version < 4)
-			{
-				StatusType::setVersionError(status, "IAttachment", cloopVTable->version, 4);
-				StatusType::checkException(status);
-				return 0;
-			}
-			StatusType::clearException(status);
-			unsigned ret = static_cast<VTable*>(this->cloopVTable)->getRemoteProtocolVersion(this, status);
 			StatusType::checkException(status);
 			return ret;
 		}
@@ -9815,7 +9800,6 @@ namespace Firebird
 					this->getStatementTimeout = &Name::cloopgetStatementTimeoutDispatcher;
 					this->setStatementTimeout = &Name::cloopsetStatementTimeoutDispatcher;
 					this->createBatch = &Name::cloopcreateBatchDispatcher;
-					this->getRemoteProtocolVersion = &Name::cloopgetRemoteProtocolVersionDispatcher;
 				}
 			} vTable;
 
@@ -10157,21 +10141,6 @@ namespace Firebird
 			}
 		}
 
-		static unsigned CLOOP_CARG cloopgetRemoteProtocolVersionDispatcher(IAttachment* self, IStatus* status) throw()
-		{
-			StatusType status2(status);
-
-			try
-			{
-				return static_cast<Name*>(self)->Name::getRemoteProtocolVersion(&status2);
-			}
-			catch (...)
-			{
-				StatusType::catchException(&status2);
-				return static_cast<unsigned>(0);
-			}
-		}
-
 		static void CLOOP_CARG cloopaddRefDispatcher(IReferenceCounted* self) throw()
 		{
 			try
@@ -10234,7 +10203,6 @@ namespace Firebird
 		virtual unsigned getStatementTimeout(StatusType* status) = 0;
 		virtual void setStatementTimeout(StatusType* status, unsigned timeOut) = 0;
 		virtual IBatch* createBatch(StatusType* status, ITransaction* transaction, unsigned stmtLength, const char* sqlStmt, unsigned dialect, IMessageMetadata* inMetadata, unsigned parLength, const unsigned char* par) = 0;
-		virtual unsigned getRemoteProtocolVersion(StatusType* status) = 0;
 	};
 
 	template <typename Name, typename StatusType, typename Base>

--- a/src/include/firebird/IdlFbInterfaces.h
+++ b/src/include/firebird/IdlFbInterfaces.h
@@ -1931,11 +1931,11 @@ namespace Firebird
 	public:
 		struct VTable : public IReferenceCounted::VTable
 		{
-			void (CLOOP_CARG *receive)(IRequest* self, IStatus* status, int level, unsigned msgType, unsigned length, unsigned char* message) throw();
-			void (CLOOP_CARG *send)(IRequest* self, IStatus* status, int level, unsigned msgType, unsigned length, const unsigned char* message) throw();
+			void (CLOOP_CARG *receive)(IRequest* self, IStatus* status, int level, unsigned msgType, unsigned length, void* message) throw();
+			void (CLOOP_CARG *send)(IRequest* self, IStatus* status, int level, unsigned msgType, unsigned length, const void* message) throw();
 			void (CLOOP_CARG *getInfo)(IRequest* self, IStatus* status, int level, unsigned itemsLength, const unsigned char* items, unsigned bufferLength, unsigned char* buffer) throw();
 			void (CLOOP_CARG *start)(IRequest* self, IStatus* status, ITransaction* tra, int level) throw();
-			void (CLOOP_CARG *startAndSend)(IRequest* self, IStatus* status, ITransaction* tra, int level, unsigned msgType, unsigned length, const unsigned char* message) throw();
+			void (CLOOP_CARG *startAndSend)(IRequest* self, IStatus* status, ITransaction* tra, int level, unsigned msgType, unsigned length, const void* message) throw();
 			void (CLOOP_CARG *unwind)(IRequest* self, IStatus* status, int level) throw();
 			void (CLOOP_CARG *free)(IRequest* self, IStatus* status) throw();
 		};
@@ -1953,14 +1953,14 @@ namespace Firebird
 	public:
 		static const unsigned VERSION = 3;
 
-		template <typename StatusType> void receive(StatusType* status, int level, unsigned msgType, unsigned length, unsigned char* message)
+		template <typename StatusType> void receive(StatusType* status, int level, unsigned msgType, unsigned length, void* message)
 		{
 			StatusType::clearException(status);
 			static_cast<VTable*>(this->cloopVTable)->receive(this, status, level, msgType, length, message);
 			StatusType::checkException(status);
 		}
 
-		template <typename StatusType> void send(StatusType* status, int level, unsigned msgType, unsigned length, const unsigned char* message)
+		template <typename StatusType> void send(StatusType* status, int level, unsigned msgType, unsigned length, const void* message)
 		{
 			StatusType::clearException(status);
 			static_cast<VTable*>(this->cloopVTable)->send(this, status, level, msgType, length, message);
@@ -1981,7 +1981,7 @@ namespace Firebird
 			StatusType::checkException(status);
 		}
 
-		template <typename StatusType> void startAndSend(StatusType* status, ITransaction* tra, int level, unsigned msgType, unsigned length, const unsigned char* message)
+		template <typename StatusType> void startAndSend(StatusType* status, ITransaction* tra, int level, unsigned msgType, unsigned length, const void* message)
 		{
 			StatusType::clearException(status);
 			static_cast<VTable*>(this->cloopVTable)->startAndSend(this, status, tra, level, msgType, length, message);
@@ -9401,7 +9401,7 @@ namespace Firebird
 			this->cloopVTable = &vTable;
 		}
 
-		static void CLOOP_CARG cloopreceiveDispatcher(IRequest* self, IStatus* status, int level, unsigned msgType, unsigned length, unsigned char* message) throw()
+		static void CLOOP_CARG cloopreceiveDispatcher(IRequest* self, IStatus* status, int level, unsigned msgType, unsigned length, void* message) throw()
 		{
 			StatusType status2(status);
 
@@ -9415,7 +9415,7 @@ namespace Firebird
 			}
 		}
 
-		static void CLOOP_CARG cloopsendDispatcher(IRequest* self, IStatus* status, int level, unsigned msgType, unsigned length, const unsigned char* message) throw()
+		static void CLOOP_CARG cloopsendDispatcher(IRequest* self, IStatus* status, int level, unsigned msgType, unsigned length, const void* message) throw()
 		{
 			StatusType status2(status);
 
@@ -9457,7 +9457,7 @@ namespace Firebird
 			}
 		}
 
-		static void CLOOP_CARG cloopstartAndSendDispatcher(IRequest* self, IStatus* status, ITransaction* tra, int level, unsigned msgType, unsigned length, const unsigned char* message) throw()
+		static void CLOOP_CARG cloopstartAndSendDispatcher(IRequest* self, IStatus* status, ITransaction* tra, int level, unsigned msgType, unsigned length, const void* message) throw()
 		{
 			StatusType status2(status);
 
@@ -9538,11 +9538,11 @@ namespace Firebird
 		{
 		}
 
-		virtual void receive(StatusType* status, int level, unsigned msgType, unsigned length, unsigned char* message) = 0;
-		virtual void send(StatusType* status, int level, unsigned msgType, unsigned length, const unsigned char* message) = 0;
+		virtual void receive(StatusType* status, int level, unsigned msgType, unsigned length, void* message) = 0;
+		virtual void send(StatusType* status, int level, unsigned msgType, unsigned length, const void* message) = 0;
 		virtual void getInfo(StatusType* status, int level, unsigned itemsLength, const unsigned char* items, unsigned bufferLength, unsigned char* buffer) = 0;
 		virtual void start(StatusType* status, ITransaction* tra, int level) = 0;
-		virtual void startAndSend(StatusType* status, ITransaction* tra, int level, unsigned msgType, unsigned length, const unsigned char* message) = 0;
+		virtual void startAndSend(StatusType* status, ITransaction* tra, int level, unsigned msgType, unsigned length, const void* message) = 0;
 		virtual void unwind(StatusType* status, int level) = 0;
 		virtual void free(StatusType* status) = 0;
 	};

--- a/src/intl/lc_icu.cpp
+++ b/src/intl/lc_icu.cpp
@@ -99,7 +99,7 @@ static bool texttype_unicode_init(texttype* tt,
 	// test if that charset exist
 	if (!LD_lookup_charset(cs, charSetName, configInfo))
 	{
-		Jrd::CharSet::Delete::clear(cs);
+		Firebird::SimpleDelete<charset>::clear(cs);
 		return false;
 	}
 
@@ -120,7 +120,7 @@ bool LCICU_setup_attributes(const ASCII* name, const ASCII* charSetName, const A
 
 	if (len > 8 && strcmp(name + len - 8, "_UNICODE") == 0)
 	{
-		AutoPtr<charset, Jrd::CharSet::Delete> cs(FB_NEW_POOL(*getDefaultMemoryPool()) charset);
+		AutoPtr<charset> cs(FB_NEW_POOL(*getDefaultMemoryPool()) charset);
 		memset(cs, 0, sizeof(*cs));
 
 		// test if that charset exist

--- a/src/isql/isql.epp
+++ b/src/isql/isql.epp
@@ -311,7 +311,7 @@ static inline int fb_isdigit(const char c)
 
 IsqlGlobals::IsqlGlobals()
 {
-	Firebird::AutoPtr<Firebird::IStatus, Firebird::SimpleDispose<Firebird::IStatus> >
+	Firebird::AutoPtr<Firebird::IStatus, Firebird::SimpleDispose>
 		status_vector(fbMaster->getStatus());
 	Firebird::CheckStatusWrapper statusWrapper(status_vector);
 

--- a/src/isql/show.epp
+++ b/src/isql/show.epp
@@ -392,7 +392,7 @@ bool SHOW_dbb_parameters(Firebird::IAttachment* db_handle,
 	UCHAR buffer[BUFFER_LENGTH400];
 	TEXT msg[MSG_LENGTH];
 
-	Firebird::AutoPtr<Firebird::IStatus, Firebird::SimpleDispose<Firebird::IStatus> >
+	Firebird::AutoPtr<Firebird::IStatus, Firebird::SimpleDispose>
 		status_vector(fbMaster->getStatus());
 	Firebird::CheckStatusWrapper statusWrapper(status_vector);
 	db_handle->getInfo(&statusWrapper, item_length, db_itemsL, sizeof(buffer), buffer);

--- a/src/jrd/CryptoManager.cpp
+++ b/src/jrd/CryptoManager.cpp
@@ -70,18 +70,16 @@ namespace {
 
 	const int MAX_PLUGIN_NAME_LEN = 31;
 
+	template <typename P>
 	class ReleasePlugin
 	{
 	public:
-		static void clear(IPluginBase* ptr)
+		static void clear(P* ptr)
 		{
 			if (ptr)
-			{
 				PluginManagerInterfacePtr()->releasePlugin(ptr);
-			}
 		}
 	};
-
 }
 
 
@@ -271,7 +269,7 @@ namespace Jrd {
 		}
 
 	private:
-		AutoPtr<UCHAR, ArrayDelete<UCHAR> > buffer;
+		AutoPtr<UCHAR, ArrayDelete> buffer;
 	};
 
 	CryptoManager::CryptoManager(thread_db* tdbb)

--- a/src/jrd/EngineInterface.h
+++ b/src/jrd/EngineInterface.h
@@ -277,15 +277,15 @@ public:
 	// IRequest implementation
 	int release();
 	void receive(Firebird::CheckStatusWrapper* status, int level, unsigned int msg_type,
-		unsigned int length, unsigned char* message);
+		unsigned int length, void* message);
 	void send(Firebird::CheckStatusWrapper* status, int level, unsigned int msg_type,
-		unsigned int length, const unsigned char* message);
+		unsigned int length, const void* message);
 	void getInfo(Firebird::CheckStatusWrapper* status, int level,
 		unsigned int itemsLength, const unsigned char* items,
 		unsigned int bufferLength, unsigned char* buffer);
 	void start(Firebird::CheckStatusWrapper* status, Firebird::ITransaction* tra, int level);
 	void startAndSend(Firebird::CheckStatusWrapper* status, Firebird::ITransaction* tra, int level,
-		unsigned int msg_type, unsigned int length, const unsigned char* message);
+		unsigned int msg_type, unsigned int length, const void* message);
 	void unwind(Firebird::CheckStatusWrapper* status, int level);
 	void free(Firebird::CheckStatusWrapper* status);
 

--- a/src/jrd/EngineInterface.h
+++ b/src/jrd/EngineInterface.h
@@ -396,7 +396,6 @@ public:
 	Firebird::IBatch* createBatch(Firebird::CheckStatusWrapper* status, Firebird::ITransaction* transaction,
 		unsigned stmtLength, const char* sqlStmt, unsigned dialect,
 		Firebird::IMessageMetadata* inMetadata, unsigned parLength, const unsigned char* par);
-	unsigned int getRemoteProtocolVersion(Firebird::CheckStatusWrapper* status);
 
 public:
 	explicit JAttachment(StableAttachmentPart* js);

--- a/src/jrd/EngineInterface.h
+++ b/src/jrd/EngineInterface.h
@@ -396,6 +396,7 @@ public:
 	Firebird::IBatch* createBatch(Firebird::CheckStatusWrapper* status, Firebird::ITransaction* transaction,
 		unsigned stmtLength, const char* sqlStmt, unsigned dialect,
 		Firebird::IMessageMetadata* inMetadata, unsigned parLength, const unsigned char* par);
+	unsigned int getRemoteProtocolVersion(Firebird::CheckStatusWrapper* status);
 
 public:
 	explicit JAttachment(StableAttachmentPart* js);

--- a/src/jrd/Mapping.cpp
+++ b/src/jrd/Mapping.cpp
@@ -1089,7 +1089,7 @@ private:
 					par.getMetadata(), par.getBuffer(), nullptr, nullptr, 0));
 
 				RefPtr<IMessageMetadata> meta(curs->getMetadata(&st));
-				AutoPtr<UCHAR, ArrayDelete<UCHAR> > buffer(FB_NEW UCHAR[meta->getMessageLength(&st)]);
+				AutoPtr<UCHAR, ArrayDelete> buffer(FB_NEW UCHAR[meta->getMessageLength(&st)]);
 				UCHAR* bits = buffer + meta->getOffset(&st, 0);
 				UserId::Privileges g, l;
 

--- a/src/jrd/btr.cpp
+++ b/src/jrd/btr.cpp
@@ -2249,7 +2249,7 @@ bool BTR_types_comparable(const dsc& target, const dsc& source)
 		return (source.dsc_dtype <= dtype_long || source.dsc_dtype == dtype_int64);
 
 	if (DTYPE_IS_NUMERIC(target.dsc_dtype))
-		return (source.dsc_dtype <= dtype_double || source.dsc_dtype == dtype_int64);		//!!!!!!!!
+		return (source.dsc_dtype <= dtype_double || source.dsc_dtype == dtype_int64);
 
 	if (target.dsc_dtype == dtype_sql_date)
 		return (source.dsc_dtype <= dtype_sql_date || source.dsc_dtype == dtype_timestamp);

--- a/src/jrd/cch.cpp
+++ b/src/jrd/cch.cpp
@@ -2538,7 +2538,7 @@ static void flushDirty(thread_db* tdbb, SLONG transaction_mask, const bool sys_o
 
 
 // Collect pages modified by garbage collector or all dirty pages or release page
-// locks - depending of flush_flag, and write it to disk. 
+// locks - depending of flush_flag, and write it to disk.
 // See also comments in flushPages.
 static void flushAll(thread_db* tdbb, USHORT flush_flag)
 {
@@ -2603,7 +2603,7 @@ extern "C" {
 } // extern C
 
 
-// Write array of pages to disk in efficient order. 
+// Write array of pages to disk in efficient order.
 // First, sort pages by their numbers to make writes physically ordered and
 // thus faster. At every iteration of while loop write pages which have no high
 // precedence pages to ensure order preserved. If after some iteration there are

--- a/src/jrd/exe.cpp
+++ b/src/jrd/exe.cpp
@@ -614,7 +614,7 @@ void EXE_receive(thread_db* tdbb,
 				 jrd_req* request,
 				 USHORT msg,
 				 ULONG length,
-				 UCHAR* buffer,
+				 void* buffer,
 				 bool top_level)
 {
 /**************************************
@@ -692,7 +692,7 @@ void EXE_receive(thread_db* tdbb,
 
 			if (desc->isBlob())
 			{
-				const bid* id = (bid*) (buffer + (ULONG)(IPTR)desc->dsc_address);
+				const bid* id = (bid*) (reinterpret_cast<UCHAR*>(buffer) + (ULONG)(IPTR)desc->dsc_address);
 
 				if (transaction->tra_blobs->locate(id->bid_temp_id()))
 				{
@@ -766,7 +766,7 @@ void EXE_release(thread_db* tdbb, jrd_req* request)
 }
 
 
-void EXE_send(thread_db* tdbb, jrd_req* request, USHORT msg, ULONG length, const UCHAR* buffer)
+void EXE_send(thread_db* tdbb, jrd_req* request, USHORT msg, ULONG length, const void* buffer)
 {
 /**************************************
  *

--- a/src/jrd/exe.cpp
+++ b/src/jrd/exe.cpp
@@ -692,7 +692,7 @@ void EXE_receive(thread_db* tdbb,
 
 			if (desc->isBlob())
 			{
-				const bid* id = (bid*) (reinterpret_cast<UCHAR*>(buffer) + (ULONG)(IPTR)desc->dsc_address);
+				const bid* id = (bid*) (reinterpret_cast<UCHAR*>(buffer) + (ULONG)(IPTR) desc->dsc_address);
 
 				if (transaction->tra_blobs->locate(id->bid_temp_id()))
 				{

--- a/src/jrd/exe.h
+++ b/src/jrd/exe.h
@@ -632,7 +632,7 @@ inline void CompilerScratch::csb_repeat::deactivate()
 
 class StatusXcp
 {
-	FbLocalStatus status;
+	Firebird::FbLocalStatus status;
 
 public:
 	StatusXcp();

--- a/src/jrd/exe_proto.h
+++ b/src/jrd/exe_proto.h
@@ -46,9 +46,9 @@ const Jrd::StmtNode* EXE_looper(Jrd::thread_db* tdbb, Jrd::jrd_req* request,
 void EXE_execute_triggers(Jrd::thread_db*, Jrd::TrigVector**, Jrd::record_param*, Jrd::record_param*,
 	enum TriggerAction, Jrd::StmtNode::WhichTrigger);
 
-void EXE_receive(Jrd::thread_db*, Jrd::jrd_req*, USHORT, ULONG, UCHAR*, bool = false);
+void EXE_receive(Jrd::thread_db*, Jrd::jrd_req*, USHORT, ULONG, void*, bool = false);
 void EXE_release(Jrd::thread_db*, Jrd::jrd_req*);
-void EXE_send(Jrd::thread_db*, Jrd::jrd_req*, USHORT, ULONG, const UCHAR*);
+void EXE_send(Jrd::thread_db*, Jrd::jrd_req*, USHORT, ULONG, const void*);
 void EXE_start(Jrd::thread_db*, Jrd::jrd_req*, Jrd::jrd_tra*);
 void EXE_unwind(Jrd::thread_db*, Jrd::jrd_req*);
 

--- a/src/jrd/extds/InternalDS.cpp
+++ b/src/jrd/extds/InternalDS.cpp
@@ -118,7 +118,7 @@ InternalConnection::~InternalConnection()
 }
 
 // Status helper
-class IntStatus : public Jrd::FbLocalStatus
+class IntStatus : public Firebird::FbLocalStatus
 {
 public:
 	explicit IntStatus(FbStatusVector *p)

--- a/src/jrd/extds/IscDS.cpp
+++ b/src/jrd/extds/IscDS.cpp
@@ -1522,7 +1522,7 @@ ISC_STATUS ISC_EXPORT IscProvider::fb_database_crypt_callback(FbStatusVector* us
 	return notImplemented(user_status);
 }
 
-ISC_STATUS ISC_EXPORT IscProvider::fb_dsql_set_timeout(Jrd::FbStatusVector* user_status,
+ISC_STATUS ISC_EXPORT IscProvider::fb_dsql_set_timeout(FbStatusVector* user_status,
 	isc_stmt_handle* stmt_handle,
 	ULONG timeout)
 {

--- a/src/jrd/inf_pub.h
+++ b/src/jrd/inf_pub.h
@@ -150,6 +150,7 @@ enum db_info_types
 	fb_info_ses_idle_timeout_run = 131,
 
 	fb_info_conn_flags = 132,
+	fb_info_protocol_version = 133,
 
 	isc_info_db_last_value   /* Leave this LAST! */
 };

--- a/src/jrd/intl_builtin.cpp
+++ b/src/jrd/intl_builtin.cpp
@@ -1717,7 +1717,7 @@ ULONG INTL_builtin_setup_attributes(const ASCII* textTypeName, const ASCII* char
 	// the preprocessor, but this is a task for another day.
 	if (strstr(textTypeName, "UNICODE") && strcmp(textTypeName, "UNICODE_FSS") != 0)
 	{
-		Firebird::AutoPtr<charset, Jrd::CharSet::Delete> cs(FB_NEW charset);
+		Firebird::AutoPtr<charset> cs(FB_NEW charset);
 		memset(cs, 0, sizeof(*cs));
 
 		// test if that charset exists

--- a/src/jrd/jrd.cpp
+++ b/src/jrd/jrd.cpp
@@ -3487,7 +3487,7 @@ JEvents* JAttachment::queEvents(CheckStatusWrapper* user_status, IEventCallback*
 
 
 void JRequest::receive(CheckStatusWrapper* user_status, int level, unsigned int msg_type,
-					   unsigned int msg_length, unsigned char* msg)
+					   unsigned int msg_length, void* msg)
 {
 /**************************************
  *
@@ -3800,7 +3800,7 @@ int JBlob::seek(CheckStatusWrapper* user_status, int mode, int offset)
 
 
 void JRequest::send(CheckStatusWrapper* user_status, int level, unsigned int msg_type,
-	unsigned int msg_length, const unsigned char* msg)
+	unsigned int msg_length, const void* msg)
 {
 /**************************************
  *
@@ -4025,7 +4025,7 @@ void JService::start(CheckStatusWrapper* user_status, unsigned int spbLength, co
 
 
 void JRequest::startAndSend(CheckStatusWrapper* user_status, ITransaction* tra, int level,
-	unsigned int msg_type, unsigned int msg_length, const unsigned char* msg)
+	unsigned int msg_type, unsigned int msg_length, const void* msg)
 {
 /**************************************
  *
@@ -8394,7 +8394,7 @@ void JRD_autocommit_ddl(thread_db* tdbb, jrd_tra* transaction)
 }
 
 
-void JRD_receive(thread_db* tdbb, jrd_req* request, USHORT msg_type, ULONG msg_length, UCHAR* msg)
+void JRD_receive(thread_db* tdbb, jrd_req* request, USHORT msg_type, ULONG msg_length, void* msg)
 {
 /**************************************
  *
@@ -8418,7 +8418,7 @@ void JRD_receive(thread_db* tdbb, jrd_req* request, USHORT msg_type, ULONG msg_l
 }
 
 
-void JRD_send(thread_db* tdbb, jrd_req* request, USHORT msg_type, ULONG msg_length, const UCHAR* msg)
+void JRD_send(thread_db* tdbb, jrd_req* request, USHORT msg_type, ULONG msg_length, const void* msg)
 {
 /**************************************
  *
@@ -8532,7 +8532,7 @@ void JRD_rollback_retaining(thread_db* tdbb, jrd_tra* transaction)
 
 
 void JRD_start_and_send(thread_db* tdbb, jrd_req* request, jrd_tra* transaction,
-	USHORT msg_type, ULONG msg_length, const UCHAR* msg)
+	USHORT msg_type, ULONG msg_length, const void* msg)
 {
 /**************************************
  *

--- a/src/jrd/jrd.cpp
+++ b/src/jrd/jrd.cpp
@@ -4824,6 +4824,12 @@ IBatch* JAttachment::createBatch(CheckStatusWrapper* status, ITransaction* trans
 }
 
 
+unsigned int JAttachment::getRemoteProtocolVersion(Firebird::CheckStatusWrapper* status)
+{
+	return 0;		// protocol == 0, i.e. no network, i.e. embedded connection
+}
+
+
 int JResultSet::fetchNext(CheckStatusWrapper* user_status, void* buffer)
 {
 	try

--- a/src/jrd/jrd.cpp
+++ b/src/jrd/jrd.cpp
@@ -4824,12 +4824,6 @@ IBatch* JAttachment::createBatch(CheckStatusWrapper* status, ITransaction* trans
 }
 
 
-unsigned int JAttachment::getRemoteProtocolVersion(Firebird::CheckStatusWrapper* status)
-{
-	return 0;		// protocol == 0, i.e. no network, i.e. embedded connection
-}
-
-
 int JResultSet::fetchNext(CheckStatusWrapper* user_status, void* buffer)
 {
 	try

--- a/src/jrd/jrd.h
+++ b/src/jrd/jrd.h
@@ -768,7 +768,7 @@ private:
 	ThreadContextHolder(const ThreadContextHolder&);
 	ThreadContextHolder& operator= (const ThreadContextHolder&);
 
-	FbLocalStatus localStatus;
+	Firebird::FbLocalStatus localStatus;
 	FbStatusVector* currentStatus;
 	thread_db context;
 };
@@ -808,7 +808,7 @@ public:
 	}
 
 private:
-	FbLocalStatus m_local_status;
+	Firebird::FbLocalStatus m_local_status;
 	thread_db* const m_tdbb;
 	FbStatusVector* const m_old_status;
 

--- a/src/jrd/jrd_proto.h
+++ b/src/jrd/jrd_proto.h
@@ -59,7 +59,7 @@ void	JRD_print_procedure_info(Jrd::thread_db*, const char*);
 
 void JRD_autocommit_ddl(Jrd::thread_db* tdbb, Jrd::jrd_tra* transaction);
 void JRD_receive(Jrd::thread_db* tdbb, Jrd::jrd_req* request, USHORT msg_type, ULONG msg_length,
-	UCHAR* msg);
+	void* msg);
 void JRD_start(Jrd::thread_db* tdbb, Jrd::jrd_req* request, Jrd::jrd_tra* transaction);
 
 void JRD_commit_transaction(Jrd::thread_db* tdbb, Jrd::jrd_tra* transaction);
@@ -67,9 +67,9 @@ void JRD_commit_retaining(Jrd::thread_db* tdbb, Jrd::jrd_tra* transaction);
 void JRD_rollback_transaction(Jrd::thread_db* tdbb, Jrd::jrd_tra* transaction);
 void JRD_rollback_retaining(Jrd::thread_db* tdbb, Jrd::jrd_tra* transaction);
 void JRD_send(Jrd::thread_db* tdbb, Jrd::jrd_req* request, USHORT msg_type, ULONG msg_length,
-	const UCHAR* msg);
+	const void* msg);
 void JRD_start_and_send(Jrd::thread_db* tdbb, Jrd::jrd_req* request, Jrd::jrd_tra* transaction,
-	USHORT msg_type, ULONG msg_length, const UCHAR* msg);
+	USHORT msg_type, ULONG msg_length, const void* msg);
 void JRD_start_transaction(Jrd::thread_db* tdbb, Jrd::jrd_tra** transaction,
 	Jrd::Attachment* attachment, unsigned int tpb_length, const UCHAR* tpb);
 void JRD_unwind_request(Jrd::thread_db* tdbb, Jrd::jrd_req* request);

--- a/src/jrd/sort.cpp
+++ b/src/jrd/sort.cpp
@@ -499,7 +499,7 @@ void Sort::sort(thread_db* tdbb)
 			++run_count;
 		}
 
-		AutoPtr<run_merge_hdr*, ArrayDelete<run_merge_hdr*> > streams(
+		AutoPtr<run_merge_hdr*, ArrayDelete> streams(
 			FB_NEW_POOL(m_owner->getPool()) run_merge_hdr*[run_count]);
 
 		run_merge_hdr** m1 = streams;

--- a/src/jrd/status.h
+++ b/src/jrd/status.h
@@ -34,8 +34,6 @@
 namespace Jrd
 {
 	typedef Firebird::CheckStatusWrapper FbStatusVector;
-	typedef Firebird::FbLocalStatus FbLocalStatus;
-	typedef Firebird::ThrowLocalStatus ThrowLocalStatus;
 }
 
 #endif // JRD_STATUS_H

--- a/src/jrd/status.h
+++ b/src/jrd/status.h
@@ -29,90 +29,13 @@
 #ifndef JRD_STATUS_H
 #define JRD_STATUS_H
 
-#include "../common/StatusHolder.h"
-#include "../common/utils_proto.h"
-
-const int MAX_ERRMSG_LEN	= 128;
-const int MAX_ERRSTR_LEN	= 1024;
+#include "../common/status.h"
 
 namespace Jrd
 {
 	typedef Firebird::CheckStatusWrapper FbStatusVector;
-
-	template <class SW>
-	class LocalStatusWrapper
-	{
-	public:
-		LocalStatusWrapper()
-			: localStatusVector(&localStatus)
-		{ }
-
-		explicit LocalStatusWrapper(Firebird::MemoryPool& p)
-			: localStatus(p), localStatusVector(&localStatus)
-		{ }
-
-		SW* operator->()
-		{
-			return &localStatusVector;
-		}
-
-		SW* operator&()
-		{
-			return &localStatusVector;
-		}
-
-		ISC_STATUS operator[](unsigned n) const
-		{
-			fb_assert(n < fb_utils::statusLength(localStatusVector.getErrors()));
-			return localStatusVector.getErrors()[n];
-		}
-
-		const SW* operator->() const
-		{
-			return &localStatusVector;
-		}
-
-		const SW* operator&() const
-		{
-			return &localStatusVector;
-		}
-
-		void check() const
-		{
-			if (localStatusVector.isDirty())
-			{
-				if (localStatus.getState() & Firebird::IStatus::STATE_ERRORS)
-					raise();
-			}
-		}
-
-		void copyTo(SW* to) const
-		{
-			fb_utils::copyStatus(to, &localStatusVector);
-		}
-
-		void raise() const
-		{
-			Firebird::status_exception::raise(&localStatus);
-		}
-
-		bool isEmpty() const
-		{
-			return localStatusVector.isEmpty();
-		}
-
-		bool isSuccess() const
-		{
-			return localStatusVector.isEmpty();
-		}
-
-	private:
-		Firebird::LocalStatus localStatus;
-		SW localStatusVector;
-	};
-
-	typedef LocalStatusWrapper<FbStatusVector> FbLocalStatus;
-	typedef LocalStatusWrapper<Firebird::ThrowStatusWrapper> ThrowLocalStatus;
+	typedef Firebird::FbLocalStatus FbLocalStatus;
+	typedef Firebird::ThrowLocalStatus ThrowLocalStatus;
 }
 
 #endif // JRD_STATUS_H

--- a/src/jrd/svc.h
+++ b/src/jrd/svc.h
@@ -277,7 +277,7 @@ private:
 	static THREAD_ENTRY_DECLARE run(THREAD_ENTRY_PARAM arg);
 
 private:
-	FbLocalStatus svc_status;						// status vector for running service
+	Firebird::FbLocalStatus svc_status;				// status vector for running service
 	Firebird::string svc_parsed_sw;					// Here point elements of argv
 	ULONG	svc_stdout_head;
 	ULONG	svc_stdout_tail;

--- a/src/jrd/val.h
+++ b/src/jrd/val.h
@@ -50,7 +50,8 @@ public:
 };
 
 const UCHAR DEFAULT_DOUBLE  = dtype_double;
-const ULONG MAX_RECORD_SIZE	= 65535;
+
+const ULONG MAX_RECORD_SIZE	= 1024 * 1024; // 1MB
 
 namespace Jrd {
 

--- a/src/jrd/val.h
+++ b/src/jrd/val.h
@@ -51,7 +51,7 @@ public:
 
 const UCHAR DEFAULT_DOUBLE  = dtype_double;
 
-const ULONG MAX_RECORD_SIZE	= 1024 * 1024; // 1MB
+const ULONG MAX_RECORD_SIZE	= 65535;
 
 namespace Jrd {
 

--- a/src/lock/print.cpp
+++ b/src/lock/print.cpp
@@ -569,7 +569,7 @@ int CLIB_ROUTINE main( int argc, char *argv[])
 		exit(FINI_OK);
 	}
 
-	Firebird::AutoPtr<UCHAR, Firebird::ArrayDelete<UCHAR> > buffer;
+	Firebird::AutoPtr<UCHAR, Firebird::ArrayDelete> buffer;
 	lhb* LOCK_header = NULL;
 	Firebird::AutoPtr<sh_mem> shmem_data;
 

--- a/src/msgs/messages2.sql
+++ b/src/msgs/messages2.sql
@@ -970,7 +970,7 @@ Data source : @4', NULL, NULL)
 ('non_plugin_protocol', NULL, 'server.cpp', NULL, 0, 860, NULL, 'Plugin not supported by network protocol', NULL, NULL);
 ('message_format', NULL, 'server.cpp', NULL, 0, 861, NULL, 'Error parsing message format', NULL, NULL);
 ('batch_param_version', NULL, NULL, NULL, 0, 862, NULL, 'Wrong version of batch parameters block @1, should be @2', NULL, NULL);
-('batch_msg_long', NULL, 'DsqlBatch.cpp', NULL, 0, 863, NULL, 'Message size (@1) in batch exceeds internal buffer size (@2)', NULL, NULL);
+('batch_msg_long', NULL, '** Unused **', NULL, 0, 863, NULL, 'Message size (@1) in batch exceeds internal buffer size (@2)', NULL, NULL);
 ('batch_open', NULL, 'DsqlBatch.cpp', NULL, 0, 864, NULL, 'Batch already opened for this statement', NULL, NULL);
 ('batch_type', NULL, 'DsqlBatch.cpp', NULL, 0, 865, NULL, 'Invalid type of statement used in batch', NULL, NULL);
 ('batch_param', NULL, 'DsqlBatch.cpp', NULL, 0, 866, NULL, 'Statement used in batch must have parameters', NULL, NULL);

--- a/src/remote/client/interface.cpp
+++ b/src/remote/client/interface.cpp
@@ -770,11 +770,6 @@ public:
 		unsigned stmtLength, const char* sqlStmt, unsigned dialect,
 		IMessageMetadata* inMetadata, unsigned parLength, const unsigned char* par);
 
-	unsigned getRemoteProtocolVersion(CheckStatusWrapper* status)
-	{
-		return rdb->rdb_port->port_protocol & FB_PROTOCOL_MASK;
-	}
-
 public:
 	Attachment(Rdb* handle, const PathName& path)
 		: rdb(handle), dbPath(getPool(), path)

--- a/src/remote/client/interface.cpp
+++ b/src/remote/client/interface.cpp
@@ -5610,7 +5610,7 @@ void Request::send(CheckStatusWrapper* status, int level, unsigned int msg_type,
 
 		RMessage* message = request->rrq_rpt[msg_type].rrq_message;
 		// We are lying here, but the interface shows for years this param as const
-		message->msg_address = const_cast<unsigned char*>(reinterpret_cast<const unsigned char*>(msg));
+		message->msg_address = const_cast<unsigned char*>(static_cast<const unsigned char*>(msg));
 
 		PACKET* packet = &rdb->rdb_packet;
 		packet->p_operation = op_send;
@@ -5903,7 +5903,7 @@ void Request::startAndSend(CheckStatusWrapper* status, Firebird::ITransaction* a
 
 		REMOTE_reset_request(request, 0);
 		RMessage* message = request->rrq_rpt[msg_type].rrq_message;
-		message->msg_address = const_cast<unsigned char*>(reinterpret_cast<const unsigned char*>(msg));
+		message->msg_address = const_cast<unsigned char*>(static_cast<const unsigned char*>(msg));
 
 		PACKET* packet = &rdb->rdb_packet;
 		packet->p_operation = op_start_send_and_receive;

--- a/src/remote/client/interface.cpp
+++ b/src/remote/client/interface.cpp
@@ -488,7 +488,7 @@ private:
 	void sendBlobPacket(unsigned size, const UCHAR* ptr);
 	void sendMessagePacket(unsigned size, const UCHAR* ptr);
 
-	Firebird::AutoPtr<UCHAR, Firebird::ArrayDelete<UCHAR> > messageStreamBuffer, blobStreamBuffer;
+	Firebird::AutoPtr<UCHAR, Firebird::ArrayDelete> messageStreamBuffer, blobStreamBuffer;
 	ULONG messageStream;
 	UCHAR* blobStream;
 	ULONG* sizePointer;
@@ -2674,7 +2674,7 @@ IBatchCompletionState* Batch::execute(CheckStatusWrapper* status, ITransaction* 
 		send_packet(port, packet);
 
 		statement->rsr_batch_size = alignedSize;
-		AutoPtr<BatchCompletionState, SimpleDispose<BatchCompletionState> >
+		AutoPtr<BatchCompletionState, SimpleDispose>
 			cs(FB_NEW BatchCompletionState(flags & (1 << IBatch::TAG_RECORD_COUNTS), 256));
 		statement->rsr_batch_cs = cs;
 		receive_packet(port, packet);

--- a/src/remote/client/interface.cpp
+++ b/src/remote/client/interface.cpp
@@ -621,15 +621,15 @@ public:
 	// IRequest implementation
 	int release();
 	void receive(CheckStatusWrapper* status, int level, unsigned int msg_type,
-						 unsigned int length, unsigned char* message);
+						 unsigned int length, void* message);
 	void send(CheckStatusWrapper* status, int level, unsigned int msg_type,
-					  unsigned int length, const unsigned char* message);
+					  unsigned int length, const void* message);
 	void getInfo(CheckStatusWrapper* status, int level,
 						 unsigned int itemsLength, const unsigned char* items,
 						 unsigned int bufferLength, unsigned char* buffer);
 	void start(CheckStatusWrapper* status, Firebird::ITransaction* tra, int level);
 	void startAndSend(CheckStatusWrapper* status, Firebird::ITransaction* tra, int level, unsigned int msg_type,
-							  unsigned int length, const unsigned char* message);
+							  unsigned int length, const void* message);
 	void unwind(CheckStatusWrapper* status, int level);
 	void free(CheckStatusWrapper* status);
 
@@ -5056,7 +5056,7 @@ Firebird::IEvents* Attachment::queEvents(CheckStatusWrapper* status, Firebird::I
 
 
 void Request::receive(CheckStatusWrapper* status, int level, unsigned int msg_type,
-					  unsigned int msg_length, unsigned char* msg)
+					  unsigned int msg_length, void* msg)
 {
 /**************************************
  *
@@ -5569,7 +5569,7 @@ int Blob::seek(CheckStatusWrapper* status, int mode, int offset)
 
 
 void Request::send(CheckStatusWrapper* status, int level, unsigned int msg_type,
-				   unsigned int /*length*/, const unsigned char* msg)
+				   unsigned int /*length*/, const void* msg)
 {
 /**************************************
  *
@@ -5600,7 +5600,7 @@ void Request::send(CheckStatusWrapper* status, int level, unsigned int msg_type,
 
 		RMessage* message = request->rrq_rpt[msg_type].rrq_message;
 		// We are lying here, but the interface shows for years this param as const
-		message->msg_address = const_cast<UCHAR*>(msg);
+		message->msg_address = const_cast<unsigned char*>(reinterpret_cast<const unsigned char*>(msg));
 
 		PACKET* packet = &rdb->rdb_packet;
 		packet->p_operation = op_send;
@@ -5851,7 +5851,7 @@ void Service::start(CheckStatusWrapper* status,
 
 
 void Request::startAndSend(CheckStatusWrapper* status, Firebird::ITransaction* apiTra, int level,
-						   unsigned int msg_type, unsigned int /*length*/, const unsigned char* msg)
+						   unsigned int msg_type, unsigned int /*length*/, const void* msg)
 {
 /**************************************
  *
@@ -5893,7 +5893,7 @@ void Request::startAndSend(CheckStatusWrapper* status, Firebird::ITransaction* a
 
 		REMOTE_reset_request(request, 0);
 		RMessage* message = request->rrq_rpt[msg_type].rrq_message;
-		message->msg_address = const_cast<unsigned char*>(msg);
+		message->msg_address = const_cast<unsigned char*>(reinterpret_cast<const unsigned char*>(msg));
 
 		PACKET* packet = &rdb->rdb_packet;
 		packet->p_operation = op_start_send_and_receive;

--- a/src/remote/merge.cpp
+++ b/src/remote/merge.cpp
@@ -48,7 +48,6 @@ USHORT MERGE_database_info(const UCHAR* in,
 							USHORT base_level,
 							const UCHAR* version,
 							const UCHAR* id)
-							//ULONG mask Was always zero
 {
 /**************************************
  *

--- a/src/remote/protocol.cpp
+++ b/src/remote/protocol.cpp
@@ -893,7 +893,7 @@ bool_t xdr_protocol(XDR* xdrs, PACKET* p)
 
 			while (count--)
 			{
-				DEB_BATCH(fprintf(stderr, "BatRem: xdr packed msg\n"));
+				DEB_RBATCH(fprintf(stderr, "BatRem: xdr packed msg\n"));
 				if (!xdr_packed_message(xdrs, message, statement->rsr_format))
 					return P_FALSE(xdrs, p);
 				message->msg_address += statement->rsr_batch_size;
@@ -912,7 +912,7 @@ bool_t xdr_protocol(XDR* xdrs, PACKET* p)
 			MAP(xdr_short, reinterpret_cast<SSHORT&>(b->p_batch_transaction));
 
 			if (xdrs->x_op != XDR_FREE)
-				DEB_BATCH(fprintf(stderr, "BatRem: xdr execute\n"));
+				DEB_RBATCH(fprintf(stderr, "BatRem: xdr execute\n"));
 
 			return P_TRUE(xdrs, p);
 		}
@@ -931,7 +931,7 @@ bool_t xdr_protocol(XDR* xdrs, PACKET* p)
 
 			rem_port* port = (rem_port*) xdrs->x_public;
 			SSHORT statement_id = b->p_batch_statement;
-			DEB_BATCH(fprintf(stderr, "BatRem: xdr CS %d\n", statement_id));
+			DEB_RBATCH(fprintf(stderr, "BatRem: xdr CS %d\n", statement_id));
 			Rsr* statement;
 
 			if (statement_id >= 0)
@@ -961,12 +961,12 @@ bool_t xdr_protocol(XDR* xdrs, PACKET* p)
 
 			if ((xdrs->x_op == XDR_DECODE) && (!b->p_batch_updates))
 			{
-				DEB_BATCH(fprintf(stderr, "BatRem: xdr reccount=%d\n", b->p_batch_reccount));
+				DEB_RBATCH(fprintf(stderr, "BatRem: xdr reccount=%d\n", b->p_batch_reccount));
 				statement->rsr_batch_cs->regSize(b->p_batch_reccount);
 			}
 
 			// Process update counters
-			DEB_BATCH(fprintf(stderr, "BatRem: xdr up %d\n", b->p_batch_updates));
+			DEB_RBATCH(fprintf(stderr, "BatRem: xdr up %d\n", b->p_batch_updates));
 			for (unsigned i = 0; i < b->p_batch_updates; ++i)
 			{
 				SLONG v;
@@ -988,7 +988,7 @@ bool_t xdr_protocol(XDR* xdrs, PACKET* p)
 			// Process status vectors
 			ULONG pos = 0u;
 			LocalStatus to;
-			DEB_BATCH(fprintf(stderr, "BatRem: xdr sv %d\n", b->p_batch_vectors));
+			DEB_RBATCH(fprintf(stderr, "BatRem: xdr sv %d\n", b->p_batch_vectors));
 
 			for (unsigned i = 0; i < b->p_batch_vectors; ++i, ++pos)
 			{
@@ -1026,7 +1026,7 @@ bool_t xdr_protocol(XDR* xdrs, PACKET* p)
 
 			// Process status-less errors
 			pos = 0u;
-			DEB_BATCH(fprintf(stderr, "BatRem: xdr err %d\n", b->p_batch_errors));
+			DEB_RBATCH(fprintf(stderr, "BatRem: xdr err %d\n", b->p_batch_errors));
 
 			for (unsigned i = 0; i < b->p_batch_errors; ++i, ++pos)
 			{
@@ -1059,7 +1059,7 @@ bool_t xdr_protocol(XDR* xdrs, PACKET* p)
 			MAP(xdr_short, reinterpret_cast<SSHORT&>(b->p_batch_statement));
 
 			if (xdrs->x_op != XDR_FREE)
-				DEB_BATCH(fprintf(stderr, "BatRem: xdr release\n"));
+				DEB_RBATCH(fprintf(stderr, "BatRem: xdr release\n"));
 
 			return P_TRUE(xdrs, p);
 		}

--- a/src/remote/remote.h
+++ b/src/remote/remote.h
@@ -123,7 +123,7 @@ namespace os_utils
 
 struct rem_port;
 
-typedef Firebird::AutoPtr<UCHAR, Firebird::ArrayDelete<UCHAR> > UCharArrayAutoPtr;
+typedef Firebird::AutoPtr<UCHAR, Firebird::ArrayDelete > UCharArrayAutoPtr;
 
 typedef Firebird::RefPtr<Firebird::IAttachment> ServAttachment;
 typedef Firebird::RefPtr<Firebird::IBlob> ServBlob;

--- a/src/remote/remote.h
+++ b/src/remote/remote.h
@@ -64,7 +64,7 @@
 //#define COMPRESS_DEBUG 1
 #endif // WIRE_COMPRESS_SUPPORT
 
-#define DEB_BATCH(x)
+#define DEB_RBATCH(x)
 
 #define REM_SEND_OFFSET(bs) (0)
 #define REM_RECV_OFFSET(bs) (bs)

--- a/src/remote/server/server.cpp
+++ b/src/remote/server/server.cpp
@@ -3494,7 +3494,7 @@ void rem_port::batch_exec(P_BATCH_EXEC* batch, PACKET* sendL)
 	Rtr* transaction = NULL;
 	getHandle(transaction, batch->p_batch_transaction);
 
-	AutoPtr<IBatchCompletionState, SimpleDispose<IBatchCompletionState> >
+	AutoPtr<IBatchCompletionState, SimpleDispose>
 		ics(statement->rsr_batch->execute(&status_vector, transaction->rtr_iface));
 
 	if (status_vector.getState() & IStatus::STATE_ERRORS)

--- a/src/utilities/ntrace/traceplugin.cpp
+++ b/src/utilities/ntrace/traceplugin.cpp
@@ -84,7 +84,7 @@ Firebird::ITracePlugin* TraceFactoryImpl::trace_create(Firebird::CheckStatusWrap
 			return NULL; // Plugin is not needed, no error happened.
 		}
 
-		Firebird::AutoPtr<Firebird::ITraceLogWriter, Firebird::SimpleRelease<Firebird::ITraceLogWriter> >
+		Firebird::AutoPtr<Firebird::ITraceLogWriter, Firebird::SimpleRelease>
 			logWriter(initInfo->getLogWriter());
 
 		if (logWriter)

--- a/src/yvalve/YObjects.h
+++ b/src/yvalve/YObjects.h
@@ -510,6 +510,7 @@ public:
 	YBatch* createBatch(Firebird::CheckStatusWrapper* status, Firebird::ITransaction* transaction,
 		unsigned stmtLength, const char* sqlStmt, unsigned dialect,
 		Firebird::IMessageMetadata* inMetadata, unsigned parLength, const unsigned char* par);
+	unsigned int getRemoteProtocolVersion(Firebird::CheckStatusWrapper* status);
 
 public:
 	Firebird::IProvider* provider;

--- a/src/yvalve/YObjects.h
+++ b/src/yvalve/YObjects.h
@@ -210,14 +210,14 @@ public:
 
 	// IRequest implementation
 	void receive(Firebird::CheckStatusWrapper* status, int level, unsigned int msgType,
-		unsigned int length, unsigned char* message);
+		unsigned int length, void* message);
 	void send(Firebird::CheckStatusWrapper* status, int level, unsigned int msgType,
-		unsigned int length, const unsigned char* message);
+		unsigned int length, const void* message);
 	void getInfo(Firebird::CheckStatusWrapper* status, int level, unsigned int itemsLength,
 		const unsigned char* items, unsigned int bufferLength, unsigned char* buffer);
 	void start(Firebird::CheckStatusWrapper* status, Firebird::ITransaction* transaction, int level);
 	void startAndSend(Firebird::CheckStatusWrapper* status, Firebird::ITransaction* transaction, int level,
-		unsigned int msgType, unsigned int length, const unsigned char* message);
+		unsigned int msgType, unsigned int length, const void* message);
 	void unwind(Firebird::CheckStatusWrapper* status, int level);
 	void free(Firebird::CheckStatusWrapper* status);
 

--- a/src/yvalve/YObjects.h
+++ b/src/yvalve/YObjects.h
@@ -510,7 +510,6 @@ public:
 	YBatch* createBatch(Firebird::CheckStatusWrapper* status, Firebird::ITransaction* transaction,
 		unsigned stmtLength, const char* sqlStmt, unsigned dialect,
 		Firebird::IMessageMetadata* inMetadata, unsigned parLength, const unsigned char* par);
-	unsigned int getRemoteProtocolVersion(Firebird::CheckStatusWrapper* status);
 
 public:
 	Firebird::IProvider* provider;

--- a/src/yvalve/why.cpp
+++ b/src/yvalve/why.cpp
@@ -5928,22 +5928,6 @@ YBatch* YAttachment::createBatch(CheckStatusWrapper* status, ITransaction* trans
 	return NULL;
 }
 
-unsigned int YAttachment::getRemoteProtocolVersion(CheckStatusWrapper* status)
-{
-	try
-	{
-		YEntry<YAttachment> entry(status, this);
-
-		return entry.next()->getRemoteProtocolVersion(status);
-	}
-	catch (const Exception& e)
-	{
-		e.stuffException(status);
-	}
-
-	return 0;
-}
-
 
 //-------------------------------------
 

--- a/src/yvalve/why.cpp
+++ b/src/yvalve/why.cpp
@@ -5928,6 +5928,22 @@ YBatch* YAttachment::createBatch(CheckStatusWrapper* status, ITransaction* trans
 	return NULL;
 }
 
+unsigned int YAttachment::getRemoteProtocolVersion(CheckStatusWrapper* status)
+{
+	try
+	{
+		YEntry<YAttachment> entry(status, this);
+
+		return entry.next()->getRemoteProtocolVersion(status);
+	}
+	catch (const Exception& e)
+	{
+		e.stuffException(status);
+	}
+
+	return 0;
+}
+
 
 //-------------------------------------
 

--- a/src/yvalve/why.cpp
+++ b/src/yvalve/why.cpp
@@ -3922,7 +3922,7 @@ void YRequest::destroy(unsigned dstrFlags)
 }
 
 void YRequest::receive(CheckStatusWrapper* status, int level, unsigned int msgType,
-	unsigned int length, unsigned char* message)
+	unsigned int length, void* message)
 {
 	try
 	{
@@ -3936,7 +3936,7 @@ void YRequest::receive(CheckStatusWrapper* status, int level, unsigned int msgTy
 }
 
 void YRequest::send(CheckStatusWrapper* status, int level, unsigned int msgType,
-	unsigned int length, const unsigned char* message)
+	unsigned int length, const void* message)
 {
 	try
 	{
@@ -3980,7 +3980,7 @@ void YRequest::start(CheckStatusWrapper* status, ITransaction* transaction, int 
 }
 
 void YRequest::startAndSend(CheckStatusWrapper* status, ITransaction* transaction, int level,
-	unsigned int msgType, unsigned int length, const unsigned char* message)
+	unsigned int msgType, unsigned int length, const void* message)
 {
 	try
 	{


### PR DESCRIPTION
Use of IBatch in gbak seriously increases performance of restore over the wire. In a case of localhost connection using TCP/IP restore runs 2 - 6 times faster. First case is with a real database, containing a lot of indices and some blobs, second - specially created test database without indices but with a lot of small blobs. 

This also fixes http://tracker.firebirdsql.org/browse/CORE-5637 due to use of SQL instead BLR to restore tables like PLG$USERS which helps avoid conflict between old field length and new UNICODE_FSS rules.