### PR TITLE
extern/cloop: Missing dependency of $(BIN_DIR)/cloop on $(BIN_DIR)

### DIFF
--- a/extern/cloop/Makefile
+++ b/extern/cloop/Makefile
@@ -90,6 +90,7 @@ $(BIN_DIR)/cloop: \
 	$(OBJ_DIR)/cloop/Lexer.o \
 	$(OBJ_DIR)/cloop/Parser.o \
 	$(OBJ_DIR)/cloop/Main.o \
+	| $(BIN_DIR)
 
 	$(LD) $^ -o $@ $(LIBS)
 


### PR DESCRIPTION
When building Firebird 3.0.7 as part of LibreOffice, I saw it fail once (at
<https://ci.libreoffice.org/job/gerrit_linux_clang_dbgutil/74624/>) with

[...]
> config.status: creating gen/Makefile.extern.editline
> config.status: creating src/include/gen/autoconfig.auto
> config.status: executing libtool commands
>
>
> The Firebird3 package has been configured with the following options:
>
>                     Raw devices : enabled
>                    Service name : gds_db
>                    Service port : 3050
>                    GPRE modules : c_cxx.cpp
>
>                     Install Dir : /usr/local/firebird
>
> mkpar.c:182:2: warning: add explicit braces to avoid dangling else [-Wdangling-else]
>         else
>         ^
> 1 warning generated.
> main.o: In function `create_file_names':
> main.c:(.text+0x976): warning: the use of `mktemp' is dangerous, better use `mkstemp'
> /usr/bin/ld: cannot open output file /home/tdf/lode/jenkins/workspace/lo_gerrit/Config/linux_clang_dbgutil_64/workdir/UnpackedTarball/firebird/gen/Debug/cloop/release/bin/cloop: No such file or directory
> clang-5.0: error: linker command failed with exit code 1 (use -v to see invocation)
> Makefile:84: recipe for target '/home/tdf/lode/jenkins/workspace/lo_gerrit/Config/linux_clang_dbgutil_64/workdir/UnpackedTarball/firebird/gen/Debug/cloop/release/bin/cloop' failed
> make[6]: *** [/home/tdf/lode/jenkins/workspace/lo_gerrit/Config/linux_clang_dbgutil_64/workdir/UnpackedTarball/firebird/gen/Debug/cloop/release/bin/cloop] Error 1
> make[6]: Target 'all' not remade because of errors.
> Makefile:130: recipe for target 'extern' failed
> make[5]: *** [extern] Error 2
> Makefile:181: recipe for target 'master_process' failed
> make[4]: *** [master_process] Error 2
> Makefile:72: recipe for target 'Debug' failed
> make[3]: *** [Debug] Error 2
> Makefile:6: recipe for target 'Debug' failed
> make[2]: *** [Debug] Error 2
> /home/tdf/lode/jenkins/workspace/lo_gerrit/Config/linux_clang_dbgutil_64/external/firebird/ExternalProject_firebird.mk:29: recipe for target '/home/tdf/lode/jenkins/workspace/lo_gerrit/Config/linux_clang_dbgutil_64/workdir/ExternalProject/firebird/build' failed
> make[1]: *** [/home/tdf/lode/jenkins/workspace/lo_gerrit/Config/linux_clang_dbgutil_64/workdir/ExternalProject/firebird/build] Error 1
[...]