### PR TITLE
CORE-6004: Add a switch to disable the "TCP Loopback Fast Path" option

### DIFF
--- a/builds/install/misc/firebird.conf.in
+++ b/builds/install/misc/firebird.conf.in
@@ -774,7 +774,7 @@
 #
 # Type: Boolean, default 1 (true)
 #
-#TcpLoopbackFastPathOption = 1
+#TcpLoopbackFastPath = 1
 
 #
 # Allows setting of IPV6_V6ONLY socket option. If enabled, IPv6 sockets

--- a/builds/install/misc/firebird.conf.in
+++ b/builds/install/misc/firebird.conf.in
@@ -769,6 +769,14 @@
 #TcpNoNagle = 1
 
 #
+# Either enables or disables the "TCP Loopback Fast Path" feature (SIO_LOOPBACK_FAST_PATH).
+# Applies to Windows (version 8/2012 or higher) only.
+#
+# Type: Boolean, default 1 (true)
+#
+#TcpLoopbackFastPathOption = 1
+
+#
 # Allows setting of IPV6_V6ONLY socket option. If enabled, IPv6 sockets
 # allow only IPv6 communication and separate sockets must be used for
 # IPv4 and IPv6. Default is false.

--- a/doc/Firebird_conf.txt
+++ b/doc/Firebird_conf.txt
@@ -124,7 +124,7 @@ Only meaningful for Windows SS on SMP systems.
 OldParameterOrdering       boolean  default false
 TcpRemoteBufferSize        integer  default 8192 (bytes)
 TcpNoNagle                 boolean  default false
-TcpLoopbackFastPathOption  boolean  default true
+TcpLoopbackFastPath        boolean  default true
 IpcMapSize                 integer  default 4096 (bytes)
 DefaultDbCachePages        integer  default SS: 2048. CS: 75
 ConnectionTimeout          integer  default 180 (seconds)

--- a/doc/Firebird_conf.txt
+++ b/doc/Firebird_conf.txt
@@ -124,6 +124,7 @@ Only meaningful for Windows SS on SMP systems.
 OldParameterOrdering       boolean  default false
 TcpRemoteBufferSize        integer  default 8192 (bytes)
 TcpNoNagle                 boolean  default false
+TcpLoopbackFastPathOption  boolean  default true
 IpcMapSize                 integer  default 4096 (bytes)
 DefaultDbCachePages        integer  default SS: 2048. CS: 75
 ConnectionTimeout          integer  default 180 (seconds)

--- a/src/common/config/config.cpp
+++ b/src/common/config/config.cpp
@@ -148,7 +148,7 @@ const Config::ConfigEntry Config::entries[MAX_CONFIG_KEY] =
 	{TYPE_INTEGER,		"CpuAffinityMask",			(ConfigValue) 0},
 	{TYPE_INTEGER,		"TcpRemoteBufferSize",		(ConfigValue) 8192},		// bytes
 	{TYPE_BOOLEAN,		"TcpNoNagle",				(ConfigValue) true},
-	{TYPE_BOOLEAN,		"TcpLoopbackFastPathOption",(ConfigValue) true},
+	{TYPE_BOOLEAN,		"TcpLoopbackFastPath",      (ConfigValue) true},
 	{TYPE_INTEGER,		"DefaultDbCachePages",		(ConfigValue) -1},			// pages
 	{TYPE_INTEGER,		"ConnectionTimeout",		(ConfigValue) 180},			// seconds
 	{TYPE_INTEGER,		"DummyPacketInterval",		(ConfigValue) 0},			// seconds
@@ -493,9 +493,9 @@ bool Config::getTcpNoNagle() const
 	return get<bool>(KEY_TCP_NO_NAGLE);
 }
 
-bool Config::getTcpLoopbackFastPathOption() const
+bool Config::getTcpLoopbackFastPath() const
 {
-	return get<bool>(KEY_TCP_LOOPBACK_FAST_PATH_OPTION);
+	return get<bool>(KEY_TCP_LOOPBACK_FAST_PATH);
 }
 
 bool Config::getIPv6V6Only() const

--- a/src/common/config/config.cpp
+++ b/src/common/config/config.cpp
@@ -148,6 +148,7 @@ const Config::ConfigEntry Config::entries[MAX_CONFIG_KEY] =
 	{TYPE_INTEGER,		"CpuAffinityMask",			(ConfigValue) 0},
 	{TYPE_INTEGER,		"TcpRemoteBufferSize",		(ConfigValue) 8192},		// bytes
 	{TYPE_BOOLEAN,		"TcpNoNagle",				(ConfigValue) true},
+	{TYPE_BOOLEAN,		"TcpLoopbackFastPathOption",(ConfigValue) true},
 	{TYPE_INTEGER,		"DefaultDbCachePages",		(ConfigValue) -1},			// pages
 	{TYPE_INTEGER,		"ConnectionTimeout",		(ConfigValue) 180},			// seconds
 	{TYPE_INTEGER,		"DummyPacketInterval",		(ConfigValue) 0},			// seconds
@@ -490,6 +491,11 @@ int Config::getTcpRemoteBufferSize()
 bool Config::getTcpNoNagle() const
 {
 	return get<bool>(KEY_TCP_NO_NAGLE);
+}
+
+bool Config::getTcpLoopbackFastPathOption() const
+{
+	return get<bool>(KEY_TCP_LOOPBACK_FAST_PATH_OPTION);
 }
 
 bool Config::getIPv6V6Only() const

--- a/src/common/config/config.h
+++ b/src/common/config/config.h
@@ -95,7 +95,7 @@ public:
 		KEY_CPU_AFFINITY_MASK,
 		KEY_TCP_REMOTE_BUFFER_SIZE,
 		KEY_TCP_NO_NAGLE,
-		KEY_TCP_LOOPBACK_FAST_PATH_OPTION,
+		KEY_TCP_LOOPBACK_FAST_PATH,
 		KEY_DEFAULT_DB_CACHE_PAGES,
 		KEY_CONNECTION_TIMEOUT,
 		KEY_DUMMY_PACKET_INTERVAL,
@@ -254,7 +254,7 @@ public:
 	bool getTcpNoNagle() const;
 
 	// Enable or disable the TCP Loopback Fast Path option
-	bool getTcpLoopbackFastPathOption() const;
+	bool getTcpLoopbackFastPath() const;
 
 	// Let IPv6 socket accept only IPv6 packets
 	bool getIPv6V6Only() const;

--- a/src/common/config/config.h
+++ b/src/common/config/config.h
@@ -95,6 +95,7 @@ public:
 		KEY_CPU_AFFINITY_MASK,
 		KEY_TCP_REMOTE_BUFFER_SIZE,
 		KEY_TCP_NO_NAGLE,
+		KEY_TCP_LOOPBACK_FAST_PATH_OPTION,
 		KEY_DEFAULT_DB_CACHE_PAGES,
 		KEY_CONNECTION_TIMEOUT,
 		KEY_DUMMY_PACKET_INTERVAL,
@@ -251,6 +252,9 @@ public:
 
 	// Disable Nagle algorithm
 	bool getTcpNoNagle() const;
+
+	// Enable or disable the TCP Loopback Fast Path option
+	bool getTcpLoopbackFastPathOption() const;
 
 	// Let IPv6 socket accept only IPv6 packets
 	bool getIPv6V6Only() const;

--- a/src/remote/inet.cpp
+++ b/src/remote/inet.cpp
@@ -3243,7 +3243,7 @@ static bool setNoNagleOption(rem_port* port)
 bool setFastLoopbackOption(rem_port* port, SOCKET s /*= 0*/)
 {
 #ifdef WIN_NT
-	if (port->getPortConfig()->getTcpLoopbackFastPathOption())
+	if (port->getPortConfig()->getTcpLoopbackFastPath())
 	{
 		if (s == 0)
 			s = port->port_handle;

--- a/src/remote/inet.cpp
+++ b/src/remote/inet.cpp
@@ -3240,7 +3240,7 @@ static bool setNoNagleOption(rem_port* port)
 	return true;
 }
 
-bool setFastLoopbackOption(rem_port* port, SOCKET s = 0)
+bool setFastLoopbackOption(rem_port* port, SOCKET s /*= 0*/)
 {
 #ifdef WIN_NT
 	if (port->getPortConfig()->getTcpLoopbackFastPathOption())

--- a/src/remote/inet.cpp
+++ b/src/remote/inet.cpp
@@ -3242,16 +3242,18 @@ static bool setNoNagleOption(rem_port* port)
 bool setFastLoopbackOption(SOCKET s)
 {
 #ifdef WIN_NT
-	int optval = 1;
-	DWORD bytes = 0;
+	if (Config::getDefaultConfig()->getTcpLoopbackFastPathOption())
+	{
+		int optval = 1;
+		DWORD bytes = 0;
 
-	int ret = WSAIoctl(s, SIO_LOOPBACK_FAST_PATH, &optval, sizeof(optval),
-					   NULL, 0, &bytes, 0, 0);
+		int ret = WSAIoctl(s, SIO_LOOPBACK_FAST_PATH, &optval, sizeof(optval),
+			NULL, 0, &bytes, 0, 0);
 
-	return (ret == 0);
-#else
-	return false;
+		return (ret == 0);
+	}
 #endif
+	return false;
 }
 
 void setStopMainThread(FPTR_INT func)


### PR DESCRIPTION
This affects Windows 8/2012 and higher only.

