### PR TITLE
Resolves: tdf#125284 config entries not substituted under Turkish locale

### DIFF
--- a/src/common/config/config_file.cpp
+++ b/src/common/config/config_file.cpp
@@ -530,16 +530,14 @@ bool ConfigFile::substituteStandardDir(const String& from, String& to) const
 		unsigned code;
 		const char* name;
 	} dirs[] = {
-#define NMDIR(a) {Firebird::IConfigManager::a, "FB_"#a},
-		NMDIR(DIR_CONF)
-		NMDIR(DIR_SECDB)
-		NMDIR(DIR_PLUGINS)
-		NMDIR(DIR_UDF)
-		NMDIR(DIR_SAMPLE)
-		NMDIR(DIR_SAMPLEDB)
-		NMDIR(DIR_INTL)
-		NMDIR(DIR_MSG)
-#undef NMDIR
+		{Firebird::IConfigManager::DIR_CONF, "FB_dir_conf"},
+		{Firebird::IConfigManager::DIR_SECDB, "FB_dir_secdb"},
+		{Firebird::IConfigManager::DIR_PLUGINS, "FB_dir_plugins"},
+		{Firebird::IConfigManager::DIR_UDF, "FB_dir_udf"},
+		{Firebird::IConfigManager::DIR_SAMPLE, "FB_dir_sample"},
+		{Firebird::IConfigManager::DIR_SAMPLEDB, "FB_dir_sampledb"},
+		{Firebird::IConfigManager::DIR_INTL, "FB_dir_intl"},
+		{Firebird::IConfigManager::DIR_MSG, "FB_dir_msg"},
 		{Firebird::IConfigManager::DIR_COUNT, NULL}
 	};
 


### PR DESCRIPTION
https://bugs.documentfoundation.org/show_bug.cgi?id=125284

This leads to the inability of LibreOffice to create embedded firebird
databases under a Turkish locale.

strcasecmp is used with LC_CTYPE honoured, and...

"These functions shall behave as if the strings had been converted to
lowercase and then a byte comparison performed".

Turkish has the infamous problem that the lowercase of I is the
dotless ı not i.

so strcasecmp("i", "I") != 0 means dir_FOO doesn't caseless match DIR_FOO

firebird/databases.conf contains $(dir_sampleDb) and the string it's compared
to is DIR_SAMPLEDB so a simple fix is to changed DIR_SAMPLEDB to dir_sampledb
and the defalt config will then substitute fine.