### PR TITLE
Fixed CORE-5902 - Add Firebird Event fails with error

### DIFF
--- a/src/remote/SockAddr.h
+++ b/src/remote/SockAddr.h
@@ -59,6 +59,8 @@ private:
 	void checkAndFixFamily();
 
 public:
+	void convertFromMacOsToPosixWindows();
+	void convertFromPosixWindowsToMacOs();
 	void clear();
 	const SockAddr& operator = (const SockAddr& x);
 
@@ -117,6 +119,44 @@ inline void SockAddr::checkAndFixFamily()
 	default:
 		fb_assert(false);
 		break;
+	}
+}
+
+inline void SockAddr::convertFromMacOsToPosixWindows()
+{
+	struct
+	{
+		uint16_t sa_family;
+		char sa_data[14];
+	} sockAddrPosixWindows;
+
+	if (length() > sizeof(sockAddrPosixWindows))
+		fb_assert(false);
+	else
+	{
+		sockAddrPosixWindows.sa_family = ptr()->sa_family;
+		memcpy(sockAddrPosixWindows.sa_data, ptr()->sa_data, length() - 2);
+		memcpy(ptr(), &sockAddrPosixWindows, length());
+	}
+}
+
+inline void SockAddr::convertFromPosixWindowsToMacOs()
+{
+	struct
+	{
+		uint8_t sa_len;
+		uint8_t sa_family;
+		char sa_data[14];
+	} sockAddrMacOs;
+
+	if (length() > sizeof(sockAddrMacOs))
+		fb_assert(false);
+	else
+	{
+		sockAddrMacOs.sa_len = length();
+		sockAddrMacOs.sa_family = ptr()->sa_family;
+		memcpy(sockAddrMacOs.sa_data, ptr()->sa_data, length() - 2);
+		memcpy(ptr(), &sockAddrMacOs, length());
 	}
 }
 

--- a/src/remote/inet.cpp
+++ b/src/remote/inet.cpp
@@ -1613,32 +1613,10 @@ static rem_port* aux_request( rem_port* port, PACKET* packet)
 		ARCHITECTURE == arch_darwin_x64 ||
 		ARCHITECTURE == arch_darwin_ppc64;
 
-	struct
-	{
-		uint8_t sa_len;
-		uint8_t sa_family;
-		char sa_data[14];
-	} sockAddrMacOs;
-
-	struct
-	{
-		uint16_t sa_family;
-		char sa_data[14];
-	} sockAddrPosixWindows;
-
-	if (macOsClient && !macOsServer)
-	{
-		sockAddrMacOs.sa_len = port_address.length();
-		sockAddrMacOs.sa_family = port_address.ptr()->sa_family;
-		memcpy(sockAddrMacOs.sa_data, port_address.ptr()->sa_data, port_address.length() - 2);
-		memcpy(port_address.ptr(), &sockAddrMacOs, port_address.length());
-	}
-	else if (!macOsClient && macOsServer)
-	{
-		sockAddrPosixWindows.sa_family = port_address.ptr()->sa_family;
-		memcpy(sockAddrPosixWindows.sa_data, port_address.ptr()->sa_data, port_address.length() - 2);
-		memcpy(port_address.ptr(), &sockAddrPosixWindows, port_address.length());
-	}
+	if (macOsServer && !macOsClient)
+		port_address.convertFromMacOsToPosixWindows();
+	else if (!macOsServer && macOsClient)
+		port_address.convertFromPosixWindowsToMacOs();
 
 	response->p_resp_data.cstr_length = (ULONG) port_address.length();
 	memcpy(response->p_resp_data.cstr_address, port_address.ptr(), port_address.length());

--- a/src/remote/remote.h
+++ b/src/remote/remote.h
@@ -1014,6 +1014,7 @@ struct rem_port : public Firebird::GlobalStorage, public Firebird::RefCounted
 	rem_str*		port_version;
 	rem_str*		port_host;				// Our name
 	rem_str*		port_connection;		// Name of connection
+	P_ARCH			port_client_arch;
 	Firebird::string port_login;
 	Firebird::string port_user_name;
 	Firebird::string port_peer_name;
@@ -1078,7 +1079,7 @@ public:
 		port_packet_vector(0),
 #endif
 		port_objects(getPool()), port_version(0), port_host(0),
-		port_connection(0), port_login(getPool()),
+		port_connection(0), port_client_arch(arch_generic), port_login(getPool()),
 		port_user_name(getPool()), port_peer_name(getPool()),
 		port_protocol_id(getPool()), port_address(getPool()),
 		port_rpr(0), port_statement(0), port_receive_rmtque(0),

--- a/src/remote/server/server.cpp
+++ b/src/remote/server/server.cpp
@@ -1884,6 +1884,7 @@ static bool accept_connection(rem_port* port, P_CNCT* connect, PACKET* send)
 	if (type == ptype_lazy_send)
 		port->port_flags |= PORT_lazy;
 
+	port->port_client_arch = connect->p_cnct_client;
 
 	Firebird::ClumpletReader id(Firebird::ClumpletReader::UnTagged,
 								connect->p_cnct_user_id.cstr_address,


### PR DESCRIPTION
"While isc_que_events - Failed to establish a secondary connection for event processing".