### PR TITLE
If stdin is FILE_TYPE_PIPE then we should treat it as non-interactive

### DIFF
--- a/src/isql/isql.epp
+++ b/src/isql/isql.epp
@@ -8753,7 +8753,7 @@ static bool stdin_redirected()
 #ifdef WIN_NT
 	HANDLE in = GetStdHandle(STD_INPUT_HANDLE);
 	const DWORD file_type = GetFileType(in);
-	if (file_type == FILE_TYPE_CHAR || file_type == FILE_TYPE_PIPE)
+	if (file_type == FILE_TYPE_CHAR)
 		return false;
 #else
 	if (isatty(fileno(stdin)))


### PR DESCRIPTION
With current check isql always in interactive mode, even when input is piped (like echo connect 'test'; | isql.exe ...)