### PR TITLE
CORE-5710 make precision optional for DECFLOAT

### DIFF
--- a/doc/sql.extensions/README.data_types
+++ b/doc/sql.extensions/README.data_types
@@ -116,23 +116,25 @@ DECFLOAT (FB 4.0)
     Alex Peshkoff <peshkoff@mail.ru>
 
   Syntax rules:
+    DECFLOAT
     DECFLOAT(16)
     DECFLOAT(34)
 
   Storage:
-    64-bit / 128-bit, format according to IEEE 754.
+    64-bit / 128-bit, format according to IEEE 754 Decimal64/Decimal128
 
   Example(s):
     1. DECLARE VARIABLE VAR1 DECFLOAT(34);
     2. CREATE TABLE TABLE1 (FIELD1 DECFLOAT(16));
 
   Note(s):
-    1.	A number of standard functions can be used with DECFLOAT datatype. It is:
+    1.	If no precision has been specified in the type declaration, the precision is 34.
+    2.	A number of standard functions can be used with DECFLOAT datatype. It is:
     	ABS, CEILING, EXP, FLOOR, LN, LOG, LOG10, POWER, SIGN, SQRT.
     	Agregate functions SUM, AVG, MAX and MIN also work with DECFLOAT data.
     	All statistics aggregates (like but not limited to STDDEV or CORR) work with DECFLOAT data.
 
-    2.	Firebird supports four functions, specially designed to support DECFLOAT data:
+    3.	Firebird supports four functions, specially designed to support DECFLOAT data:
     	- COMPARE_DECFLOAT - compares two DECFLOAT values to be equal, different or unordered.
     		Returns SMALLINT value which can be as follows:
     			0 - values are equal
@@ -155,7 +157,7 @@ DECFLOAT (FB 4.0)
     		DECFLOAT values are ordered as follows:
     			-nan < -snan < -inf < -0.1 < -0.10 < -0 < 0 < 0.10 < 0.1 < inf < snan < nan
 
-	3.	Firebird supports new session control operator SET DECFLOAT. It has following forms:
+	4.	Firebird supports new session control operator SET DECFLOAT. It has following forms:
 			SET DECFLOAT ROUND <mode> - controls rounding mode used in operations with DECFLOAT
 				values. Valid modes are: CEILING (towards +infinity), UP (away from 0), HALF_UP
 				(to nearest, if equidistant - up), HALF_EVEN (to nearest, if equidistant - ensure
@@ -180,7 +182,7 @@ DECFLOAT (FB 4.0)
 				required precision but range of values is very limited). When using is a tool like
 				generic purporse GUI client choice of CHAR binding is OK in most cases.
 
-	4.	The length of DECFLOAT literals are limited to 1024 characters. For longer values, you will
+	5.	The length of DECFLOAT literals are limited to 1024 characters. For longer values, you will
 			need to use the scientific notation. For example, the 0.0<1020 zeroes>11 cannot be used
 			as a literal, instead you can use the equivalent in scientific notation: 1.1E-1022.
 			Similarly 10<1022 zeroes>0 can be presented as 1.0E1024.

--- a/src/dsql/parse-conflicts.txt
+++ b/src/dsql/parse-conflicts.txt
@@ -1,1 +1,1 @@
-54 shift/reduce conflicts, 17 reduce/reduce conflicts.
+54 shift/reduce conflicts, 35 reduce/reduce conflicts.

--- a/src/dsql/parse-conflicts.txt
+++ b/src/dsql/parse-conflicts.txt
@@ -1,1 +1,1 @@
-54 shift/reduce conflicts, 35 reduce/reduce conflicts.
+54 shift/reduce conflicts, 17 reduce/reduce conflicts.

--- a/src/dsql/parse.y
+++ b/src/dsql/parse.y
@@ -4135,7 +4135,8 @@ keyword_or_column
 	| UPDATING
 	| VAR_SAMP
 	| VAR_POP
-	| UNBOUNDED				// added in FB 4.0
+	| DECFLOAT				// added in FB 4.0
+	| UNBOUNDED
 	| WINDOW
 	;
 

--- a/src/dsql/parse.y
+++ b/src/dsql/parse.y
@@ -8488,7 +8488,6 @@ non_reserved_word
 	| BIND					// added in FB 4.0
 	| COMPARE_DECFLOAT
 	| CUME_DIST
-	| DECFLOAT
 	| DEFINER
 	| EXCLUDE
 	| FIRST_DAY

--- a/src/dsql/parse.y
+++ b/src/dsql/parse.y
@@ -4799,15 +4799,15 @@ varbinary_character_keyword
 
 %type <legacyField> decfloat_type
 decfloat_type
-	: DECFLOAT '(' signed_long_integer ')'
+	: DECFLOAT precision_opt_nz
 		{
-			if ($3 != 16 && $3 != 34)
-				yyabandon(YYPOSNARG(3), -842, isc_decprecision_err);	// DecFloat precision must be 16 or 34.
+			if ($2 != 0 && $2 != 16 && $2 != 34)
+				yyabandon(YYPOSNARG(2), -842, isc_decprecision_err);	// DecFloat precision must be 16 or 34.
 
 			$$ = newNode<dsql_fld>();
-			$$->precision = $3;
-			$$->dtype = $3 == 16 ? dtype_dec64 : dtype_dec128;
-			$$->length = $3 == 16 ? sizeof(Decimal64) : sizeof(Decimal128);
+			$$->precision = $2 == 0 ? 34 : (USHORT) $2;
+			$$->dtype = $2 == 16 ? dtype_dec64 : dtype_dec128;
+			$$->length = $2 == 16 ? sizeof(Decimal64) : sizeof(Decimal128);
 		}
 	;
 
@@ -5009,6 +5009,12 @@ precision_opt
 	| '(' nonneg_short_integer ')'	{ $$ = $2; }
 	;
 
+// alternative to precision_opt that does not allow zero
+%type <int32Val> precision_opt_nz
+precision_opt_nz
+	: /* nothing */				{ $$ = 0; }
+	| '(' pos_short_integer ')'	{ $$ = $2; }
+	;
 
 // transaction statements
 

--- a/src/yvalve/keywords.cpp
+++ b/src/yvalve/keywords.cpp
@@ -160,7 +160,7 @@ static const TOK tokens[] =
 	{TOK_DAY, "DAY", false},
 	{TOK_DDL, "DDL", true},
 	{TOK_DEC, "DEC", false},
-	{TOK_DECFLOAT, "DECFLOAT", true},
+	{TOK_DECFLOAT, "DECFLOAT", false},
 	{TOK_DECIMAL, "DECIMAL", false},
 	{TOK_DECLARE, "DECLARE", false},
 	{TOK_DECODE, "DECODE", true},


### PR DESCRIPTION
Fixes [CORE-5710](http://tracker.firebirdsql.org/browse/CORE-5710)

This commit increases the number of reduce/reduce conflicts, but I couldn't find a way to fix that.