### PR TITLE
Fix alpine build

### DIFF
--- a/src/common/os/os_utils.h
+++ b/src/common/os/os_utils.h
@@ -34,8 +34,9 @@
 #include "../common/StatusArg.h"
 #include "../common/classes/array.h"
 
-#ifdef WIN_NT
 #include <sys/stat.h>
+
+#ifdef WIN_NT
 
 #define mode_t int
 #define DEFAULT_OPEN_MODE (_S_IREAD | _S_IWRITE)


### PR DESCRIPTION
I have tried to build FB in alpine and got this compile error:
`In file included from /build/fb3/firebird-R3_0_5/src/common/isc.cpp:49:
/build/fb3/firebird-R3_0_5/src/common/../common/os/os_utils.h:60:44: error: 'mode_t' has not been declared
  int open(const char* pathname, int flags, mode_t mode = DEFAULT_OPEN_MODE);`

I supposed, that UNIX header file `<sys/stat.h>` cannot be under `#ifdef WIN_NT`.