### PR TITLE
Add padding for on-disk structures to ensure their sizes are always guaranteed

### DIFF
--- a/src/jrd/ods.h
+++ b/src/jrd/ods.h
@@ -423,6 +423,7 @@ struct header_page
 	SLONG hdr_att_high;				// High word of the next attachment counter
 	USHORT hdr_tra_high[4];			// High words of the transaction counters
 	UCHAR hdr_data[1];				// Misc data
+	USHORT hdr_padding;				// Padding
 };
 
 #define HDR_SIZE static_cast<FB_SIZE_T>(offsetof(Ods::header_page, hdr_data[0]))
@@ -479,6 +480,7 @@ struct page_inv_page
 	ULONG pip_extent;			// Lowest free extent
 	ULONG pip_used;				// Number of pages allocated from this PIP page
 	UCHAR pip_bits[1];
+	USHORT pip_padding;			// Padding
 };
 
 
@@ -530,6 +532,7 @@ struct pointer_page
 	USHORT ppg_count;			// Number of slots active
 	USHORT ppg_relation;		// Relation id
 	USHORT ppg_min_space;		// Lowest slot with space available
+	USHORT ppg_padding;		// Padding
 	ULONG ppg_page[1];			// Data page vector
 };
 
@@ -564,6 +567,7 @@ struct tx_inv_page
 	pag tip_header;
 	ULONG tip_next;				// Next transaction inventory page
 	UCHAR tip_transactions[1];
+	USHORT tip_padding;			// Padding
 };
 
 
@@ -588,6 +592,7 @@ struct rhd
 	USHORT rhd_flags;			// flags, etc
 	UCHAR rhd_format;			// format version
 	UCHAR rhd_data[1];			// record data
+	USHORT rhd_padding;			// padding
 };
 
 #define RHD_SIZE static_cast<FB_SIZE_T>(offsetof(Ods::rhd, rhd_data[0]))
@@ -603,6 +608,7 @@ struct rhde
 	UCHAR rhde_format;			// format version	// until here, same as rhd
 	USHORT rhde_tra_high;		// higher bits of transaction id
 	UCHAR rhde_data[1];			// record data
+	USHORT rhde_padding;			// padding
 };
 
 #define RHDE_SIZE static_cast<FB_SIZE_T>(offsetof(Ods::rhde, rhde_data[0]))
@@ -634,6 +640,7 @@ struct blh
 	USHORT blh_max_segment;		// Longest segment
 	USHORT blh_flags;			// flags, etc
 	UCHAR blh_level;			// Number of address levels, see blb_level in blb.h
+	USHORT blh_padding;			// Padding
 	ULONG blh_count;			// Total number of segments
 	ULONG blh_length;			// Total length of data
 	USHORT blh_sub_type;		// Blob sub-type

--- a/src/misc/ods.txt
+++ b/src/misc/ods.txt
@@ -87,6 +87,7 @@ hdr_crypt_plugin 88
 hdr_att_high 120
 hdr_tra_high 124
 hdr_data 132
+hdr_padding 134
 
  *** struct page_inv_page 32
 pip_header 0
@@ -94,6 +95,7 @@ pip_min 16
 pip_extent 20
 pip_used 24
 pip_bits 28
+pip_padding 30
 
  *** struct scns_page 24
 scn_header 0
@@ -107,12 +109,14 @@ ppg_next 20
 ppg_count 24
 ppg_relation 26
 ppg_min_space 28
+ppg_padding 30
 ppg_page 32
 
  *** struct tx_inv_page 24
 tip_header 0
 tip_next 16
 tip_transactions 20
+tip_padding 22
 
  *** struct generator_page 32
 gpg_header 0
@@ -127,6 +131,7 @@ rhd_b_line 8
 rhd_flags 10
 rhd_format 12
 rhd_data 13
+rhd_padding 14
 
  *** struct rhde 20
 rhde_transaction 0
@@ -136,6 +141,7 @@ rhde_flags 10
 rhde_format 12
 rhde_tra_high 14
 rhde_data 16
+rhde_padding 18
 
  *** struct rhdf 24
 rhdf_transaction 0
@@ -154,6 +160,7 @@ blh_max_sequence 4
 blh_max_segment 8
 blh_flags 10
 blh_level 12
+blh_padding 14
 blh_count 16
 blh_length 20
 blh_sub_type 24


### PR DESCRIPTION
In order to guarantee that the on-disk structures have always the expected
sizes, we should use padding fields within these structs rather than relying
on the native alignment of the target architecture which can result in
unexpected sizes for architectures with unusual native alignment.