### PR TITLE
fix CXXFLAGS in Linux makefiles

### DIFF
--- a/builds/posix/prefix.linux
+++ b/builds/posix/prefix.linux
@@ -19,7 +19,7 @@
 # 2 Oct 2002, Nickolay Samofatov - Major cleanup
 
 COMMON_FLAGS=-ggdb -DFB_SEND_FLAGS=MSG_NOSIGNAL -DLINUX -pipe -MMD -fPIC -fmessage-length=0 -fno-delete-null-pointer-checks
-CXXFLAGS=-std=gnu++03
+CXXFLAGS:=-std=gnu++03 $(CXXFLAGS)
 OPTIMIZE_FLAGS=-O3 -march=i586 -mtune=i686 -fno-omit-frame-pointer
 WARN_FLAGS=-Wall -Wno-switch -Wno-parentheses -Wno-unknown-pragmas -Wno-unused-variable -Wno-narrowing
 

--- a/builds/posix/prefix.linux_amd64
+++ b/builds/posix/prefix.linux_amd64
@@ -19,7 +19,7 @@
 # 2 Oct 2002, Nickolay Samofatov - Major cleanup
 
 COMMON_FLAGS=-ggdb -DFB_SEND_FLAGS=MSG_NOSIGNAL -DLINUX -DAMD64 -pipe -MMD -fPIC -fmessage-length=0 -fno-delete-null-pointer-checks
-CXXFLAGS=-std=gnu++03
+CXXFLAGS:=-std=gnu++03 $(CXXFLAGS)
 OPTIMIZE_FLAGS=-O3 -fno-omit-frame-pointer
 WARN_FLAGS=-Wall -Wno-switch -Wno-parentheses -Wno-unknown-pragmas -Wno-unused-variable -Wno-invalid-offsetof -Wno-narrowing -Wno-unused-local-typedefs
 

--- a/builds/posix/prefix.linux_generic
+++ b/builds/posix/prefix.linux_generic
@@ -19,7 +19,7 @@
 # 2 Oct 2002, Nickolay Samofatov - Major cleanup
 
 COMMON_FLAGS=-DLINUX -pipe -MMD -fPIC -DFB_SEND_FLAGS=MSG_NOSIGNAL -fno-delete-null-pointer-checks
-CXXFLAGS=-std=gnu++03
+CXXFLAGS:=-std=gnu++03 $(CXXFLAGS)
 
 PROD_FLAGS=-ggdb -O3 $(COMMON_FLAGS)
 DEV_FLAGS=-ggdb -p -Wall -Wno-switch $(COMMON_FLAGS) -Wno-non-virtual-dtor


### PR DESCRIPTION
There are 2 issues with commit f5b6afeddbc8e90e6162ed2e86b257dcf27427c6:

1) Makefiles unconditionally override CXXFLAGS, so the CXXFLAGS that are
   passed to configure no longer take effect during the build

2) Clang 7 refuses to compile any code that uses ICU, because ICU 63
   makes use of C++11 features (strangely GCC doesn't complain);
   -std=gnu++11 appears to work so let's use that