### PR TITLE
New feature CORE-4933 : Add better transaction control to isql

### DIFF
--- a/src/isql/isql.epp
+++ b/src/isql/isql.epp
@@ -441,6 +441,8 @@ static int Exit_value = 0;
 static bool Interactive = true;
 static bool Input_file = false;
 
+static const char* DEFAULT_DML_TRANS_SQL = "SET TRANSACTION";
+static Firebird::GlobalPtr<Firebird::string> TranParams;
 
 // Values used in the SET command.
 // Initial options set exclusively from the command line are not included here.
@@ -468,7 +470,8 @@ public:
 		BailOnError = false;
 		StmtTimeout = 0;
 		ISQL_charset[0] = 0;
-		KeepTranParams = false;
+		KeepTranParams = true;
+		TranParams->assign(DEFAULT_DML_TRANS_SQL);
 	}
 
 	ColList global_Cols;
@@ -493,7 +496,6 @@ public:
 	bool KeepTranParams;
 };
 
-static Firebird::GlobalPtr<Firebird::string> TranParams;
 static SetValues setValues;
 
 
@@ -551,8 +553,6 @@ static const UCHAR default_tpb[] =
 	isc_tpb_read_committed, isc_tpb_wait,
 	isc_tpb_no_rec_version
 };
-
-static const char* DEFAULT_DML_TRANS_SQL = "SET TRANSACTION";
 
 #ifdef NOT_USED_OR_REPLACED
 // CVC: Just in case we need it for R/O operations in the future.
@@ -5185,9 +5185,12 @@ static processing_state frontend_set(const char* cmd, const char* const* parms,
 		break;
 
 	case SetOptions::keepTranParams:
-		ret = do_set_command(parms[2], &setValues.KeepTranParams);
-		if (ret != ps_ERR)
-			TranParams->assign(setValues.KeepTranParams ? DEFAULT_DML_TRANS_SQL : "");
+		{
+			const bool oldValue = setValues.KeepTranParams;
+			ret = do_set_command(parms[2], &setValues.KeepTranParams);
+			if ((ret != ps_ERR) && (oldValue != setValues.KeepTranParams))
+				TranParams->assign(setValues.KeepTranParams ? DEFAULT_DML_TRANS_SQL : "");
+		}
 
 		break;
 

--- a/src/isql/isql.epp
+++ b/src/isql/isql.epp
@@ -468,6 +468,7 @@ public:
 		BailOnError = false;
 		StmtTimeout = 0;
 		ISQL_charset[0] = 0;
+		KeepTranParams = false;
 	}
 
 	ColList global_Cols;
@@ -489,8 +490,10 @@ public:
 	bool BailOnError;
 	unsigned int StmtTimeout;
 	SCHAR ISQL_charset[MAXCHARSET_SIZE];
+	bool KeepTranParams;
 };
 
+static Firebird::GlobalPtr<Firebird::string> TranParams;
 static SetValues setValues;
 
 
@@ -549,6 +552,8 @@ static const UCHAR default_tpb[] =
 	isc_tpb_no_rec_version
 };
 
+static const char* DEFAULT_DML_TRANS_SQL = "SET TRANSACTION";
+
 #ifdef NOT_USED_OR_REPLACED
 // CVC: Just in case we need it for R/O operations in the future.
 static const UCHAR	batch_tpb[] =
@@ -586,6 +591,17 @@ static bool startTransaction(Firebird::ITransaction** t, unsigned len = 0, const
 
 static bool M_Transaction()
 {
+	if (DB && !M__trans && setValues.KeepTranParams)
+	{
+		M__trans = DB->execute(fbStatus, nullptr, 
+							   TranParams->length(), TranParams->c_str(),
+							   isqlGlob.SQL_dialect, nullptr, nullptr, nullptr, nullptr);
+
+		if (ISQL_errmsg(fbStatus))
+			return false;
+
+		return DB != NULL;
+	}
 	return startTransaction(&M__trans);
 }
 
@@ -4949,6 +4965,7 @@ static processing_state frontend_set(const char* cmd, const char* const* parms,
 //#endif
 			sql, warning, sqlCont, heading, bail,
 			bulk_insert, maxrows, stmtTimeout,
+			keepTranParams,
 			wrong
 		};
 		SetOptions(const optionsMap* inmap, size_t insize, int wrongval)
@@ -4989,6 +5006,7 @@ static processing_state frontend_set(const char* cmd, const char* const* parms,
 		{SetOptions::sqlCont, "TRUSTED", 0},	// TRUSTED ROLE, will get DSQL error other case
 		{SetOptions::stmtTimeout, "LOCAL_TIMEOUT", 0},
 		{SetOptions::sqlCont, "DECFLOAT", 0},
+		{SetOptions::keepTranParams, "KEEP_TRAN_PARAMS", 9},
 	};
 
 	// Display current set options
@@ -5164,6 +5182,13 @@ static processing_state frontend_set(const char* cmd, const char* const* parms,
 				ret = SKIP;
 			}
 		}
+		break;
+
+	case SetOptions::keepTranParams:
+		ret = do_set_command(parms[2], &setValues.KeepTranParams);
+		if (ret != ps_ERR)
+			TranParams->assign(setValues.KeepTranParams ? DEFAULT_DML_TRANS_SQL : "");
+
 		break;
 
 	default:
@@ -5997,6 +6022,9 @@ static processing_state print_sets()
 	print_set("Warnings:", setValues.Warnings);
 	print_set("Bail on error:", setValues.BailOnError);
 	isqlGlob.printf("%-25s%lu%s", "Local statement timeout:", setValues.StmtTimeout, NEWLINE);
+	print_set("Keep transaction params:", setValues.KeepTranParams);
+	if (setValues.KeepTranParams)
+		isqlGlob.printf("    %s%s", TranParams->c_str(), NEWLINE);
 	return SKIP;
 }
 
@@ -6667,6 +6695,9 @@ static processing_state newtrans(const TEXT* statement)
 	{
 		return FAIL;
 	}
+
+	if (setValues.KeepTranParams)
+		TranParams->assign(statement);
 
 	return SKIP;
 }


### PR DESCRIPTION
Add new SET command at ISQL: SET KEEP_TRAN_PARAMS:
- when ON it keeps text of following successful SET TRANSACTION statement and
new DML transactions is started using the same SQL (instead of defaul CONCURRENCY WAIT mode)
- when OFF, isql start new DML transaction as usual.
Name KEEP_TRAN_PARAMS could be cut up to the KEEP_TRAN.

Example:

SQL> SET;
...
**Keep transaction params: OFF**
SQL> SET KEEP_TRAN;
SQL> SET;
...
**Keep transaction params: ON
    SET TRANSACTION**
SQL>commit;
SQL>SET TRANSACTION READ COMMITTED WAIT;
SQL>SET;
...
**Keep transaction params: ON
    SET TRANSACTION READ COMMITTED WAIT**
SQL> SELECT RDB$GET_CONTEXT('SYSTEM', 'ISOLATION_LEVEL') FROM RDB$DATABASE;

RDB$GET_CONTEXT

=============================================================
READ COMMITTED
SQL> commit;
SQL> SELECT RDB$GET_CONTEXT('SYSTEM', 'ISOLATION_LEVEL') FROM RDB$DATABASE;

RDB$GET_CONTEXT

=============================================================
READ COMMITTED

SQL> SET KEEP_TRAN OFF;
SQL> SELECT RDB$GET_CONTEXT('SYSTEM', 'ISOLATION_LEVEL') FROM RDB$DATABASE;

RDB$GET_CONTEXT

=============================================================
READ COMMITTED

SQL> commit;
SQL> SELECT RDB$GET_CONTEXT('SYSTEM', 'ISOLATION_LEVEL') FROM RDB$DATABASE;

RDB$GET_CONTEXT

=============================================================
SNAPSHOT

SQL> SET;
...
Keep transaction params: OFF
SQL>
