### PR TITLE
Restrict tzdata-update to FirebirdSQL/firebird

### DIFF
--- a/.github/workflows/tzdata-update.yml
+++ b/.github/workflows/tzdata-update.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   tzdata-update:
+    if: github.repository == 'FirebirdSQL/firebird'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This should prevent the tzdata-update task from running on forks and creating pull requests, and partially failing because it can't assign to user asfernandes.