### PR TITLE
If guard starts in daemon mode then close all fds to properly daemonize (fix for PR #143)

### DIFF
--- a/src/utilities/guard/guard.cpp
+++ b/src/utilities/guard/guard.cpp
@@ -170,8 +170,9 @@ int CLIB_ROUTINE main( int argc, char **argv)
 
 	//Keep stdout and stderr opened and let server emit output
 	//or redirect stdout/stderr to /dev/null or file by user choice
+	//If we want to daemonize - close all fds and let child to reopen it.
 	int mask = 0; // FD_ZERO(&mask);
-	mask |= (1 << 1 | 1 << 2); // FD_SET(1, &mask); FD_SET(2, &mask);
+	mask |= daemon ? 0 : (1 << 1 | 1 << 2); // FD_SET(1, &mask); FD_SET(2, &mask);
 	divorce_terminal(mask);
 
 	time_t timer = 0;


### PR DESCRIPTION
Also in server detect if stdout/stderr fds were closed by guard and reopen
with redirecting to file or /dev/null