### PR TITLE
Compile an external trigger before executing if it was deleted

### DIFF
--- a/src/jrd/ExtEngineManager.cpp
+++ b/src/jrd/ExtEngineManager.cpp
@@ -1532,7 +1532,7 @@ void ExtEngineManager::makeProcedure(thread_db* tdbb, CompilerScratch* csb, jrd_
 
 void ExtEngineManager::makeTrigger(thread_db* tdbb, CompilerScratch* csb, Jrd::Trigger* trg,
 	const MetaName& engine, const string& entryPoint, const string& body,
-	unsigned type)
+	unsigned type, bool makeNode)
 {
 	string entryPointTrimmed = entryPoint;
 	entryPointTrimmed.trim();
@@ -1610,14 +1610,17 @@ void ExtEngineManager::makeTrigger(thread_db* tdbb, CompilerScratch* csb, Jrd::T
 		trg->extTrigger = FB_NEW_POOL(getPool()) Trigger(tdbb, pool, csb, this, attInfo->engine,
 			metadata.release(), externalTrigger, trg);
 
-		CompoundStmtNode* mainNode = FB_NEW_POOL(getPool()) CompoundStmtNode(getPool());
-		mainNode->statements.append(trg->extTrigger->computedStatements);
+		if (makeNode)
+		{
+			CompoundStmtNode* mainNode = FB_NEW_POOL(getPool()) CompoundStmtNode(getPool());
+			mainNode->statements.append(trg->extTrigger->computedStatements);
 
-		ExtTriggerNode* extTriggerNode = FB_NEW_POOL(getPool()) ExtTriggerNode(getPool(),
-			trg->extTrigger);
-		mainNode->statements.add(extTriggerNode);
+			ExtTriggerNode* extTriggerNode = FB_NEW_POOL(getPool()) ExtTriggerNode(getPool(),
+				trg->extTrigger);
+			mainNode->statements.add(extTriggerNode);
 
-		PAR_preparsed_node(tdbb, trg->relation, mainNode, NULL, &csb, &trg->statement, true, 0);
+			PAR_preparsed_node(tdbb, trg->relation, mainNode, NULL, &csb, &trg->statement, true, 0);
+		}
 	}
 	catch (...)
 	{

--- a/src/jrd/ExtEngineManager.h
+++ b/src/jrd/ExtEngineManager.h
@@ -321,7 +321,7 @@ public:
 		const Firebird::string& body);
 	void makeTrigger(thread_db* tdbb, CompilerScratch* csb, Jrd::Trigger* trg,
 		const MetaName& engine, const Firebird::string& entryPoint,
-		const Firebird::string& body, unsigned type);
+                const Firebird::string& body, unsigned type, bool makeNode);
 
 private:
 	Firebird::IExternalEngine* getEngine(thread_db* tdbb,


### PR DESCRIPTION
Additional fix for "Commit ffb9f220 by Dmitry Yemanov, 2020-08-09 13:58 This should fix CORE-6382: Triggers accessing a table prevent concurrent DDL command from dropping that table".

External trigger is deleted after a commit without deleting `ExtTriggerNode` that is still referencing it. Executing the external trigger again causes the server to crash. Can be reproduced using the `Triggers.cpp` example from firebird/examples/udr/:

./isql -user SYSDBA -password masterkey 127.0.0.1:/tmp/main.fdb
Database: 127.0.0.1:/tmp/main.fdb, User: SYSDBA
SQL> insert into persons(id, name, address, info) values(12, 'Person 12', 'address', 'info');
SQL> commit;
SQL> insert into persons(id, name, address, info) values(13, 'Person 13', 'address', 'info');
Statement failed, SQLSTATE = 08006
Error reading data from the connection.

`Assertion (index < count) failure: /home/vasiliy/dev/github/firebird/src/jrd/../jrd/../common/classes/array.h 139`

Stack:

1   Jrd::ExtEngineManager::Trigger::execute           ExtEngineManager.cpp 942  0x7ffff5214aac 
2   (anonymous namespace)::ExtTriggerNode::execute    ExtEngineManager.cpp 457  0x7ffff5212dda 
3   EXE_looper                                        exe.cpp              1357 0x7ffff5372c4b 
4   looper_seh                                        exe.cpp              1465 0x7ffff53730cd 
5   execute_looper                                    exe.cpp              1062 0x7ffff53718ff 
6   EXE_start                                         exe.cpp              925  0x7ffff5371390 
7   EXE_execute_triggers                              exe.cpp              1203 0x7ffff53720dd 
8   Jrd::StoreNode::store                             StmtNodes.cpp        7568 0x7ffff559ba7d 
9   Jrd::StoreNode::execute                           StmtNodes.cpp        7500 0x7ffff559b6dc 
10  EXE_looper                                        exe.cpp              1357 0x7ffff5372c4b 
11  looper_seh                                        exe.cpp              1465 0x7ffff53730cd 
12  execute_looper                                    exe.cpp              1062 0x7ffff53718ff 
13  EXE_start                                         exe.cpp              925  0x7ffff5371390 
14  JRD_start                                         jrd.cpp              8947 0x7ffff53c8883 
15  Jrd::DsqlDmlRequest::doExecute                    dsql.cpp             707  0x7ffff55cb07f 
16  Jrd::DsqlDmlRequest::execute                      dsql.cpp             860  0x7ffff55cbb35 
17  DSQL_execute                                      dsql.cpp             178  0x7ffff55c886d 
18  Jrd::JStatement::execute                          jrd.cpp              4908 0x7ffff53baa69 