### PR TITLE
Fixed CORE-6110: 64-bit transaction IDs are not stored properly in status vector

### DIFF
--- a/src/dsql/DdlNodes.epp
+++ b/src/dsql/DdlNodes.epp
@@ -11996,11 +11996,11 @@ void AlterDatabaseNode::execute(thread_db* tdbb, DsqlCompilerScratch* dsqlScratc
 
 			// msg 297: Concurrent ALTER DATABASE is not supported
 			Arg::PrivateDyn status(297);
+			string trans_num_str;
 
 			if (conflict_trans)
 			{
 				// Cannot use Arg::Num here because transaction number is 64-bit signed integer
-				string trans_num_str;
 				trans_num_str.printf("%lld", conflict_trans);
 				status << Arg::Gds(isc_concurrent_transaction) << Arg::Str(trans_num_str);
 			}

--- a/src/dsql/DdlNodes.epp
+++ b/src/dsql/DdlNodes.epp
@@ -11998,7 +11998,12 @@ void AlterDatabaseNode::execute(thread_db* tdbb, DsqlCompilerScratch* dsqlScratc
 			Arg::PrivateDyn status(297);
 
 			if (conflict_trans)
-				status << Arg::Gds(isc_concurrent_transaction) << Arg::Num(conflict_trans);
+			{
+				// Cannot use Arg::Num here because transaction number is 64-bit signed integer
+				string trans_num_str;
+				trans_num_str.printf("%lld", conflict_trans);
+				status << Arg::Gds(isc_concurrent_transaction) << Arg::Str(trans_num_str);
+			}
 
 			status_exception::raise(status);
 		}

--- a/src/dsql/DdlNodes.epp
+++ b/src/dsql/DdlNodes.epp
@@ -12001,7 +12001,7 @@ void AlterDatabaseNode::execute(thread_db* tdbb, DsqlCompilerScratch* dsqlScratc
 			if (conflict_trans)
 			{
 				// Cannot use Arg::Num here because transaction number is 64-bit signed integer
-				trans_num_str.printf("%lld", conflict_trans);
+				trans_num_str.printf("%" SQUADFORMAT, conflict_trans);
 				status << Arg::Gds(isc_concurrent_transaction) << Arg::Str(trans_num_str);
 			}
 

--- a/src/jrd/tra.cpp
+++ b/src/jrd/tra.cpp
@@ -1137,7 +1137,7 @@ jrd_tra* TRA_reconnect(thread_db* tdbb, const UCHAR* id, USHORT length)
 
 		// Cannot use Arg::Num here because transaction number is 64-bit signed integer
 		string trans_num_str;
-		trans_num_str.printf("%lld", number);
+		trans_num_str.printf("%" SQUADFORMAT, number);
 
 		ERR_post(Arg::Gds(isc_no_recon) <<
 				 Arg::Gds(isc_tra_state) << Arg::Str(trans_num_str) << Arg::Str(text));

--- a/src/jrd/tra.cpp
+++ b/src/jrd/tra.cpp
@@ -1135,8 +1135,12 @@ jrd_tra* TRA_reconnect(thread_db* tdbb, const UCHAR* id, USHORT length)
 		USHORT flags = 0;
 		gds__msg_lookup(NULL, JRD_BUGCHK, message, sizeof(text), text, &flags);
 
+		// Cannot use Arg::Num here because transaction number is 64-bit signed integer
+		string trans_num_str;
+		trans_num_str.printf("%lld", number);
+
 		ERR_post(Arg::Gds(isc_no_recon) <<
-				 Arg::Gds(isc_tra_state) << Arg::Num(number) << Arg::Str(text));
+				 Arg::Gds(isc_tra_state) << Arg::Str(trans_num_str) << Arg::Str(text));
 	}
 
 	MemoryPool* const pool = attachment->createPool();

--- a/src/jrd/vio.cpp
+++ b/src/jrd/vio.cpp
@@ -888,7 +888,7 @@ bool VIO_chase_record_version(thread_db* tdbb, record_param* rpb,
 
 					// Cannot use Arg::Num here because transaction number is 64-bit signed integer
 					string trans_num_str;
-					trans_num_str.printf("%lld", rpb->rpb_transaction_nr);
+					trans_num_str.printf("%" SQUADFORMAT, rpb->rpb_transaction_nr);
 
 					ERR_post(Arg::Gds(isc_deadlock) <<
 							 Arg::Gds(isc_read_conflict) <<
@@ -1019,7 +1019,7 @@ bool VIO_chase_record_version(thread_db* tdbb, record_param* rpb,
 
 				// Cannot use Arg::Num here because transaction number is 64-bit signed integer
 				string trans_num_str;
-				trans_num_str.printf("%lld", rpb->rpb_transaction_nr);
+				trans_num_str.printf("%" SQUADFORMAT, rpb->rpb_transaction_nr);
 				ERR_post(Arg::Gds(isc_rec_in_limbo) << Arg::Str(trans_num_str));
 			}
 
@@ -1924,7 +1924,7 @@ void VIO_erase(thread_db* tdbb, record_param* rpb, jrd_tra* transaction)
 		{
 			// Cannot use Arg::Num here because transaction number is 64-bit signed integer
 			string trans_num_str;
-			trans_num_str.printf("%lld", rpb->rpb_transaction_nr);
+			trans_num_str.printf("%" SQUADFORMAT, rpb->rpb_transaction_nr);
 
 			ERR_post(Arg::Gds(isc_deadlock) <<
 					 Arg::Gds(isc_update_conflict) <<
@@ -2388,7 +2388,7 @@ bool VIO_get_current(thread_db* tdbb,
 			{
 				// Cannot use Arg::Num here because transaction number is 64-bit signed integer
 				string trans_num_str;
-				trans_num_str.printf("%lld", rpb->rpb_transaction_nr);
+				trans_num_str.printf("%" SQUADFORMAT, rpb->rpb_transaction_nr);
 				ERR_post(Arg::Gds(isc_rec_in_limbo) << Arg::Str(trans_num_str));
 			}
 			// fall thru
@@ -2992,7 +2992,7 @@ void VIO_modify(thread_db* tdbb, record_param* org_rpb, record_param* new_rpb, j
 	{
 		// Cannot use Arg::Num here because transaction number is 64-bit signed integer
 		string trans_num_str;
-		trans_num_str.printf("%lld", org_rpb->rpb_transaction_nr);
+		trans_num_str.printf("%" SQUADFORMAT, org_rpb->rpb_transaction_nr);
 
 		ERR_post(Arg::Gds(isc_deadlock) <<
 				 Arg::Gds(isc_update_conflict) <<
@@ -3220,7 +3220,7 @@ bool VIO_refetch_record(thread_db* tdbb, record_param* rpb, jrd_tra* transaction
 
 		// Cannot use Arg::Num here because transaction number is 64-bit signed integer
 		string trans_num_str;
-		trans_num_str.printf("%lld", rpb->rpb_transaction_nr);
+		trans_num_str.printf("%" SQUADFORMAT, rpb->rpb_transaction_nr);
 
 		ERR_post(Arg::Gds(isc_deadlock) <<
 				 Arg::Gds(isc_update_conflict) <<
@@ -4196,7 +4196,7 @@ bool VIO_writelock(thread_db* tdbb, record_param* org_rpb, jrd_tra* transaction)
 
 				// Cannot use Arg::Num here because transaction number is 64-bit signed integer
 				string trans_num_str;
-				trans_num_str.printf("%lld", org_rpb->rpb_transaction_nr);
+				trans_num_str.printf("%" SQUADFORMAT, org_rpb->rpb_transaction_nr);
 
 				ERR_post(Arg::Gds(isc_deadlock) <<
 						 Arg::Gds(isc_update_conflict) <<
@@ -5890,7 +5890,7 @@ static int prepare_update(	thread_db*		tdbb,
 
 					// Cannot use Arg::Num here because transaction number is 64-bit signed integer
 					string trans_num_str;
-					trans_num_str.printf("%lld", update_conflict_trans);
+					trans_num_str.printf("%" SQUADFORMAT, update_conflict_trans);
 
 					ERR_post(Arg::Gds(isc_deadlock) <<
 							 Arg::Gds(isc_update_conflict) <<
@@ -5903,7 +5903,7 @@ static int prepare_update(	thread_db*		tdbb,
 				{
 					// Cannot use Arg::Num here because transaction number is 64-bit signed integer
 					string trans_num_str;
-					trans_num_str.printf("%lld", rpb->rpb_transaction_nr);
+					trans_num_str.printf("%" SQUADFORMAT, rpb->rpb_transaction_nr);
 					ERR_post(Arg::Gds(isc_trainlim) << Arg::Gds(isc_rec_in_limbo) << Arg::Str(trans_num_str));
 				}
 

--- a/src/jrd/vio.cpp
+++ b/src/jrd/vio.cpp
@@ -886,9 +886,13 @@ bool VIO_chase_record_version(thread_db* tdbb, record_param* rpb,
 				{
 					tdbb->bumpRelStats(RuntimeStatistics::RECORD_CONFLICTS, relation->rel_id);
 
+					// Cannot use Arg::Num here because transaction number is 64-bit signed integer
+					string trans_num_str;
+					trans_num_str.printf("%lld", rpb->rpb_transaction_nr);
+
 					ERR_post(Arg::Gds(isc_deadlock) <<
 							 Arg::Gds(isc_read_conflict) <<
-							 Arg::Gds(isc_concurrent_transaction) << Arg::Num(rpb->rpb_transaction_nr));
+							 Arg::Gds(isc_concurrent_transaction) << Arg::Str(trans_num_str));
 				}
 
 				// refetch the record and try again.  The active transaction
@@ -1012,7 +1016,11 @@ bool VIO_chase_record_version(thread_db* tdbb, record_param* rpb,
 			if (!(transaction->tra_flags & TRA_ignore_limbo))
 			{
 				CCH_RELEASE(tdbb, &rpb->getWindow(tdbb));
-				ERR_post(Arg::Gds(isc_rec_in_limbo) << Arg::Num(rpb->rpb_transaction_nr));
+
+				// Cannot use Arg::Num here because transaction number is 64-bit signed integer
+				string trans_num_str;
+				trans_num_str.printf("%lld", rpb->rpb_transaction_nr);
+				ERR_post(Arg::Gds(isc_rec_in_limbo) << Arg::Str(trans_num_str));
 			}
 
 		case tra_active:
@@ -1914,9 +1922,13 @@ void VIO_erase(thread_db* tdbb, record_param* rpb, jrd_tra* transaction)
 		PageStack stack;
 		if (prepare_update(tdbb, transaction, tid_fetch, rpb, &temp, 0, stack, false))
 		{
+			// Cannot use Arg::Num here because transaction number is 64-bit signed integer
+			string trans_num_str;
+			trans_num_str.printf("%lld", rpb->rpb_transaction_nr);
+
 			ERR_post(Arg::Gds(isc_deadlock) <<
 					 Arg::Gds(isc_update_conflict) <<
-					 Arg::Gds(isc_concurrent_transaction) << Arg::Num(rpb->rpb_transaction_nr));
+					 Arg::Gds(isc_concurrent_transaction) << Arg::Str(trans_num_str));
 		}
 
 		// Old record was restored and re-fetched for write.  Now replace it.
@@ -2373,7 +2385,12 @@ bool VIO_get_current(thread_db* tdbb,
 
 		case tra_limbo:
 			if (!(transaction->tra_flags & TRA_ignore_limbo))
-				ERR_post(Arg::Gds(isc_rec_in_limbo) << Arg::Num(rpb->rpb_transaction_nr));
+			{
+				// Cannot use Arg::Num here because transaction number is 64-bit signed integer
+				string trans_num_str;
+				trans_num_str.printf("%lld", rpb->rpb_transaction_nr);
+				ERR_post(Arg::Gds(isc_rec_in_limbo) << Arg::Str(trans_num_str));
+			}
 			// fall thru
 
 		case tra_active:
@@ -2973,9 +2990,13 @@ void VIO_modify(thread_db* tdbb, record_param* org_rpb, record_param* new_rpb, j
 	if (prepare_update(tdbb, transaction, org_rpb->rpb_transaction_nr, org_rpb, &temp, new_rpb,
 					   stack, false))
 	{
+		// Cannot use Arg::Num here because transaction number is 64-bit signed integer
+		string trans_num_str;
+		trans_num_str.printf("%lld", org_rpb->rpb_transaction_nr);
+
 		ERR_post(Arg::Gds(isc_deadlock) <<
 				 Arg::Gds(isc_update_conflict) <<
-				 Arg::Gds(isc_concurrent_transaction) << Arg::Num(org_rpb->rpb_transaction_nr));
+				 Arg::Gds(isc_concurrent_transaction) << Arg::Str(trans_num_str));
 	}
 
 	IDX_modify_flag_uk_modified(tdbb, org_rpb, new_rpb, transaction);
@@ -3197,9 +3218,13 @@ bool VIO_refetch_record(thread_db* tdbb, record_param* rpb, jrd_tra* transaction
 	{
 		tdbb->bumpRelStats(RuntimeStatistics::RECORD_CONFLICTS, rpb->rpb_relation->rel_id);
 
+		// Cannot use Arg::Num here because transaction number is 64-bit signed integer
+		string trans_num_str;
+		trans_num_str.printf("%lld", rpb->rpb_transaction_nr);
+
 		ERR_post(Arg::Gds(isc_deadlock) <<
 				 Arg::Gds(isc_update_conflict) <<
-				 Arg::Gds(isc_concurrent_transaction) << Arg::Num(rpb->rpb_transaction_nr));
+				 Arg::Gds(isc_concurrent_transaction) << Arg::Str(trans_num_str));
 	}
 
 	return true;
@@ -4164,12 +4189,19 @@ bool VIO_writelock(thread_db* tdbb, record_param* org_rpb, jrd_tra* transaction)
 			org_rpb->rpb_runtime_flags |= RPB_refetch;
 			return false;
 		case PREPARE_LOCKERR:
-			// We got some kind of locking error (deadlock, timeout or lock_conflict)
-			// Error details should be stuffed into status vector at this point
-			// hvlad: we have no details as TRA_wait has already cleared the status vector
-			ERR_post(Arg::Gds(isc_deadlock) <<
-					 Arg::Gds(isc_update_conflict) <<
-					 Arg::Gds(isc_concurrent_transaction) << Arg::Num(org_rpb->rpb_transaction_nr));
+			{
+				// We got some kind of locking error (deadlock, timeout or lock_conflict)
+				// Error details should be stuffed into status vector at this point
+				// hvlad: we have no details as TRA_wait has already cleared the status vector
+
+				// Cannot use Arg::Num here because transaction number is 64-bit signed integer
+				string trans_num_str;
+				trans_num_str.printf("%lld", org_rpb->rpb_transaction_nr);
+
+				ERR_post(Arg::Gds(isc_deadlock) <<
+						 Arg::Gds(isc_update_conflict) <<
+						 Arg::Gds(isc_concurrent_transaction) << Arg::Str(trans_num_str));
+			}
 	}
 
 	// Old record was restored and re-fetched for write.  Now replace it.
@@ -5856,15 +5888,24 @@ static int prepare_update(	thread_db*		tdbb,
 				{
 					tdbb->bumpRelStats(RuntimeStatistics::RECORD_CONFLICTS, relation->rel_id);
 
+					// Cannot use Arg::Num here because transaction number is 64-bit signed integer
+					string trans_num_str;
+					trans_num_str.printf("%lld", update_conflict_trans);
+
 					ERR_post(Arg::Gds(isc_deadlock) <<
 							 Arg::Gds(isc_update_conflict) <<
-							 Arg::Gds(isc_concurrent_transaction) << Arg::Num(update_conflict_trans));
+							 Arg::Gds(isc_concurrent_transaction) << Arg::Str(trans_num_str));
 				}
 			case tra_active:
 				return PREPARE_LOCKERR;
 
 			case tra_limbo:
-				ERR_post(Arg::Gds(isc_trainlim) << Arg::Gds(isc_rec_in_limbo) << Arg::Num(rpb->rpb_transaction_nr));
+				{
+					// Cannot use Arg::Num here because transaction number is 64-bit signed integer
+					string trans_num_str;
+					trans_num_str.printf("%lld", rpb->rpb_transaction_nr);
+					ERR_post(Arg::Gds(isc_trainlim) << Arg::Gds(isc_rec_in_limbo) << Arg::Str(trans_num_str));
+				}
 
 			case tra_dead:
 				break;


### PR DESCRIPTION
Arg::Str is used instead of Arg::Num for isc_concurrent_transaction, isc_rec_in_limbo, isc_tra_state error messages because transaction number is 64-bit signed integer.

In the general case it doesn't matter which types of argument are used in messages. For example, when isql gets a status vector, it checks the type of argument and prints its value in the right way.