### PR TITLE
Fix CORE-6338: Mark attachment of sweep thread with ATT_sweep_thread flag and protect it with mutex to avoid races with JRD_release_attachment

### DIFF
--- a/src/jrd/Attachment.h
+++ b/src/jrd/Attachment.h
@@ -413,6 +413,7 @@ const ULONG ATT_security_db			= 0x20000L; // Attachment used for security purpos
 const ULONG ATT_mapping				= 0x40000L; // Attachment used for mapping auth block
 const ULONG ATT_crypt_thread		= 0x80000L; // Attachment from crypt thread
 const ULONG ATT_monitor_init		= 0x100000L; // Attachment is registered in monitoring
+const ULONG ATT_sweep_thread		= 0x200000L; // Attachment from sweep thread
 
 const ULONG ATT_NO_CLEANUP			= (ATT_no_cleanup | ATT_notify_gc);
 

--- a/src/jrd/Database.cpp
+++ b/src/jrd/Database.cpp
@@ -93,6 +93,7 @@ namespace Jrd
 				MemoryPool::deletePool(dbb_pools[i]);
 		}
 
+		delete dbb_sweeper;
 		delete dbb_monitoring_data;
 		delete dbb_backup_manager;
 		delete dbb_crypto_manager;

--- a/src/jrd/Database.h
+++ b/src/jrd/Database.h
@@ -80,6 +80,7 @@ class ExternalFileDirectoryList;
 class MonitoringData;
 class GarbageCollector;
 class CryptoManager;
+class Sweeper;
 
 // general purpose vector
 template <class T, BlockType TYPE = type_vec>
@@ -471,6 +472,7 @@ public:
 	unsigned dbb_linger_seconds;
 	time_t dbb_linger_end;
 	Firebird::RefPtr<Firebird::IPluginConfig> dbb_plugin_config;
+	Sweeper* dbb_sweeper;
 
 	// returns true if primary file is located on raw device
 	bool onRawDevice() const;

--- a/src/jrd/tra.h
+++ b/src/jrd/tra.h
@@ -653,6 +653,24 @@ inline void Savepoint::deleteActions(VerbAction* list)
 	}
 };
 
+
+class Sweeper
+{
+public:
+	explicit Sweeper(Database* dbb);
+	~Sweeper();
+	void start();
+	void stop();
+	Database* getDatabase();
+
+private:
+	Database* dbb;
+	Thread::Handle sweepThreadHandle;
+
+public:
+	Firebird::Mutex mutex;
+};
+
 } //namespace Jrd
 
 #endif // JRD_TRA_H


### PR DESCRIPTION
This is draft solution to fix CORE-6338. I've left almost all sweep thread starting logic intact but wrapped it with class to control sweeper attachment thread and added some locking to avoid racing between sweeper starting and attachment release. Please review.