### PR TITLE
Fixed bug GH-6843 : Crash when UDR is used by system attachment, for ex. Garbage Collector

### DIFF
--- a/src/jrd/Attachment.h
+++ b/src/jrd/Attachment.h
@@ -385,11 +385,7 @@ public:
 
 	JAttachment* getInterface() throw();
 
-	JProvider* getProvider()
-	{
-		fb_assert(att_provider);
-		return att_provider;
-	}
+	JProvider* getProvider();
 
 private:
 	Attachment(MemoryPool* pool, Database* dbb, JProvider* provider);
@@ -459,6 +455,12 @@ inline bool Attachment::isRWGbak() const
 inline bool Attachment::isUtility() const
 {
 	return (att_utility != UTIL_NONE);
+}
+
+inline JProvider* Attachment::getProvider()
+{
+	fb_assert(att_provider || (att_flags & ATT_system));
+	return att_provider;
 }
 
 // This class holds references to all attachments it contains

--- a/src/jrd/ExtEngineManager.h
+++ b/src/jrd/ExtEngineManager.h
@@ -167,6 +167,8 @@ private:
 		void* setInfo(int code, void* value);
 
 	private:
+		void checkExternalAttachment();
+
 		Firebird::IExternalEngine* engine;
 		Attachment* internalAttachment;
 		Firebird::ITransaction* internalTransaction;

--- a/src/jrd/vio.cpp
+++ b/src/jrd/vio.cpp
@@ -5091,6 +5091,7 @@ void Database::garbage_collector(Database* dbb)
 			TRA_commit(tdbb, transaction, false);
 
 		Monitoring::cleanupAttachment(tdbb);
+		dbb->dbb_extManager.closeAttachment(tdbb, attachment);
 		attachment->releaseLocks(tdbb);
 		LCK_fini(tdbb, LCK_OWNER_attachment);
 


### PR DESCRIPTION
This PR introduces ability for External Contex to correctly work with not assigned externalAttachment\externalTransaction in case of usage within system attachment.
If UDR tries to access current connection (via externalAttachment\externalTransaction), error is raised.
Note, UDR should not do anything with system attachments, else it could break too much internals.
