### PR TITLE
Fix Thread handle type on Windows

### DIFF
--- a/src/common/ThreadStart.cpp
+++ b/src/common/ThreadStart.cpp
@@ -309,13 +309,16 @@ Thread Thread::start(ThreadEntryPoint* routine, void* arg, int priority_arg, Han
 	 * Advanced Windows by Richter pg. # 109. */
 
 	unsigned thread_id;
-	unsigned long real_handle =
-		_beginthreadex(NULL, 0, THREAD_ENTRYPOINT, THREAD_ARG, CREATE_SUSPENDED, &thread_id);
-	if (!real_handle)
+	HANDLE handle =
+		reinterpret_cast<HANDLE>(_beginthreadex(NULL, 0, THREAD_ENTRYPOINT, THREAD_ARG, CREATE_SUSPENDED, &thread_id));
+	if (!handle)
 	{
+		// Though MSDN says that _beginthreadex() returns error in errno,
+		// GetLastError() still works because RTL call no other system
+		// functions after CreateThread() in the case of error.
+		// Watch out if it is ever changed.
 		Firebird::system_call_failed::raise("_beginthreadex", GetLastError());
 	}
-	HANDLE handle = reinterpret_cast<HANDLE>(real_handle);
 
 	SetThreadPriority(handle, priority);
 


### PR DESCRIPTION
MSVC compiler complains about 'warning C4312: "reinterpret_cast": conversion from "unsigned long" to "HANDLE" of greater size'. Seems like a real error, if real_handle is too small to hold the full "HANDLE" value, returned by _beginthreadex.

This is strangely just fixed in master, not B3_0_Release. Maybe the real value is just 32bit...
The included commit is just a cherry-pick of the master fix.

There is a LibreOffice gerrit merge pending as: https://gerrit.libreoffice.org/c/core/+/105924

For your convenience I have copied the last comment:

> Patch Set 2:
> 
> > Patch Set 2:
> > 
> > I don't know any specific data that could suggest that thread handles be 32-bit on _WIN64. I do know that there are some special processing of handles *when* you use WinAPI to create handles *to allow inter-process passing* - then it's actually 32-bit, to allow 32-bit processes access the handle object created by 64-bit process. But this is not the case, and I believe that this is a real upstream bug.
> 
> Hmm - since we use threads not processes here, no such rule should apply. I don't think you can run a thread with a different "bitness" in the same process. While the next handle user, SetThreadPriority, may silently fail, but would be no major problem, the next line is ResumeThread(handle). Failing that would probably be a real bug... That code is from 2008. Nobody uses Firebird with Threads?!#
> 
> Anyway, I think the patch can't be wrong, so better be safe then sorry.

So am I / we missing something, or is this a real bug worth fixing in 3.0?