### PR TITLE
Fix external engine memory leaks

### DIFF
--- a/src/jrd/Attachment.cpp
+++ b/src/jrd/Attachment.cpp
@@ -253,6 +253,20 @@ Jrd::Attachment::~Attachment()
 	for (unsigned n = 0; n < att_batches.getCount(); ++n)
 		att_batches[n]->resetHandle();
 
+	for (Function** iter = att_functions.begin(); iter < att_functions.end(); ++iter)
+	{
+		Function* const function = *iter;
+		if (function)
+			delete function;
+	}
+
+	for (jrd_prc** iter = att_procedures.begin(); iter < att_procedures.end(); ++iter)
+	{
+		jrd_prc* const procedure = *iter;
+		if (procedure)
+			delete procedure;
+	}
+
 	while (att_pools.hasData())
 		deletePool(att_pools.pop());
 

--- a/src/jrd/ExtEngineManager.cpp
+++ b/src/jrd/ExtEngineManager.cpp
@@ -887,7 +887,7 @@ ExtEngineManager::Trigger::Trigger(thread_db* tdbb, MemoryPool& pool, ExtEngineM
 
 ExtEngineManager::Trigger::~Trigger()
 {
-	// hvlad: shouldn't we call trigger->dispose() here ?
+	trigger->dispose();
 }
 
 
@@ -1047,6 +1047,7 @@ void ExtEngineManager::closeAttachment(thread_db* tdbb, Attachment* attachment)
 				ContextManager<IExternalFunction> ctxManager(tdbb, attInfo, attInfo->adminCharSet);
 				FbLocalStatus status;
 				engine->closeAttachment(&status, attInfo->context);	//// FIXME: log status
+				engine->release();
 			}
 
 			delete attInfo;

--- a/src/jrd/Function.h
+++ b/src/jrd/Function.h
@@ -75,6 +75,11 @@ namespace Jrd
 			delete fun_external;
 		}
 
+		virtual void releaseExternal()
+		{
+			delete fun_external;
+			fun_external = NULL;
+		}
 	public:
 		int (*fun_entrypoint)();				// function entrypoint
 		USHORT fun_inputs;						// input arguments

--- a/src/jrd/Function.h
+++ b/src/jrd/Function.h
@@ -70,6 +70,11 @@ namespace Jrd
 		virtual bool checkCache(thread_db* tdbb) const;
 		virtual void clearCache(thread_db* tdbb);
 
+		virtual ~Function()
+		{
+			delete fun_external;
+		}
+
 	public:
 		int (*fun_entrypoint)();				// function entrypoint
 		USHORT fun_inputs;						// input arguments

--- a/src/jrd/Routine.cpp
+++ b/src/jrd/Routine.cpp
@@ -322,6 +322,7 @@ void Routine::remove(thread_db* tdbb)
 		setSecurityName("");
 		setId(0);
 		setDefaultCount(0);
+		releaseExternal();
 	}
 }
 

--- a/src/jrd/Routine.h
+++ b/src/jrd/Routine.h
@@ -148,6 +148,7 @@ namespace Jrd
 		void release(thread_db* tdbb);
 		void releaseStatement(thread_db* tdbb);
 		void remove(thread_db* tdbb);
+		virtual void releaseExternal() {};
 
 	public:
 		virtual int getObjectType() const = 0;

--- a/src/jrd/jrd.cpp
+++ b/src/jrd/jrd.cpp
@@ -9020,8 +9020,6 @@ void TrigVector::release(thread_db* tdbb) const
 			JrdStatement* stmt = t->statement;
 			if (stmt)
 				stmt->release(tdbb);
-
-			delete t->extTrigger;
 		}
 
 		delete this;

--- a/src/jrd/jrd.h
+++ b/src/jrd/jrd.h
@@ -170,6 +170,11 @@ public:
 		  extBody(p),
 		  extTrigger(NULL)
 	{}
+
+	virtual ~Trigger()
+	{
+		delete extTrigger;
+	}
 };
 
 
@@ -251,6 +256,11 @@ public:
 	{
 		delete prc_record_format;
 		prc_record_format = NULL;
+	}
+
+	virtual ~jrd_prc()
+	{
+		delete prc_external;
 	}
 
 	virtual bool checkCache(thread_db* tdbb) const;

--- a/src/jrd/jrd.h
+++ b/src/jrd/jrd.h
@@ -265,6 +265,12 @@ public:
 
 	virtual bool checkCache(thread_db* tdbb) const;
 	virtual void clearCache(thread_db* tdbb);
+
+	virtual void releaseExternal()
+	{
+		delete prc_external;
+		prc_external = NULL;
+	}
 };
 
 


### PR DESCRIPTION
Some engine objects never destructing explicitly, but hold resources of external engine which should be released. As I see udr_engine do not affected leaking, but architecture of fbjava prone to leaking if dispose/release never called. I've added straightforward solution to avoid memory leaks from external engine, is it ok? 3.0 have same problem.