### PR TITLE
Fix wrong result of MET_lookup_relation call when RDB$RELATION_ID is NULL

### DIFF
--- a/src/jrd/met.epp
+++ b/src/jrd/met.epp
@@ -2953,6 +2953,10 @@ jrd_rel* MET_lookup_relation(thread_db* tdbb, const MetaName& name)
 	FOR(REQUEST_HANDLE request)
 		X IN RDB$RELATIONS WITH X.RDB$RELATION_NAME EQ name.c_str()
 	{
+		// RDB$RELATION_ID can be NULL here if the relation is not committed yet
+		if (X.RDB$RELATION_ID.NULL)
+			return NULL;
+
 		relation = MET_relation(tdbb, X.RDB$RELATION_ID);
 		if (relation->rel_name.length() == 0) {
 			relation->rel_name = name;


### PR DESCRIPTION
RDB$RELATION_ID can be NULL for relations which are not committed yet. Without the fix the function uses its value (which is 0 in that case) and returns the pointer to jrd_rel of RDB$PAGES.