### PR TITLE
Postfix for CORE-6110: always store strings in local StatusVector's memory

### DIFF
--- a/src/common/StatusArg.cpp
+++ b/src/common/StatusArg.cpp
@@ -30,7 +30,6 @@
 #include "../common/StatusArg.h"
 #include "../common/utils_proto.h"
 
-#include "../common/classes/fb_string.h"
 #include "../common/classes/MetaName.h"
 #include "../common/classes/alloc.h"
 #include "fb_exception.h"
@@ -60,7 +59,8 @@ Base::Base(ISC_STATUS k, ISC_STATUS c) :
 
 StatusVector::ImplStatusVector::ImplStatusVector(const ISC_STATUS* s) throw()
 	: Base::ImplBase(0, 0),
-	  m_status_vector(*getDefaultMemoryPool())
+	  m_status_vector(*getDefaultMemoryPool()),
+	  m_strings(*getDefaultMemoryPool())
 {
 	fb_assert(s);
 
@@ -73,7 +73,8 @@ StatusVector::ImplStatusVector::ImplStatusVector(const ISC_STATUS* s) throw()
 
 StatusVector::ImplStatusVector::ImplStatusVector(const IStatus* s) throw()
 	: Base::ImplBase(0, 0),
-	  m_status_vector(*getDefaultMemoryPool())
+	  m_status_vector(*getDefaultMemoryPool()),
+	  m_strings(*getDefaultMemoryPool())
 {
 	fb_assert(s);
 
@@ -87,7 +88,8 @@ StatusVector::ImplStatusVector::ImplStatusVector(const IStatus* s) throw()
 
 StatusVector::ImplStatusVector::ImplStatusVector(const Exception& ex) throw()
 	: Base::ImplBase(0, 0),
-	  m_status_vector(*getDefaultMemoryPool())
+	  m_status_vector(*getDefaultMemoryPool()),
+	  m_strings(*getDefaultMemoryPool())
 {
 	clear();
 
@@ -125,6 +127,7 @@ void StatusVector::ImplStatusVector::clear() throw()
 	m_warning = 0;
 	m_status_vector.clear();
 	m_status_vector.push(isc_arg_end);
+	m_strings.erase();
 }
 
 bool StatusVector::ImplStatusVector::compare(const StatusVector& v) const throw()
@@ -142,6 +145,52 @@ void StatusVector::ImplStatusVector::assign(const Exception& ex) throw()
 {
 	clear();
 	ex.stuffException(m_status_vector);
+	putStrArg(0);
+}
+
+void StatusVector::ImplStatusVector::putStrArg(unsigned startWith)
+{
+	for (ISC_STATUS* arg = m_status_vector.begin() + startWith; *arg != isc_arg_end; arg += fb_utils::nextArg(*arg))
+	{
+		if (!fb_utils::isStr(*arg))
+			continue;
+
+		const char** ptr = reinterpret_cast<const char**>(&arg[fb_utils::nextArg(*arg) - 1]);
+		unsigned pos = m_strings.length();
+		const char* oldBase = m_strings.c_str();
+
+		if (*arg == isc_arg_cstring)
+		{
+			m_strings.append(*ptr, arg[1]);
+			m_strings.append(1, '\0');
+		}
+		else
+			 m_strings.append(*ptr, strlen(*ptr) + 1);
+
+		*ptr = &m_strings[pos];
+		setStrPointers(oldBase);
+	}
+}
+
+void StatusVector::ImplStatusVector::setStrPointers(const char* oldBase)
+{
+	const char* const newBase = m_strings.c_str();
+	if (newBase == oldBase)
+		return;
+
+	const char* const newEnd = &newBase[m_strings.length()];
+
+	for (ISC_STATUS* arg = m_status_vector.begin(); *arg != isc_arg_end; arg += fb_utils::nextArg(*arg))
+	{
+		if (!fb_utils::isStr(*arg))
+			continue;
+
+		const char** ptr = reinterpret_cast<const char**>(&arg[fb_utils::nextArg(*arg) - 1]);
+		if (newBase <= *ptr && *ptr < newEnd)
+			break;
+
+		*ptr = &newBase[*ptr - oldBase];
+	}
 }
 
 void StatusVector::ImplStatusVector::append(const StatusVector& v) throw()
@@ -176,6 +225,16 @@ void StatusVector::ImplStatusVector::prepend(const StatusVector& v) throw()
 	*this = newVector;
 }
 
+StatusVector::ImplStatusVector& StatusVector::ImplStatusVector::operator=(const StatusVector::ImplStatusVector& src)
+{
+	m_status_vector = src.m_status_vector;
+	m_warning = src.m_warning;
+	m_strings = src.m_strings;
+	setStrPointers(src.m_strings.c_str());
+
+	return *this;
+}
+
 bool StatusVector::ImplStatusVector::appendErrors(const ImplBase* const v) throw()
 {
 	return append(v->value(), v->firstWarning() ? v->firstWarning() : v->length());
@@ -201,6 +260,7 @@ bool StatusVector::ImplStatusVector::append(const ISC_STATUS* const from, const 
 		fb_utils::copyStatus(&s[lenBefore], count + 1, from, count);
 	if (copied < count)
 		m_status_vector.shrink(lenBefore + copied + 1);
+	putStrArg(lenBefore);
 
 	if (!m_warning)
 	{
@@ -229,6 +289,8 @@ void StatusVector::ImplStatusVector::shiftLeft(const Base& arg) throw()
 	m_status_vector[length()] = arg.getKind();
 	m_status_vector.push(arg.getCode());
 	m_status_vector.push(isc_arg_end);
+
+	putStrArg(length() - 2);
 }
 
 void StatusVector::ImplStatusVector::shiftLeft(const Warning& arg) throw()

--- a/src/common/StatusArg.cpp
+++ b/src/common/StatusArg.cpp
@@ -178,7 +178,7 @@ void StatusVector::ImplStatusVector::setStrPointers(const char* oldBase)
 	if (newBase == oldBase)
 		return;
 
-	const char* const newEnd = &newBase[m_strings.length()];
+	const char* const newEnd = m_strings.end();
 
 	for (ISC_STATUS* arg = m_status_vector.begin(); *arg != isc_arg_end; arg += fb_utils::nextArg(*arg))
 	{
@@ -186,7 +186,7 @@ void StatusVector::ImplStatusVector::setStrPointers(const char* oldBase)
 			continue;
 
 		const char** ptr = reinterpret_cast<const char**>(&arg[fb_utils::nextArg(*arg) - 1]);
-		if (newBase <= *ptr && *ptr < newEnd)
+		if (*ptr >= newBase && *ptr < newEnd)
 			break;
 
 		*ptr = &newBase[*ptr - oldBase];

--- a/src/common/StatusArg.cpp
+++ b/src/common/StatusArg.cpp
@@ -161,7 +161,7 @@ void StatusVector::ImplStatusVector::putStrArg(unsigned startWith)
 
 		if (*arg == isc_arg_cstring)
 		{
-			m_strings.grow(arg[1] + 1);
+			m_strings.reserve(m_strings.length() + arg[1] + 1);
 			m_strings.append(*ptr, arg[1]);
 			m_strings.append(1, '\0');
 		}

--- a/src/common/StatusArg.cpp
+++ b/src/common/StatusArg.cpp
@@ -161,6 +161,7 @@ void StatusVector::ImplStatusVector::putStrArg(unsigned startWith)
 
 		if (*arg == isc_arg_cstring)
 		{
+			m_strings.grow(arg[1] + 1);
 			m_strings.append(*ptr, arg[1]);
 			m_strings.append(1, '\0');
 		}

--- a/src/common/StatusArg.h
+++ b/src/common/StatusArg.h
@@ -32,6 +32,7 @@
 #include "fb_exception.h"
 #include "firebird/Interface.h"
 #include "../common/SimpleStatusVector.h"
+#include "../common/classes/fb_string.h"
 
 namespace Firebird {
 
@@ -107,10 +108,17 @@ protected:
 		StaticStatusVector m_status_vector;
 		unsigned int m_warning;
 
+		string m_strings;
+
+		void putStrArg(unsigned startWith);
+		void setStrPointers(const char* oldBase);
+
 		bool appendErrors(const ImplBase* const v) throw();
 		bool appendWarnings(const ImplBase* const v) throw();
 		bool append(const ISC_STATUS* const from, const unsigned int count) throw();
 		void append(const ISC_STATUS* const from) throw();
+
+		ImplStatusVector& operator=(const ImplStatusVector& src);
 
 	public:
 		virtual const ISC_STATUS* value() const throw() { return m_status_vector.begin(); }
@@ -134,7 +142,8 @@ protected:
 
 		ImplStatusVector(ISC_STATUS k, ISC_STATUS c) throw()
 			: ImplBase(k, c),
-			  m_status_vector(*getDefaultMemoryPool())
+			  m_status_vector(*getDefaultMemoryPool()),
+			  m_strings(*getDefaultMemoryPool())
 		{
 			clear();
 		}

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -1151,7 +1151,7 @@ unsigned int copyStatus(ISC_STATUS* const to, const unsigned int space,
 		{
 			break;
 		}
-		i += (from[i] == isc_arg_cstring ? 3 : 2);
+		i += nextArg(from[i]);
 		if (i > space - 1)
 		{
 			break;
@@ -1224,7 +1224,7 @@ void setIStatus(Firebird::CheckStatusWrapper* to, const ISC_STATUS* from) throw(
 				to->setWarnings(w);
 				break;
 			}
-			w += (*w == isc_arg_cstring ? 3 : 2);
+			w += nextArg(*w);
 		}
 		to->setErrors2(w - from, from);
 	}
@@ -1243,7 +1243,7 @@ unsigned int statusLength(const ISC_STATUS* const status) throw()
 		{
 			return l;
 		}
-		l += (status[l] == isc_arg_cstring ? 3 : 2);
+		l += nextArg(status[l]);
 	}
 }
 
@@ -1259,18 +1259,14 @@ bool cmpStatus(unsigned int len, const ISC_STATUS* a, const ISC_STATUS* b) throw
 		if (i == len - 1 && *op1 == isc_arg_end)
 			break;
 
-		i += (*op1 == isc_arg_cstring ? 3 : 2);
+		i += nextArg(*op1);
 		if (i > len)		// arg does not fit
 			return false;
 
 		unsigned l1, l2;
 		const char *s1, *s2;
-		switch (*op1)
+		if (isStr(*op1))
 		{
-		case isc_arg_cstring:
-		case isc_arg_string:
-		case isc_arg_interpreted:
-		case isc_arg_sql_state:
 			if (*op1 == isc_arg_cstring)
 			{
 				l1 = op1[1];
@@ -1290,13 +1286,9 @@ bool cmpStatus(unsigned int len, const ISC_STATUS* a, const ISC_STATUS* b) throw
 				return false;
 			if (memcmp(s1, s2, l1) != 0)
 				return false;
-			break;
-
-		default:
-			if (op1[1] != op2[1])
-				return false;
-			break;
 		}
+		else if (op1[1] != op2[1])
+			return false;
 	}
 
 	return true;
@@ -1314,19 +1306,15 @@ unsigned int subStatus(const ISC_STATUS* in, unsigned int cin,
 			if (*op1 != *op2)
 				goto miss;
 
-			i += (*op1 == isc_arg_cstring ? 3 : 2);
+			i += nextArg(*op1);
 			if (i > csub)		// arg does not fit
 				goto miss;
 
-			unsigned l1, l2;
-			const char *s1, *s2;
 
-			switch (*op1)
+			if (isStr(*op1))
 			{
-			case isc_arg_cstring:
-			case isc_arg_string:
-			case isc_arg_interpreted:
-			case isc_arg_sql_state:
+				unsigned l1, l2;
+				const char *s1, *s2;
 				if (*op1 == isc_arg_cstring)
 				{
 					l1 = op1[1];
@@ -1346,19 +1334,14 @@ unsigned int subStatus(const ISC_STATUS* in, unsigned int cin,
 					goto miss;
 				if (memcmp(s1, s2, l1) != 0)
 					goto miss;
-				break;
-
-			default:
-				if (op1[1] != op2[1])
-					goto miss;
-				break;
 			}
-
+			else if (op1[1] != op2[1])
+				goto miss;
 		}
 
 		return pos;
 
-miss:	pos += (in[pos] == isc_arg_cstring ? 3 : 2);
+miss:	pos += nextArg(in[pos]);
 	}
 
 	return ~0u;
@@ -1596,11 +1579,11 @@ unsigned sqlTypeToDsc(unsigned runOffset, unsigned sqlType, unsigned sqlLength,
 	return runOffset + sizeof(SSHORT);
 }
 
-const ISC_STATUS* nextArg(const ISC_STATUS* v) throw()
+const ISC_STATUS* nextCode(const ISC_STATUS* v) throw()
 {
 	do
 	{
-		v += (v[0] == isc_arg_cstring ? 3 : 2);
+		v += nextArg(v[0]);
 	} while (v[0] != isc_arg_warning && v[0] != isc_arg_gds && v[0] != isc_arg_end);
 
 	return v;
@@ -1608,7 +1591,7 @@ const ISC_STATUS* nextArg(const ISC_STATUS* v) throw()
 
 bool containsErrorCode(const ISC_STATUS* v, ISC_STATUS code)
 {
-	for (; v[0] == isc_arg_gds; v = nextArg(v))
+	for (; v[0] == isc_arg_gds; v = nextCode(v))
 	{
 		if (v[1] == code)
 			return true;

--- a/src/common/utils_proto.h
+++ b/src/common/utils_proto.h
@@ -153,7 +153,26 @@ namespace fb_utils
 	unsigned int subStatus(const ISC_STATUS* in, unsigned int cin,
 						   const ISC_STATUS* sub, unsigned int csub) throw();
 	bool cmpStatus(unsigned int len, const ISC_STATUS* a, const ISC_STATUS* b) throw();
-	const ISC_STATUS* nextArg(const ISC_STATUS* v) throw();
+	const ISC_STATUS* nextCode(const ISC_STATUS* v) throw();
+
+	inline unsigned nextArg(const ISC_STATUS v) throw()
+	{
+		return v == isc_arg_cstring ? 3 : 2;
+	}
+
+	inline bool isStr(const ISC_STATUS v) throw()
+	{
+		switch (v)
+		{
+		case isc_arg_cstring:
+		case isc_arg_string:
+		case isc_arg_interpreted:
+		case isc_arg_sql_state:
+			return true;
+		}
+
+		return false;
+	}
 
 	// Check does vector contain particular code or not
 	bool containsErrorCode(const ISC_STATUS* v, ISC_STATUS code);

--- a/src/jrd/jrd.cpp
+++ b/src/jrd/jrd.cpp
@@ -1164,7 +1164,7 @@ namespace Jrd
 
 					// strip spam messages
 					const ISC_STATUS* v = status->getErrors();
-					for (; v[0] == isc_arg_gds; v = fb_utils::nextArg(v))
+					for (; v[0] == isc_arg_gds; v = fb_utils::nextCode(v))
 					{
 						if (v[1] != isc_dsql_error && v[1] != isc_sqlerr)
 							break;


### PR DESCRIPTION
This solves once and forever any problems with incorrect usage of Arg::Str and derived from it args. The price is relatively small [when no exceptions raised - sizeof(Firebird::string) per StatusVector ] memory overhead. With typical usage when StatusVector is inside a scope:
if (error)
    (Arg1 << Arg2 << ...).raise();
there is no overhead as long as error did not happen.

When error is raised overhead obviously depends upon length of arguments and complexity of operations with them.