### PR TITLE
Improvement: add MON$SESSION_TIMEZONE to MON$ATTACHMENTS.

### DIFF
--- a/src/jrd/Monitoring.cpp
+++ b/src/jrd/Monitoring.cpp
@@ -961,6 +961,8 @@ void Monitoring::putAttachment(SnapshotData::DumpRecord& record, const Jrd::Atta
 	if (!attachment->att_user)
 		return;
 
+	const auto dbb = attachment->att_database;
+
 	record.reset(rel_mon_attachments);
 
 	PathName attName(attachment->att_filename);
@@ -1036,6 +1038,13 @@ void Monitoring::putAttachment(SnapshotData::DumpRecord& record, const Jrd::Atta
 	}
 	// statement timeout, milliseconds
 	record.storeInteger(f_mon_att_stmt_timeout, attachment->getStatementTimeout());
+
+	if (ENCODE_ODS(dbb->dbb_ods_version, dbb->dbb_minor_version) >= ODS_13_1)
+	{
+		char timeZoneBuffer[TimeZoneUtil::MAX_SIZE];
+		TimeZoneUtil::format(timeZoneBuffer, sizeof(timeZoneBuffer), attachment->att_current_timezone);
+		record.storeString(f_mon_att_session_tz, string(timeZoneBuffer));
+	}
 
 	record.write();
 

--- a/src/jrd/names.h
+++ b/src/jrd/names.h
@@ -451,3 +451,5 @@ NAME("RDB$CONFIG_VALUE", nam_cfg_value)
 NAME("RDB$CONFIG_DEFAULT", nam_cfg_default)
 NAME("RDB$CONFIG_IS_SET", nam_cfg_is_set)
 NAME("RDB$CONFIG_SOURCE", nam_cfg_source)
+
+NAME("MON$SESSION_TIMEZONE", nam_mon_session_tz)

--- a/src/jrd/ods.h
+++ b/src/jrd/ods.h
@@ -123,7 +123,8 @@ const USHORT ODS_CURRENT12		= 0;
 // Minor versions for ODS 13
 
 const USHORT ODS_CURRENT13_0	= 0;	// Firebird 4.0 features
-const USHORT ODS_CURRENT13		= 0;
+const USHORT ODS_CURRENT13_1	= 1;	// Firebird 4.1 features
+const USHORT ODS_CURRENT13		= 1;
 
 // useful ODS macros. These are currently used to flag the version of the
 // system triggers and system indices in ini.e
@@ -144,6 +145,7 @@ const USHORT ODS_11_1		= ENCODE_ODS(ODS_VERSION11, 1);
 const USHORT ODS_11_2		= ENCODE_ODS(ODS_VERSION11, 2);
 const USHORT ODS_12_0		= ENCODE_ODS(ODS_VERSION12, 0);
 const USHORT ODS_13_0		= ENCODE_ODS(ODS_VERSION13, 0);
+const USHORT ODS_13_1		= ENCODE_ODS(ODS_VERSION13, 1);
 
 const USHORT ODS_FIREBIRD_FLAG = 0x8000;
 
@@ -171,7 +173,7 @@ const USHORT ODS_RELEASED = ODS_CURRENT13_0;	// The lowest stable minor version
 const USHORT ODS_CURRENT = ODS_CURRENT13;		// The highest defined minor version
 												// number for this ODS_VERSION!
 
-const USHORT ODS_CURRENT_VERSION = ODS_13_0;	// Current ODS version in use which includes
+const USHORT ODS_CURRENT_VERSION = ODS_13_1;	// Current ODS version in use which includes
 												// both major and minor ODS versions!
 
 

--- a/src/jrd/relations.h
+++ b/src/jrd/relations.h
@@ -529,6 +529,7 @@ RELATION(nam_mon_attachments, rel_mon_attachments, ODS_11_1, rel_virtual)
 	FIELD(f_mon_att_wire_compressed, nam_wire_compressed, fld_bool, 0, ODS_13_0)
 	FIELD(f_mon_att_wire_encrypted, nam_wire_encrypted, fld_bool, 0, ODS_13_0)
 	FIELD(f_mon_att_remote_crypt, nam_wire_crypt_plugin, fld_remote_crypt, 0, ODS_13_0)
+	FIELD(f_mon_att_session_tz, nam_mon_session_tz, fld_tz_name, 0, ODS_13_1)
 END_RELATION
 
 // Relation 35 (MON$TRANSACTIONS)


### PR DESCRIPTION
Returns the attachment's current session timezone as `RDB$GET_CONTEXT('SYSTEM', 'SESSION_TIMEZONE')`.