### PR TITLE
Fixed CORE-6110: 64-bit transaction IDs are not stored properly in status vector

### DIFF
--- a/src/dsql/DdlNodes.epp
+++ b/src/dsql/DdlNodes.epp
@@ -12427,9 +12427,14 @@ void AlterDatabaseNode::execute(thread_db* tdbb, DsqlCompilerScratch* dsqlScratc
 
 			// msg 297: Concurrent ALTER DATABASE is not supported
 			Arg::PrivateDyn status(297);
+			string trans_num_str;
 
 			if (conflict_trans)
-				status << Arg::Gds(isc_concurrent_transaction) << Arg::Num(conflict_trans);
+			{
+				// Cannot use Arg::Num here because transaction number is 64-bit unsigned integer
+				trans_num_str.printf("%" UQUADFORMAT, conflict_trans);
+				status << Arg::Gds(isc_concurrent_transaction) << Arg::Str(trans_num_str);
+			}
 
 			status_exception::raise(status);
 		}

--- a/src/jrd/tra.cpp
+++ b/src/jrd/tra.cpp
@@ -1163,8 +1163,12 @@ jrd_tra* TRA_reconnect(thread_db* tdbb, const UCHAR* id, USHORT length)
 		USHORT flags = 0;
 		gds__msg_lookup(NULL, JRD_BUGCHK, message, sizeof(text), text, &flags);
 
+		// Cannot use Arg::Num here because transaction number is 64-bit unsigned integer
+		string trans_num_str;
+		trans_num_str.printf("%" UQUADFORMAT, number);
+
 		ERR_post(Arg::Gds(isc_no_recon) <<
-				 Arg::Gds(isc_tra_state) << Arg::Num(number) << Arg::Str(text));
+				 Arg::Gds(isc_tra_state) << Arg::Str(trans_num_str) << Arg::Str(text));
 	}
 
 	MemoryPool* const pool = attachment->createPool();


### PR DESCRIPTION
Arg::Str is used instead of Arg::Num for isc_concurrent_transaction, isc_rec_in_limbo, isc_tra_state error messages because transaction number is 64-bit unsigned integer.