### PR TITLE
Redirect stdout and stderr to /dev/null if possible

### DIFF
--- a/src/common/os/posix/divorce.cpp
+++ b/src/common/os/posix/divorce.cpp
@@ -113,6 +113,12 @@ void divorce_terminal(int mask)
 		}
 	}
 
+	if (int dev_null = open("/dev/null", O_RDWR) >= 0)
+	{
+		dup2(dev_null, fileno(stdout));
+		dup2(dev_null, fileno(stderr));
+	}
+
 #ifdef SIGTTOU
 	// ignore all the teminal related signal if define
 	signal(SIGTTOU, SIG_IGN);


### PR DESCRIPTION
Guardian closes stdin/stdout/stderr/... before
launching server binary so server can reuse those
descriptors when opening files or using shmem for
example. So some stray stdout can introduce
unwanted data or even crash server. Server do not
emit any stdout/stderr in release build but
UDRs or external libraries can print to stdout.