### PR TITLE
ARM needs MSG_NOSIGNAL in FB_SEND_FLAGS, too

### DIFF
--- a/builds/posix/prefix.linux_arm
+++ b/builds/posix/prefix.linux_arm
@@ -20,10 +20,9 @@
 
 #LD=@CXX@
 
-#PROD_FLAGS=-ggdb -O3 -fno-omit-frame-pointer -DLINUX -pipe -MMD -fPIC
-#DEV_FLAGS=-ggdb -DLINUX -DDEBUG_GDS_ALLOC -pipe -MMD -p -fPIC -Wall -Wno-switch
+COMMON_FLAGS=-DLINUX -DARM -pipe -MMD -fPIC -fsigned-char -fmessage-length=0 -DFB_SEND_FLAGS=MSG_NOSIGNAL
 
-PROD_FLAGS=-O3 -DLINUX -DARM -pipe -p -MMD -fPIC -fsigned-char -fmessage-length=0
-DEV_FLAGS=-ggdb -DLINUX -DARM -pipe -p -MMD -fPIC -Wall -fsigned-char -fmessage-length=0 -Wno-non-virtual-dtor
+PROD_FLAGS=$(COMMON_FLAGS) -O3
+DEV_FLAGS=$(COMMON_FLAGS) -p -ggdb -Wall -Wno-non-virtual-dtor
 
 CXXFLAGS := $(CXXFLAGS) -std=c++11


### PR DESCRIPTION
We need to add MSG_NOSIGNAL to FB_SEND_FLAGS for ARM, too, otherwise
clients get killed with SIGPIPE when server connection breaks, just like
commit 37bcd38740a187dad79a14a47241945fcd193b82 did for other platforms.

Use this opportunity to also split out common build flags to COMMON_FLAGS
variable, as the above commit did.

This change will also need to be applied to 2.1, 2.5 and 3.0 branches, with a small adjustment:
2.1 and 2.5 have additional -DNDEBUG in PROD_FLAGS.
