### PR TITLE
In case of direct IO use 4K buffer alignment because on some devices …

### DIFF
--- a/src/jrd/CryptoManager.cpp
+++ b/src/jrd/CryptoManager.cpp
@@ -201,9 +201,10 @@ namespace Jrd {
 			Jrd::BufferDesc bdb(bcb);
 			bdb.bdb_page = Jrd::HEADER_PAGE_NUMBER;
 
-			UCHAR* h = FB_NEW_POOL(*Firebird::MemoryPool::getContextPool()) UCHAR[dbb->dbb_page_size + PAGE_ALIGNMENT];
+			UCHAR* h = FB_NEW_POOL(*Firebird::MemoryPool::getContextPool())
+				UCHAR[dbb->dbb_page_size + dbb->dbb_page_alignment];
 			buffer.reset(h);
-			h = FB_ALIGN(h, PAGE_ALIGNMENT);
+			h = FB_ALIGN(h, dbb->dbb_page_alignment);
 			bdb.bdb_buffer = (Ods::pag*) h;
 
 			Jrd::FbStatusVector* const status = tdbb->tdbb_status_vector;
@@ -1280,7 +1281,7 @@ namespace Jrd {
 	CryptoManager::IoResult CryptoManager::internalWrite(thread_db* tdbb, FbStatusVector* sv,
 		Ods::pag* page, IOCallback* io)
 	{
-		Buffer to;
+		Buffer to(getPool(), dbb.dbb_page_size, dbb.dbb_page_alignment);
 		Ods::pag* dest = page;
 		UCHAR savedFlags = page->pag_flags;
 

--- a/src/jrd/CryptoManager.h
+++ b/src/jrd/CryptoManager.h
@@ -314,18 +314,24 @@ private:
 	class Buffer
 	{
 	public:
+		Buffer(Firebird::MemoryPool& pool, USHORT page_size, USHORT page_alignment)
+			: alignment(page_alignment),
+			  buf(pool, page_size + page_alignment - 1)
+		{ }
+			
 		operator Ods::pag*()
 		{
-			return reinterpret_cast<Ods::pag*>(FB_ALIGN(buf, PAGE_ALIGNMENT));
+			return reinterpret_cast<Ods::pag*>(FB_ALIGN(buf.begin(), alignment));
 		}
 
 		Ods::pag* operator->()
 		{
-			return reinterpret_cast<Ods::pag*>(FB_ALIGN(buf, PAGE_ALIGNMENT));
+			return reinterpret_cast<Ods::pag*>(FB_ALIGN(buf.begin(), alignment));
 		}
 
 	private:
-		char buf[MAX_PAGE_SIZE + PAGE_ALIGNMENT - 1];
+		USHORT alignment;
+		Firebird::HalfStaticArray<char, MAX_PAGE_SIZE> buf;
 	};
 
 	class DbInfo;

--- a/src/jrd/Database.h
+++ b/src/jrd/Database.h
@@ -440,6 +440,8 @@ public:
 	FB_UINT64 dbb_repl_sequence;	// replication sequence
 	ReplicaMode dbb_replica_mode;	// replica access mode
 
+	USHORT dbb_page_alignment;
+
 	// returns true if primary file is located on raw device
 	bool onRawDevice() const;
 
@@ -503,7 +505,8 @@ private:
 		dbb_linger_end(0),
 		dbb_plugin_config(pConf),
 		dbb_repl_sequence(0),
-		dbb_replica_mode(REPLICA_NONE)
+		dbb_replica_mode(REPLICA_NONE),
+		dbb_page_alignment(PAGE_ALIGNMENT)
 	{
 		dbb_pools.add(p);
 	}

--- a/src/jrd/jrd.cpp
+++ b/src/jrd/jrd.cpp
@@ -7295,8 +7295,9 @@ static void init_database_lock(thread_db* tdbb)
 			fb_utils::init_status(tdbb->tdbb_status_vector);
 
 			// If we are in a single-threaded maintenance mode then clean up and stop waiting
-			UCHAR spare_memory[RAW_HEADER_SIZE + PAGE_ALIGNMENT];
-			UCHAR* header_page_buffer = FB_ALIGN(spare_memory, PAGE_ALIGNMENT);
+			Array<UCHAR> spare_memory;
+			UCHAR* header_page_buffer = FB_ALIGN(spare_memory.getBuffer(RAW_HEADER_SIZE + dbb->dbb_page_alignment),
+				dbb->dbb_page_alignment);
 			Ods::header_page* const header_page = reinterpret_cast<Ods::header_page*>(header_page_buffer);
 
 			PIO_header(tdbb, header_page_buffer, RAW_HEADER_SIZE);

--- a/src/jrd/nbak.h
+++ b/src/jrd/nbak.h
@@ -454,7 +454,7 @@ public:
 	bool writeDifference(thread_db* tdbb, FbStatusVector* status, ULONG diff_page, Ods::pag* page);
 	bool readDifference(thread_db* tdbb, ULONG diff_page, Ods::pag* page);
 	void flushDifference(thread_db* tdbb);
-	void setForcedWrites(const bool forceWrite, const bool notUseFSCache);
+	void setForcedWrites(thread_db* tdbb, const bool forceWrite, const bool notUseFSCache);
 
 	void shutdown(thread_db* tdbb);
 

--- a/src/jrd/ods.h
+++ b/src/jrd/ods.h
@@ -736,6 +736,7 @@ Firebird::string pagtype(UCHAR type);
 #ifndef ODS_TESTING
 // alignment for raw page access
 const USHORT PAGE_ALIGNMENT = 1024;
+const USHORT MAX_PAGE_ALIGNMENT = 4096;
 
 // size of raw I/O operation for header page
 const USHORT RAW_HEADER_SIZE = 1024;	// ROUNDUP(HDR_SIZE, PAGE_ALIGNMENT);

--- a/src/jrd/os/pio_proto.h
+++ b/src/jrd/os/pio_proto.h
@@ -43,7 +43,7 @@ Jrd::jrd_file*	PIO_create(Jrd::thread_db*, const Firebird::PathName&,
 bool	PIO_expand(const TEXT*, USHORT, TEXT*, FB_SIZE_T);
 void	PIO_extend(Jrd::thread_db*, Jrd::jrd_file*, const ULONG, const USHORT);
 void	PIO_flush(Jrd::thread_db*, Jrd::jrd_file*);
-void	PIO_force_write(Jrd::jrd_file*, const bool, const bool);
+void	PIO_force_write(Jrd::thread_db*, Jrd::jrd_file*, const bool, const bool);
 ULONG	PIO_get_number_of_pages(const Jrd::jrd_file*, const USHORT);
 void	PIO_header(Jrd::thread_db*, UCHAR*, int);
 USHORT	PIO_init_data(Jrd::thread_db*, Jrd::jrd_file*, Jrd::FbStatusVector*, ULONG, USHORT);

--- a/src/jrd/os/win32/winnt.cpp
+++ b/src/jrd/os/win32/winnt.cpp
@@ -341,7 +341,7 @@ void PIO_flush(thread_db* tdbb, jrd_file* main_file)
 }
 
 
-void PIO_force_write(jrd_file* file, const bool forceWrite, const bool notUseFSCache)
+void PIO_force_write(thread_db* tdbb, jrd_file* file, const bool forceWrite, const bool notUseFSCache)
 {
 /**************************************
  *
@@ -389,6 +389,7 @@ void PIO_force_write(jrd_file* file, const bool forceWrite, const bool notUseFSC
 		}
 		if (notUseFSCache) {
 			file->fil_flags |= FIL_no_fs_cache;
+			tdbb->getDatabase()->dbb_page_alignment = MAX_PAGE_ALIGNMENT;
 		}
 		else {
 			file->fil_flags &= ~FIL_no_fs_cache;

--- a/src/jrd/sdw.cpp
+++ b/src/jrd/sdw.cpp
@@ -94,7 +94,7 @@ void SDW_add(thread_db* tdbb, const TEXT* file_name, USHORT shadow_number, USHOR
 
 	if (dbb->dbb_flags & (DBB_force_write | DBB_no_fs_cache))
 	{
-		PIO_force_write(shadow_file, dbb->dbb_flags & DBB_force_write,
+		PIO_force_write(tdbb, shadow_file, dbb->dbb_flags & DBB_force_write,
 			dbb->dbb_flags & DBB_no_fs_cache);
 	}
 
@@ -176,7 +176,7 @@ int SDW_add_file(thread_db* tdbb, const TEXT* file_name, SLONG start, USHORT sha
 
 	if (dbb->dbb_flags & (DBB_force_write | DBB_no_fs_cache))
 	{
-		PIO_force_write(next, dbb->dbb_flags & DBB_force_write, dbb->dbb_flags & DBB_no_fs_cache);
+		PIO_force_write(tdbb, next, dbb->dbb_flags & DBB_force_write, dbb->dbb_flags & DBB_no_fs_cache);
 	}
 
 	// Always write the header page, even for a conditional
@@ -187,10 +187,10 @@ int SDW_add_file(thread_db* tdbb, const TEXT* file_name, SLONG start, USHORT sha
 	// the spare page buffer for raw disk access.
 
 	SCHAR* const spare_buffer =
-		FB_NEW_POOL(*tdbb->getDefaultPool()) char[dbb->dbb_page_size + PAGE_ALIGNMENT];
+		FB_NEW_POOL(*tdbb->getDefaultPool()) char[dbb->dbb_page_size + dbb->dbb_page_alignment];
 	// And why doesn't the code check that the allocation succeeds?
 
-	SCHAR* spare_page = FB_ALIGN(spare_buffer, PAGE_ALIGNMENT);
+	SCHAR* spare_page = FB_ALIGN(spare_buffer, dbb->dbb_page_alignment);
 
 	try {
 
@@ -1000,9 +1000,9 @@ void SDW_start(thread_db* tdbb, const TEXT* file_name,
 	// catch errors: delete the shadow file if missing, and deallocate the spare buffer
 
 	shadow = NULL;
-	SLONG* const spare_buffer =
-		FB_NEW_POOL(*tdbb->getDefaultPool()) SLONG[(dbb->dbb_page_size + PAGE_ALIGNMENT) / sizeof(SLONG)];
-	UCHAR* spare_page = FB_ALIGN((UCHAR*) spare_buffer, PAGE_ALIGNMENT);
+	SLONG* const spare_buffer = FB_NEW_POOL(*tdbb->getDefaultPool())
+		SLONG[(dbb->dbb_page_size + dbb->dbb_page_alignment) / sizeof(SLONG)];
+	UCHAR* spare_page = FB_ALIGN((UCHAR*) spare_buffer, dbb->dbb_page_alignment);
 
 	WIN window(DB_PAGE_SPACE, -1);
 	jrd_file* shadow_file = 0;
@@ -1013,7 +1013,7 @@ void SDW_start(thread_db* tdbb, const TEXT* file_name,
 
 	if (dbb->dbb_flags & (DBB_force_write | DBB_no_fs_cache))
 	{
-		PIO_force_write(shadow_file, dbb->dbb_flags & DBB_force_write,
+		PIO_force_write(tdbb, shadow_file, dbb->dbb_flags & DBB_force_write,
 			dbb->dbb_flags & DBB_no_fs_cache);
 	}
 

--- a/src/utilities/nbackup/nbackup.cpp
+++ b/src/utilities/nbackup/nbackup.cpp
@@ -79,12 +79,6 @@
 #define O_LARGEFILE 0
 #endif
 
-// How much we align memory when reading database header.
-// Sector alignment of memory is necessary to use unbuffered IO on Windows.
-// Actually, sectors may be bigger than 1K, but let's be consistent with
-// JRD regarding the matter for the moment.
-const FB_SIZE_T SECTOR_ALIGNMENT = PAGE_ALIGNMENT;
-
 using namespace Firebird;
 
 namespace
@@ -279,7 +273,8 @@ public:
 		username(_username), role(_role), password(_password),
 		run_db_triggers(_run_db_triggers), direct_io(_direct_io),
 		dbase(0), backup(0), decompress(_deco), childId(0), db_size_pages(0),
-		m_odsNumber(0), m_silent(false), m_printed(false)
+		m_odsNumber(0), m_silent(false), m_printed(false),
+		m_page_alignment(_direct_io ? MAX_PAGE_ALIGNMENT : PAGE_ALIGNMENT)
 	{
 		// Recognition of local prefix allows to work with
 		// database using TCP/IP loopback while reading file locally.
@@ -340,6 +335,7 @@ private:
 	USHORT m_odsNumber;
 	bool m_silent;		// are we already handling an exception?
 	bool m_printed;		// pr_error() was called to print status vector
+	USHORT m_page_alignment;
 
 	// IO functions
 	FB_SIZE_T read_file(FILE_HANDLE &file, void *buffer, FB_SIZE_T bufsize);
@@ -1081,12 +1077,12 @@ void NBackup::backup_database(int level, Guid& guid, const PathName& fname)
 		open_database_scan();
 
 		// Read database header
-		char unaligned_header_buffer[SECTOR_ALIGNMENT * 2];
+		Array<char> unaligned_header_buffer;
 
 		Ods::header_page *header = reinterpret_cast<Ods::header_page*>(
-			FB_ALIGN(unaligned_header_buffer, SECTOR_ALIGNMENT));
+			FB_ALIGN(unaligned_header_buffer.getBuffer(m_page_alignment*2), m_page_alignment));
 
-		if (read_file(dbase, header, SECTOR_ALIGNMENT/*sizeof(*header)*/) != SECTOR_ALIGNMENT/*sizeof(*header)*/)
+		if (read_file(dbase, header, m_page_alignment/*sizeof(*header)*/) != m_page_alignment/*sizeof(*header)*/)
 			status_exception::raise(Arg::Gds(isc_nbackup_err_eofhdrdb) << dbname.c_str() << Arg::Num(1));
 
 		if (!Ods::isSupported(header))
@@ -1104,8 +1100,8 @@ void NBackup::backup_database(int level, Guid& guid, const PathName& fname)
 
 		Array<UCHAR> unaligned_page_buffer;
 		{ // scope
-			UCHAR* buf = unaligned_page_buffer.getBuffer(header->hdr_page_size + SECTOR_ALIGNMENT);
-			page_buff = reinterpret_cast<Ods::pag*>(FB_ALIGN(buf, SECTOR_ALIGNMENT));
+			UCHAR* buf = unaligned_page_buffer.getBuffer(header->hdr_page_size + m_page_alignment);
+			page_buff = reinterpret_cast<Ods::pag*>(FB_ALIGN(buf, m_page_alignment));
 		} // end scope
 
 		ULONG db_size = db_size_pages;
@@ -1176,8 +1172,8 @@ void NBackup::backup_database(int level, Guid& guid, const PathName& fname)
 		Array<UCHAR> unaligned_scns_buffer;
 		Ods::scns_page* scns = NULL, *scns_buf = NULL;
 		{ // scope
-			UCHAR* buf = unaligned_scns_buffer.getBuffer(header->hdr_page_size + SECTOR_ALIGNMENT);
-			scns_buf = reinterpret_cast<Ods::scns_page*>(FB_ALIGN(buf, SECTOR_ALIGNMENT));
+			UCHAR* buf = unaligned_scns_buffer.getBuffer(header->hdr_page_size + m_page_alignment);
+			scns_buf = reinterpret_cast<Ods::scns_page*>(FB_ALIGN(buf, m_page_alignment));
 		}
 
 		while (true)


### PR DESCRIPTION
…pread() with less alignment returns EINVAL