### PR TITLE
fix build on big endian platforms

### DIFF
--- a/src/jrd/sort.cpp
+++ b/src/jrd/sort.cpp
@@ -713,6 +713,7 @@ void Sort::diddleKey(UCHAR* record, bool direction, bool duplicateHandling)
 	for (sort_key_def* key = m_description.begin(), *end = m_description.end(); key < end; key++)
 	{
 		UCHAR* p = record + key->getSkdOffset();
+		SORTP* lwp = (SORTP*) p;
 		USHORT n = key->getSkdLength();
 		USHORT complement = key->skd_flags & SKD_descending;
 

--- a/src/jrd/sort.h
+++ b/src/jrd/sort.h
@@ -27,6 +27,7 @@
 #include "../include/fb_blk.h"
 #include "../common/DecFloat.h"
 #include "../jrd/TempSpace.h"
+#include "../jrd/align.h"
 
 namespace Jrd {
 


### PR DESCRIPTION
The new features in Firebird 4 introduced some issues in the big endian support. These changes make the compilation pass again.