### PR TITLE
In case of direct IO use 4K buffer alignment because on some devices …

### DIFF
--- a/src/jrd/CryptoManager.cpp
+++ b/src/jrd/CryptoManager.cpp
@@ -201,9 +201,10 @@ namespace Jrd {
 			Jrd::BufferDesc bdb(bcb);
 			bdb.bdb_page = Jrd::PageNumber(Jrd::DB_PAGE_SPACE, 0);
 
-			UCHAR* h = FB_NEW_POOL(*Firebird::MemoryPool::getContextPool()) UCHAR[dbb->dbb_page_size + PAGE_ALIGNMENT];
+			UCHAR* h = FB_NEW_POOL(*Firebird::MemoryPool::getContextPool())
+				UCHAR[dbb->dbb_page_size + dbb->dbb_page_alignment];
 			buffer.reset(h);
-			h = FB_ALIGN(h, PAGE_ALIGNMENT);
+			h = FB_ALIGN(h, dbb->dbb_page_alignment);
 			bdb.bdb_buffer = (Ods::pag*) h;
 
 			Jrd::FbStatusVector* const status = tdbb->tdbb_status_vector;
@@ -1283,7 +1284,7 @@ namespace Jrd {
 	CryptoManager::IoResult CryptoManager::internalWrite(thread_db* tdbb, FbStatusVector* sv,
 		Ods::pag* page, IOCallback* io)
 	{
-		Buffer to;
+		Buffer to(getPool(), dbb.dbb_page_size, dbb.dbb_page_alignment);
 		Ods::pag* dest = page;
 		UCHAR savedFlags = page->pag_flags;
 

--- a/src/jrd/CryptoManager.h
+++ b/src/jrd/CryptoManager.h
@@ -313,18 +313,24 @@ private:
 	class Buffer
 	{
 	public:
+		Buffer(Firebird::MemoryPool& pool, USHORT page_size, USHORT page_alignment)
+			: alignment(page_alignment),
+			  buf(pool, page_size + page_alignment - 1)
+		{ }
+			
 		operator Ods::pag*()
 		{
-			return reinterpret_cast<Ods::pag*>(FB_ALIGN(buf, PAGE_ALIGNMENT));
+			return reinterpret_cast<Ods::pag*>(FB_ALIGN(buf.begin(), alignment));
 		}
 
 		Ods::pag* operator->()
 		{
-			return reinterpret_cast<Ods::pag*>(FB_ALIGN(buf, PAGE_ALIGNMENT));
+			return reinterpret_cast<Ods::pag*>(FB_ALIGN(buf.begin(), alignment));
 		}
 
 	private:
-		char buf[MAX_PAGE_SIZE + PAGE_ALIGNMENT - 1];
+		USHORT alignment;
+		Firebird::HalfStaticArray<char, MAX_PAGE_SIZE> buf;
 	};
 
 	class DbInfo;

--- a/src/jrd/Database.h
+++ b/src/jrd/Database.h
@@ -471,6 +471,7 @@ public:
 	unsigned dbb_linger_seconds;
 	time_t dbb_linger_end;
 	Firebird::RefPtr<Firebird::IPluginConfig> dbb_plugin_config;
+	USHORT dbb_page_alignment;
 
 	// returns true if primary file is located on raw device
 	bool onRawDevice() const;
@@ -524,7 +525,8 @@ private:
 		dbb_init_fini(FB_NEW_POOL(*getDefaultMemoryPool()) ExistenceRefMutex()),
 		dbb_linger_seconds(0),
 		dbb_linger_end(0),
-		dbb_plugin_config(pConf)
+		dbb_plugin_config(pConf),
+		dbb_page_alignment(PAGE_ALIGNMENT)
 	{
 		dbb_pools.add(p);
 	}

--- a/src/jrd/jrd.cpp
+++ b/src/jrd/jrd.cpp
@@ -6311,8 +6311,9 @@ static void init_database_lock(thread_db* tdbb)
 			fb_utils::init_status(tdbb->tdbb_status_vector);
 
 			// If we are in a single-threaded maintenance mode then clean up and stop waiting
-			UCHAR spare_memory[RAW_HEADER_SIZE + PAGE_ALIGNMENT];
-			UCHAR* header_page_buffer = FB_ALIGN(spare_memory, PAGE_ALIGNMENT);
+			Array<UCHAR> spare_memory;
+			UCHAR* header_page_buffer = FB_ALIGN(spare_memory.getBuffer(RAW_HEADER_SIZE + dbb->dbb_page_alignment),
+				dbb->dbb_page_alignment);
 			Ods::header_page* const header_page = reinterpret_cast<Ods::header_page*>(header_page_buffer);
 
 			PIO_header(tdbb, header_page_buffer, RAW_HEADER_SIZE);

--- a/src/jrd/nbak.cpp
+++ b/src/jrd/nbak.cpp
@@ -228,7 +228,7 @@ void BackupManager::openDelta(thread_db* tdbb)
 
 	if (database->dbb_flags & (DBB_force_write | DBB_no_fs_cache))
 	{
-		setForcedWrites(database->dbb_flags & DBB_force_write,
+		setForcedWrites(tdbb, database->dbb_flags & DBB_force_write,
 						database->dbb_flags & DBB_no_fs_cache);
 	}
 }
@@ -296,7 +296,7 @@ void BackupManager::beginBackup(thread_db* tdbb)
 	{ // logical scope
 		if (database->dbb_flags & (DBB_force_write | DBB_no_fs_cache))
 		{
-			setForcedWrites(database->dbb_flags & DBB_force_write,
+			setForcedWrites(tdbb, database->dbb_flags & DBB_force_write,
 							database->dbb_flags & DBB_no_fs_cache);
 		}
 
@@ -919,10 +919,10 @@ void BackupManager::flushDifference(thread_db* tdbb)
 	PIO_flush(tdbb, diff_file);
 }
 
-void BackupManager::setForcedWrites(const bool forceWrite, const bool notUseFSCache)
+void BackupManager::setForcedWrites(thread_db* tdbb, const bool forceWrite, const bool notUseFSCache)
 {
 	if (diff_file)
-		PIO_force_write(diff_file, forceWrite, notUseFSCache);
+		PIO_force_write(tdbb, diff_file, forceWrite, notUseFSCache);
 }
 
 BackupManager::BackupManager(thread_db* tdbb, Database* _database, int ini_state) :
@@ -934,9 +934,9 @@ BackupManager::BackupManager(thread_db* tdbb, Database* _database, int ini_state
 	allocLock(FB_NEW_POOL(*database->dbb_permanent) NBackupAllocLock(tdbb, *database->dbb_permanent, this))
 {
 	// Allocate various database page buffers needed for operation
-	temp_buffers_space = FB_NEW_POOL(*database->dbb_permanent) BYTE[database->dbb_page_size * 3 + PAGE_ALIGNMENT];
+	temp_buffers_space = FB_NEW_POOL(*database->dbb_permanent) BYTE[database->dbb_page_size * 3 + MAX_PAGE_ALIGNMENT];
 	// Align it at sector boundary for faster IO (also guarantees correct alignment for ULONG later)
-	BYTE* temp_buffers = reinterpret_cast<BYTE*>(FB_ALIGN(temp_buffers_space, PAGE_ALIGNMENT));
+	BYTE* temp_buffers = reinterpret_cast<BYTE*>(FB_ALIGN(temp_buffers_space, MAX_PAGE_ALIGNMENT));
 	memset(temp_buffers, 0, database->dbb_page_size * 3);
 
 	backup_state = ini_state;

--- a/src/jrd/nbak.h
+++ b/src/jrd/nbak.h
@@ -454,7 +454,7 @@ public:
 	bool writeDifference(thread_db* tdbb, FbStatusVector* status, ULONG diff_page, Ods::pag* page);
 	bool readDifference(thread_db* tdbb, ULONG diff_page, Ods::pag* page);
 	void flushDifference(thread_db* tdbb);
-	void setForcedWrites(const bool forceWrite, const bool notUseFSCache);
+	void setForcedWrites(thread_db* tdbb, const bool forceWrite, const bool notUseFSCache);
 
 	void shutdown(thread_db* tdbb);
 

--- a/src/jrd/ods.h
+++ b/src/jrd/ods.h
@@ -717,6 +717,7 @@ Firebird::string pagtype(UCHAR type);
 
 // alignment for raw page access
 const USHORT PAGE_ALIGNMENT = 1024;
+const USHORT MAX_PAGE_ALIGNMENT = 4096;
 
 // size of raw I/O operation for header page
 const USHORT RAW_HEADER_SIZE = 1024;	// ROUNDUP(HDR_SIZE, PAGE_ALIGNMENT);

--- a/src/jrd/os/pio_proto.h
+++ b/src/jrd/os/pio_proto.h
@@ -43,7 +43,7 @@ Jrd::jrd_file*	PIO_create(Jrd::thread_db*, const Firebird::PathName&,
 bool	PIO_expand(const TEXT*, USHORT, TEXT*, FB_SIZE_T);
 void	PIO_extend(Jrd::thread_db*, Jrd::jrd_file*, const ULONG, const USHORT);
 void	PIO_flush(Jrd::thread_db*, Jrd::jrd_file*);
-void	PIO_force_write(Jrd::jrd_file*, const bool, const bool);
+void	PIO_force_write(Jrd::thread_db*, Jrd::jrd_file*, const bool, const bool);
 ULONG	PIO_get_number_of_pages(const Jrd::jrd_file*, const USHORT);
 void	PIO_header(Jrd::thread_db*, UCHAR*, int);
 USHORT	PIO_init_data(Jrd::thread_db*, Jrd::jrd_file*, Jrd::FbStatusVector*, ULONG, USHORT);

--- a/src/jrd/os/posix/unix.cpp
+++ b/src/jrd/os/posix/unix.cpp
@@ -404,7 +404,7 @@ void PIO_flush(thread_db* tdbb, jrd_file* main_file)
 #define O_DIRECT 0
 #endif
 
-void PIO_force_write(jrd_file* file, const bool forcedWrites, const bool notUseFSCache)
+void PIO_force_write(thread_db* tdbb, jrd_file* file, const bool forcedWrites, const bool notUseFSCache)
 {
 /**************************************
  *
@@ -457,6 +457,8 @@ void PIO_force_write(jrd_file* file, const bool forcedWrites, const bool notUseF
 		file->fil_flags &= ~(FIL_force_write | FIL_no_fs_cache);
 		file->fil_flags |= (forcedWrites ? FIL_force_write : 0) |
 						   (notUseFSCache ? FIL_no_fs_cache : 0);
+		if (notUseFSCache)
+			tdbb->getDatabase()->dbb_page_alignment = MAX_PAGE_ALIGNMENT;
 	}
 #endif
 }
@@ -1181,8 +1183,8 @@ static bool raw_devices_validate_database(int desc, const PathName& file_name)
  *	Checks if the special file contains a valid database
  *
  **************************************/
-	UCHAR header_buffer[RAW_HEADER_SIZE + PAGE_ALIGNMENT];
-	UCHAR* const header = FB_ALIGN(header_buffer, PAGE_ALIGNMENT);
+	UCHAR header_buffer[RAW_HEADER_SIZE + MAX_PAGE_ALIGNMENT];
+	UCHAR* const header = FB_ALIGN(header_buffer, MAX_PAGE_ALIGNMENT);
 	const Ods::header_page* hp = (Ods::header_page*) header;
 	bool retval = false;
 
@@ -1251,8 +1253,8 @@ static bool raw_devices_validate_database(int desc, const PathName& file_name)
 
 static int raw_devices_unlink_database(const PathName& file_name)
 {
-	UCHAR header_buffer[RAW_HEADER_SIZE + PAGE_ALIGNMENT];
-	UCHAR* const header = FB_ALIGN(header_buffer, PAGE_ALIGNMENT);
+	UCHAR header_buffer[RAW_HEADER_SIZE + MAX_PAGE_ALIGNMENT];
+	UCHAR* const header = FB_ALIGN(header_buffer, MAX_PAGE_ALIGNMENT);
 
 	int desc = os_utils::open(file_name.c_str(), O_RDWR | O_BINARY);
 	if (desc < 0)

--- a/src/jrd/os/win32/winnt.cpp
+++ b/src/jrd/os/win32/winnt.cpp
@@ -345,7 +345,7 @@ void PIO_flush(thread_db* tdbb, jrd_file* main_file)
 }
 
 
-void PIO_force_write(jrd_file* file, const bool forceWrite, const bool notUseFSCache)
+void PIO_force_write(thread_db* tdbb, jrd_file* file, const bool forceWrite, const bool notUseFSCache)
 {
 /**************************************
  *
@@ -393,6 +393,7 @@ void PIO_force_write(jrd_file* file, const bool forceWrite, const bool notUseFSC
 		}
 		if (notUseFSCache) {
 			file->fil_flags |= FIL_no_fs_cache;
+			tdbb->getDatabase()->dbb_page_alignment = MAX_PAGE_ALIGNMENT;
 		}
 		else {
 			file->fil_flags &= ~FIL_no_fs_cache;

--- a/src/jrd/pag.cpp
+++ b/src/jrd/pag.cpp
@@ -266,7 +266,7 @@ USHORT PAG_add_file(thread_db* tdbb, const TEXT* file_name, SLONG start)
 
 	if (dbb->dbb_flags & (DBB_force_write | DBB_no_fs_cache))
 	{
-		PIO_force_write(next, dbb->dbb_flags & DBB_force_write, dbb->dbb_flags & DBB_no_fs_cache);
+		PIO_force_write(tdbb, next, dbb->dbb_flags & DBB_force_write, dbb->dbb_flags & DBB_no_fs_cache);
 	}
 
 	WIN window(DB_PAGE_SPACE, next->fil_min_page);
@@ -1204,13 +1204,13 @@ void PAG_header(thread_db* tdbb, bool info)
 		PageSpace* pageSpace = dbb->dbb_page_manager.findPageSpace(DB_PAGE_SPACE);
 		for (jrd_file* file = pageSpace->file; file; file = file->fil_next)
 		{
-			PIO_force_write(file,
+			PIO_force_write(tdbb, file,
 				forceWrite && !(header->hdr_flags & hdr_read_only),
 				notUseFSCache);
 		}
 
 		if (dbb->dbb_backup_manager->getState() != Ods::hdr_nbak_normal)
-			dbb->dbb_backup_manager->setForcedWrites(forceWrite, notUseFSCache);
+			dbb->dbb_backup_manager->setForcedWrites(tdbb, forceWrite, notUseFSCache);
 	}
 
 	if (header->hdr_flags & hdr_no_reserve)
@@ -1267,8 +1267,9 @@ void PAG_header_init(thread_db* tdbb)
 	// and unit of transfer is a multiple of physical disk
 	// sector for raw disk access.
 
-	UCHAR temp_buffer[RAW_HEADER_SIZE + PAGE_ALIGNMENT];
-	UCHAR* const temp_page = FB_ALIGN(temp_buffer, PAGE_ALIGNMENT);
+	Array<UCHAR> temp_buffer;
+	UCHAR* const temp_page = FB_ALIGN(temp_buffer.getBuffer(RAW_HEADER_SIZE + dbb->dbb_page_alignment),
+		dbb->dbb_page_alignment);
 
 	PIO_header(tdbb, temp_page, RAW_HEADER_SIZE);
 	const header_page* header = (header_page*) temp_page;
@@ -1385,7 +1386,7 @@ void PAG_init2(thread_db* tdbb, USHORT shadow_number)
 
 	Array<UCHAR> temp;
 	UCHAR* const temp_page =
-		FB_ALIGN(temp.getBuffer(dbb->dbb_page_size + PAGE_ALIGNMENT), PAGE_ALIGNMENT);
+		FB_ALIGN(temp.getBuffer(dbb->dbb_page_size + dbb->dbb_page_alignment), dbb->dbb_page_alignment);
 
 	PageSpace* pageSpace = dbb->dbb_page_manager.findPageSpace(DB_PAGE_SPACE);
 	jrd_file* file = pageSpace->file;
@@ -1497,7 +1498,7 @@ void PAG_init2(thread_db* tdbb, USHORT shadow_number)
 		file = file->fil_next;
 		if (dbb->dbb_flags & (DBB_force_write | DBB_no_fs_cache))
 		{
-			PIO_force_write(file, dbb->dbb_flags & DBB_force_write, dbb->dbb_flags & DBB_no_fs_cache);
+			PIO_force_write(tdbb, file, dbb->dbb_flags & DBB_force_write, dbb->dbb_flags & DBB_no_fs_cache);
 		}
 		file->fil_min_page = last_page + 1;
 		file->fil_sequence = sequence++;
@@ -1676,13 +1677,13 @@ void PAG_set_force_write(thread_db* tdbb, bool flag)
 
 	PageSpace* pageSpace = dbb->dbb_page_manager.findPageSpace(DB_PAGE_SPACE);
 	for (jrd_file* file = pageSpace->file; file; file = file->fil_next) {
-		PIO_force_write(file, flag, dbb->dbb_flags & DBB_no_fs_cache);
+		PIO_force_write(tdbb, file, flag, dbb->dbb_flags & DBB_no_fs_cache);
 	}
 
 	for (Shadow* shadow = dbb->dbb_shadow; shadow; shadow = shadow->sdw_next)
 	{
 		for (jrd_file* file = shadow->sdw_file; file; file = file->fil_next) {
-			PIO_force_write(file, flag, dbb->dbb_flags & DBB_no_fs_cache);
+			PIO_force_write(tdbb, file, flag, dbb->dbb_flags & DBB_no_fs_cache);
 		}
 	}
 }
@@ -2501,7 +2502,7 @@ ULONG PAG_page_count(thread_db* tdbb, PageCountCallback* cb)
 
 	Array<UCHAR> temp;
 	page_inv_page* pip = reinterpret_cast<Ods::page_inv_page*>
-		(FB_ALIGN(temp.getBuffer(dbb->dbb_page_size + PAGE_ALIGNMENT), PAGE_ALIGNMENT));
+		(FB_ALIGN(temp.getBuffer(dbb->dbb_page_size + dbb->dbb_page_alignment), dbb->dbb_page_alignment));
 
 	PageSpace* pageSpace = dbb->dbb_page_manager.findPageSpace(DB_PAGE_SPACE);
 	fb_assert(pageSpace);

--- a/src/jrd/sdw.cpp
+++ b/src/jrd/sdw.cpp
@@ -94,7 +94,7 @@ void SDW_add(thread_db* tdbb, const TEXT* file_name, USHORT shadow_number, USHOR
 
 	if (dbb->dbb_flags & (DBB_force_write | DBB_no_fs_cache))
 	{
-		PIO_force_write(shadow_file, dbb->dbb_flags & DBB_force_write,
+		PIO_force_write(tdbb, shadow_file, dbb->dbb_flags & DBB_force_write,
 			dbb->dbb_flags & DBB_no_fs_cache);
 	}
 
@@ -176,7 +176,7 @@ int SDW_add_file(thread_db* tdbb, const TEXT* file_name, SLONG start, USHORT sha
 
 	if (dbb->dbb_flags & (DBB_force_write | DBB_no_fs_cache))
 	{
-		PIO_force_write(next, dbb->dbb_flags & DBB_force_write, dbb->dbb_flags & DBB_no_fs_cache);
+		PIO_force_write(tdbb, next, dbb->dbb_flags & DBB_force_write, dbb->dbb_flags & DBB_no_fs_cache);
 	}
 
 	// Always write the header page, even for a conditional
@@ -187,10 +187,10 @@ int SDW_add_file(thread_db* tdbb, const TEXT* file_name, SLONG start, USHORT sha
 	// the spare page buffer for raw disk access.
 
 	SCHAR* const spare_buffer =
-		FB_NEW_POOL(*tdbb->getDefaultPool()) char[dbb->dbb_page_size + PAGE_ALIGNMENT];
+		FB_NEW_POOL(*tdbb->getDefaultPool()) char[dbb->dbb_page_size + dbb->dbb_page_alignment];
 	// And why doesn't the code check that the allocation succeeds?
 
-	SCHAR* spare_page = FB_ALIGN(spare_buffer, PAGE_ALIGNMENT);
+	SCHAR* spare_page = FB_ALIGN(spare_buffer, dbb->dbb_page_alignment);
 
 	try {
 
@@ -1000,9 +1000,9 @@ void SDW_start(thread_db* tdbb, const TEXT* file_name,
 	// catch errors: delete the shadow file if missing, and deallocate the spare buffer
 
 	shadow = NULL;
-	SLONG* const spare_buffer =
-		FB_NEW_POOL(*tdbb->getDefaultPool()) SLONG[(dbb->dbb_page_size + PAGE_ALIGNMENT) / sizeof(SLONG)];
-	UCHAR* spare_page = FB_ALIGN((UCHAR*) spare_buffer, PAGE_ALIGNMENT);
+	SLONG* const spare_buffer = FB_NEW_POOL(*tdbb->getDefaultPool())
+		SLONG[(dbb->dbb_page_size + dbb->dbb_page_alignment) / sizeof(SLONG)];
+	UCHAR* spare_page = FB_ALIGN((UCHAR*) spare_buffer, dbb->dbb_page_alignment);
 
 	WIN window(DB_PAGE_SPACE, -1);
 	jrd_file* shadow_file = 0;
@@ -1013,7 +1013,7 @@ void SDW_start(thread_db* tdbb, const TEXT* file_name,
 
 	if (dbb->dbb_flags & (DBB_force_write | DBB_no_fs_cache))
 	{
-		PIO_force_write(shadow_file, dbb->dbb_flags & DBB_force_write,
+		PIO_force_write(tdbb, shadow_file, dbb->dbb_flags & DBB_force_write,
 			dbb->dbb_flags & DBB_no_fs_cache);
 	}
 


### PR DESCRIPTION
…pread() with less alignment returns EINVAL