### PR TITLE
Fix read replication configuration file

### DIFF
--- a/src/jrd/replication/Config.h
+++ b/src/jrd/replication/Config.h
@@ -34,6 +34,7 @@ namespace Replication
 	struct Config : public Firebird::GlobalStorage
 	{
 		Config();
+		Config(const Config& other);
 
 		static Config* get(const Firebird::PathName& dbName);
 		static void enumerate(Firebird::Array<Config*>& replicas);


### PR DESCRIPTION
### - fixed crash when no subsection specified of database
Side feature: for database sections without subsection using all parameters from default config.
For example, if need to configure the server so that replication logs are written to the same directory, config may be so:
```
database
{
  log_directory = /path/to/logs
}
database = /path/to/first.fdb
database = /path/to/second.fdb
```
These two databases will use asynchronous replication with logs stored in log_directory.
This option is specific, but can be used.
I think this option is better than just skipping or throwing an error. And better than a server crash.
### - fixed read default database section for replica databases
Previously, if the config looked like:
```
database
{
  verbose_logging = true      # default is false
}
database = /your/db.fdb
{
  log_source_directory = /your/db/incominglog
}
```
the replica still set the default verbose_logging parameter, because after reading default database section erased and rewrited to the specific database section with default values.