### PR TITLE
Allow to load system ICU (when shared modules names have no version t…

### DIFF
--- a/src/common/unicode_util.cpp
+++ b/src/common/unicode_util.cpp
@@ -1168,7 +1168,7 @@ UnicodeUtil::ConversionICU& UnicodeUtil::getConversionICU()
 
 	// Try "favorite" (distributed on windows) version first
 	const int favMaj = 63;
-	const int favMin = 1;
+	const int favMin = 0;
 	try
 	{
 		if ((convIcu = ImplementConversionICU::create(favMaj, favMin)))

--- a/src/common/unicode_util.cpp
+++ b/src/common/unicode_util.cpp
@@ -87,33 +87,88 @@ public:
 	{
 	}
 
-	template <typename T> void getEntryPoint(const char* name, ModuleLoader::Module* module, T& ptr)
+	void initialize(ModuleLoader::Module* module);
+
+	template <typename T> void getEntryPoint(const char* name, ModuleLoader::Module* module, T& ptr, bool optional = false)
 	{
-		// ICU has several schemas for entries names
-		const char* patterns[] =
+		// System-wide ICU have no version number at entries names
+		if (!majorVersion)
 		{
-			"%s_%d", "%s_%d_%d", "%s_%d%d", "%s", NULL
-		};
-
-		string symbol;
-
-		for (const char** p = patterns; *p; ++p)
-		{
-			symbol.printf(*p, name, majorVersion, minorVersion);
-			module->findSymbol(NULL, symbol, ptr);
-			if (ptr)
+			if (module->findSymbol(NULL, name, ptr))
 				return;
 		}
+		else
+		{
 
-		(Arg::Gds(isc_icu_entrypoint) << name).raise();
+			// ICU has several schemas for entries names
+			const char* patterns[] =
+			{
+				"%s_%d", "%s_%d_%d", "%s_%d%d", "%s", NULL
+			};
+
+			string symbol;
+
+			for (const char** p = patterns; *p; ++p)
+			{
+				symbol.printf(*p, name, majorVersion, minorVersion);
+				if (module->findSymbol(NULL, symbol, ptr))
+					return;
+			}
+		}
+
+		if (!optional)
+			(Arg::Gds(isc_icu_entrypoint) << name).raise();
 	}
 
 	int majorVersion;
 	int minorVersion;
+};
 
+void BaseICU::initialize(ModuleLoader::Module* module)
+{
 	void (U_EXPORT2 *uInit)(UErrorCode* status);
 	void (U_EXPORT2 *uSetDataDirectory)(const char* directory);
+
+	getEntryPoint("u_init", module, uInit, true);
+	getEntryPoint("u_setDataDirectory", module, uSetDataDirectory, true);
+
+#ifdef WIN_NT
+	if (uSetDataDirectory)
+	{
+		// call uSetDataDirectory only if .dat file is exists at same folder 
+		// as the loaded module 
+
+		PathName path, file, fullName;
+		PathUtils::splitLastComponent(path, file, module->fileName);
+
+		// icuucXX.dll -> icudtXX.dll
+		file.replace(3, 2, "dt");
+
+		// icudtXX.dll -> icudtXXl.dat
+		const FB_SIZE_T pos = file.find_last_of('.');
+		file.erase(pos);
+		file.append("l.dat");
+
+		PathUtils::concatPath(fullName, path, file);
+
+		if (PathUtils::canAccess(fullName, 0))
+			uSetDataDirectory(path.c_str());
+	}
+#endif
+
+	if (uInit)
+	{
+		UErrorCode status = U_ZERO_ERROR;
+		uInit(&status);
+		if (status != U_ZERO_ERROR)
+		{
+			string diag;
+			diag.printf("u_init() error %d", status);
+			(Arg::Gds(isc_random) << diag).raise();
+		}
+	}
 };
+
 }
 
 namespace Jrd {
@@ -230,14 +285,8 @@ private:
 		if (!module)
 			return;
 
-		try
-		{
-			getEntryPoint("u_init", module, uInit);
-		}
-		catch (const status_exception&)
-		{ }
+		initialize(module);
 
-		getEntryPoint("u_setDataDirectory", module, uSetDataDirectory);
 		getEntryPoint("ucnv_open", module, ucnv_open);
 		getEntryPoint("ucnv_close", module, ucnv_close);
 		getEntryPoint("ucnv_fromUChars", module, ucnv_fromUChars);
@@ -258,27 +307,6 @@ private:
 		getEntryPoint("ucnv_setToUCallBack", module, ucnv_setToUCallBack);
 
 		getEntryPoint("u_strcmp", module, ustrcmp);
-
-#ifdef WIN_NT
-		if (uSetDataDirectory)
-		{
-			PathName path, file;
-			PathUtils::splitLastComponent(path, file, module->fileName);
-			uSetDataDirectory(path.c_str());
-		}
-#endif
-
-		if (uInit)
-		{
-			UErrorCode status = U_ZERO_ERROR;
-			uInit(&status);
-			if (status != U_ZERO_ERROR)
-			{
-				string diag;
-				diag.printf("u_init() error %d", status);
-				(Arg::Gds(isc_random) << diag).raise();
-			}
-		}
 
 		inModule = formatAndLoad(inTemplate, aMajorVersion, aMinorVersion);
 		if (!inModule)
@@ -365,24 +393,45 @@ static GlobalPtr<UnicodeUtil::ICUModules> icuModules;
 static ModuleLoader::Module* formatAndLoad(const char* templateName,
 	int majorVersion, int minorVersion)
 {
-	// ICU has several schemas for placing version into file name
-	const char* patterns[] =
-	{
-		"%d", "%d_%d", "%d%d", NULL
-	};
+	ModuleLoader::Module* module = nullptr;
 
-	PathName s, filename;
-	for (const char** p = patterns; *p; ++p)
+	// System-wide ICU have no version number at file names
+	if (!majorVersion)
 	{
-		s.printf(*p, majorVersion, minorVersion);
-		filename.printf(templateName, s.c_str());
+		PathName filename;
+		filename.printf(templateName, "");
+		module = ModuleLoader::fixAndLoadModule(NULL, filename);
+	}
+	else
+	{
+		// ICU has several schemas for placing version into file name
+		const char* patterns[] =
+		{
+			"%d_%d", "%d%d", NULL
+		};
 
-		ModuleLoader::Module* module = ModuleLoader::fixAndLoadModule(NULL, filename);
-		if (module)
-			return module;
+		PathName s, filename;
+		for (const char** p = patterns; *p; ++p)
+		{
+			s.printf(*p, majorVersion, minorVersion);
+			filename.printf(templateName, s.c_str());
+
+			module = ModuleLoader::fixAndLoadModule(NULL, filename);
+			if (module)
+				break;
+		}
+
+		// There is no sence to try pattern "%d" for different minor versions
+		if (!module && minorVersion == 0)
+		{
+			s.printf("%d", majorVersion);
+			filename.printf(templateName, s.c_str());
+
+			module = ModuleLoader::fixAndLoadModule(NULL, filename);
+		}
 	}
 
-	return nullptr;
+	return module;
 }
 
 
@@ -1040,14 +1089,8 @@ UnicodeUtil::ICU* UnicodeUtil::loadICU(const string& icuVersion, const string& c
 
 		try
 		{
-			icu->getEntryPoint("u_init", icu->ucModule, icu->uInit);
-		}
-		catch (const status_exception&)
-		{ }
+			icu->initialize(icu->ucModule);
 
-		try
-		{
-			icu->getEntryPoint("u_setDataDirectory", icu->ucModule, icu->uSetDataDirectory);
 			icu->getEntryPoint("u_versionToString", icu->ucModule, icu->uVersionToString);
 			icu->getEntryPoint("uloc_countAvailable", icu->ucModule, icu->ulocCountAvailable);
 			icu->getEntryPoint("uloc_getAvailable", icu->ucModule, icu->ulocGetAvailable);
@@ -1074,27 +1117,7 @@ UnicodeUtil::ICU* UnicodeUtil::loadICU(const string& icuVersion, const string& c
 			continue;
 		}
 
-#ifdef WIN_NT
-		if (icu->uSetDataDirectory)
-		{
-			PathName path, file;
-			PathUtils::splitLastComponent(path, file, icu->ucModule->fileName);
-			icu->uSetDataDirectory(path.c_str());
-		}
-#endif
-
 		UErrorCode status = U_ZERO_ERROR;
-
-		if (icu->uInit)
-		{
-			icu->uInit(&status);
-			if (status != U_ZERO_ERROR)
-			{
-				gds__log("u_init() error %d", status);
-				delete icu;
-				continue;
-			}
-		}
 
 		UCollator* collator = icu->ucolOpen("", &status);
 		if (!collator)
@@ -1154,14 +1177,36 @@ UnicodeUtil::ConversionICU& UnicodeUtil::getConversionICU()
 	catch (const Exception&)
 	{ }
 
+	// Try system-wide version
+	try
+	{
+		if ((convIcu = ImplementConversionICU::create(0, 0)))
+			return *convIcu;
+	}
+	catch (const Exception&)
+	{ }
+
 	// Do a regular search
 	LocalStatus ls;
 	CheckStatusWrapper lastError(&ls);
 	string version;
 
-	for (int major = 4; major <= 79; ++major)
+	// According to http://userguide.icu-project.org/design#TOC-Version-Numbers-in-ICU
+	// we using two ranges of version numbers: 3.0 - 4.8 and 49 - 79.
+	// Note 1: the most current version for now is 64, thus it is seems as enough to 
+	// limit upper bound by value of 79. It should be enlarged when necessary in the
+	// future.
+	// Note 2: the required function ucal_getTZDataVersion() is available since 3.8.
+
+	for (int major = 79; major >= 3;)
 	{
-		for (int minor = 20; minor--; ) // from 19 down to 0
+		int minor = 0; 
+		if (major == 4)
+			minor = 8;
+		else if (major <= 4)
+			minor = 9;
+
+		for (; minor >= 0; --minor)
 		{
 			if ((major == favMaj) && (minor == favMin))
 			{
@@ -1179,12 +1224,20 @@ UnicodeUtil::ConversionICU& UnicodeUtil::getConversionICU()
 				version.printf("Error loading ICU library version %d.%d", major, minor);
 			}
 		}
+
+		if (major == 49)
+			major = 4;
+		else
+			major--;
 	}
 
+	Arg::Gds err(isc_icu_library);
+
 	if (lastError.getState() & Firebird::IStatus::STATE_ERRORS)
-		(Arg::Gds(isc_icu_library) << Arg::StatusVector(lastError.getErrors())).raise();
-	else
-		Arg::Gds(isc_icu_library).raise();
+		err << Arg::StatusVector(lastError.getErrors()) << 
+			   Arg::Gds(isc_random) << Arg::Str(version);
+
+	err.raise();
 
 	// compiler warning silencer
 	return *convIcu;

--- a/src/common/unicode_util.cpp
+++ b/src/common/unicode_util.cpp
@@ -89,7 +89,8 @@ public:
 
 	void initialize(ModuleLoader::Module* module);
 
-	template <typename T> void getEntryPoint(const char* name, ModuleLoader::Module* module, T& ptr, bool optional = false)
+	template <typename T> void getEntryPoint(const char* name, ModuleLoader::Module* module, T& ptr,
+		bool optional = false)
 	{
 		// System-wide ICU have no version number at entries names
 		if (!majorVersion)
@@ -135,8 +136,8 @@ void BaseICU::initialize(ModuleLoader::Module* module)
 #ifdef WIN_NT
 	if (uSetDataDirectory)
 	{
-		// call uSetDataDirectory only if .dat file is exists at same folder 
-		// as the loaded module 
+		// call uSetDataDirectory only if .dat file is exists at same folder
+		// as the loaded module
 
 		PathName path, file, fullName;
 		PathUtils::splitLastComponent(path, file, module->fileName);
@@ -167,7 +168,7 @@ void BaseICU::initialize(ModuleLoader::Module* module)
 			(Arg::Gds(isc_random) << diag).raise();
 		}
 	}
-};
+}
 
 }
 
@@ -1193,14 +1194,14 @@ UnicodeUtil::ConversionICU& UnicodeUtil::getConversionICU()
 
 	// According to http://userguide.icu-project.org/design#TOC-Version-Numbers-in-ICU
 	// we using two ranges of version numbers: 3.0 - 4.8 and 49 - 79.
-	// Note 1: the most current version for now is 64, thus it is seems as enough to 
+	// Note 1: the most current version for now is 64, thus it is seems as enough to
 	// limit upper bound by value of 79. It should be enlarged when necessary in the
 	// future.
 	// Note 2: the required function ucal_getTZDataVersion() is available since 3.8.
 
 	for (int major = 79; major >= 3;)
 	{
-		int minor = 0; 
+		int minor = 0;
 		if (major == 4)
 			minor = 8;
 		else if (major <= 4)
@@ -1234,8 +1235,10 @@ UnicodeUtil::ConversionICU& UnicodeUtil::getConversionICU()
 	Arg::Gds err(isc_icu_library);
 
 	if (lastError.getState() & Firebird::IStatus::STATE_ERRORS)
-		err << Arg::StatusVector(lastError.getErrors()) << 
+	{
+		err << Arg::StatusVector(lastError.getErrors()) <<
 			   Arg::Gds(isc_random) << Arg::Str(version);
+	}
 
 	err.raise();
 


### PR DESCRIPTION
Allow to load system ICU (when shared modules names have no version tag).
Refactor ICU load\initialization code a bit to avoid code duplication and dumb try\catch.
Change ICU versions search range to avoid looking for never existing versions and significantly reduce search time.
Now ICU search order is: preferred version (63), system-wide version, 79-49, 4.8-3.0
Improve error reporting a bit - include ICU version number that failed to load or init.