### PR TITLE
Fix "unused parameter" warning

### DIFF
--- a/src/include/firebird/Interface.h
+++ b/src/include/firebird/Interface.h
@@ -305,7 +305,7 @@ namespace Firebird
 		}
 
 	public:
-		static void checkException(CheckStatusWrapper* status)
+		static void checkException(CheckStatusWrapper* /* status */)
 		{
 		}
 	};


### PR DESCRIPTION
For project that are compiled with "-Werror".