### PR TITLE
Reload firebird.conf after spawning CS server process.

### DIFF
--- a/src/common/config/config.cpp
+++ b/src/common/config/config.cpp
@@ -79,14 +79,10 @@ public:
 		}
 	}
 
-	/***
-	It was a kind of getting ready for changing config remotely...
-
 	void changeDefaultConfig(Config* newConfig)
 	{
 		defaultConfig = newConfig;
 	}
-	***/
 
 	Firebird::RefPtr<const Config>& getDefaultConfig()
 	{
@@ -303,6 +299,12 @@ void Config::merge(Firebird::RefPtr<const Config>& config, const Firebird::strin
 		ConfigFile txtStream(ConfigFile::USE_TEXT, dpbConfig->c_str());
 		config = FB_NEW Config(txtStream, *(config.hasData() ? config : getDefaultConfig()));
 	}
+}
+
+void Config::reload()
+{
+	ConfigFile file(fb_utils::getPrefix(Firebird::IConfigManager::DIR_CONF, CONFIG_FILE), 0);
+	firebirdConf().changeDefaultConfig(FB_NEW Config(file, *(firebirdConf().getDefaultConfig())));
 }
 
 void Config::loadValues(const ConfigFile& file)

--- a/src/common/config/config.h
+++ b/src/common/config/config.h
@@ -214,6 +214,9 @@ public:
 	// Merge config entries from DPB into existing config
 	static void merge(Firebird::RefPtr<const Config>& config, const Firebird::string* dpbConfig);
 
+	// Reload firebird.conf from disk
+	static void reload();
+
 	// reports key to be used by the following functions
 	static unsigned int getKeyByName(ConfigName name);
 	// helpers to build interface for firebird.conf file

--- a/src/remote/inet.cpp
+++ b/src/remote/inet.cpp
@@ -1102,6 +1102,7 @@ static rem_port* listener_socket(rem_port* port, USHORT flag, const addrinfo* pa
 			port->port_handle = s;
 			port->port_server_flags |= SRVR_server;
 			port->port_flags |= PORT_server;
+			Config::reload();
 			return port;
 		}
 


### PR DESCRIPTION
In pre 3.0 era classic had sometimes useful ability: it not required restart after config changes (because it was spawned by xinetd). Now if server's child process was spawned by parent firebird process config will not be reloaded, because it loaded once and inherited from parent. How about reloading it forcefuly?

This is partial solution: ServerMode and UdfAccess will not be updated,
because they cached (actually we do not need to change ServerMode, but
change UdfAccess will be useful).