### PR TITLE
CORE-5976 increase minimum for multi-database restore

### DIFF
--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -653,7 +653,7 @@ void add_files(BurpGlobals* tdgbl, const char* file_name)
 
 	// store the RDB$FILES records
 
-	FB_UINT64 start = FB_CONST64(201); // Magic number, can be taken from some constant?
+	FB_UINT64 start = FB_CONST64(256); // Magic number, can be taken from some constant?
 	SLONG count = 0;
 	const char* prev_file_name = NULL;
 


### PR DESCRIPTION
Fixes http://tracker.firebirdsql.org/browse/CORE-5976

The actual minimum size seems to be determined dynamically by the result of database creation, so I opted to increase the minimum start size from 201 to 256.