### PR TITLE
Allow keywords in locales when creating ICU collations (Fixes issue #6903)

### DIFF
--- a/src/common/unicode_util.cpp
+++ b/src/common/unicode_util.cpp
@@ -1718,7 +1718,7 @@ UnicodeUtil::ICU* UnicodeUtil::Utf16Collation::loadICU(
 					continue;
 
 				icu->ucolClose(testCollator);
-				if (U_FAILURE(status) || (status == U_USING_DEFAULT_WARNING))
+				if (status != U_ZERO_ERROR)
 					continue;
 			}
 		}

--- a/src/common/unicode_util.cpp
+++ b/src/common/unicode_util.cpp
@@ -1711,7 +1711,16 @@ UnicodeUtil::ICU* UnicodeUtil::Utf16Collation::loadICU(
 			}
 
 			if (avail < 0)
-				continue;
+			{
+				UErrorCode status = U_ZERO_ERROR;
+				UCollator* testCollator = icu->ucolOpen(locale.c_str(), &status);
+				if (!testCollator)
+					continue;
+
+				icu->ucolClose(testCollator);
+				if (U_FAILURE(status) || (status == U_USING_DEFAULT_WARNING))
+					continue;
+			}
 		}
 
 		char version[U_MAX_VERSION_STRING_LENGTH];


### PR DESCRIPTION
This fix adds a fallback check when trying to create an ICU collator and the check against locale base names has failed. With this fallback check, locales with keywords are accepted when creating a collation. In my tests, the collation worked as expected when applied to a table column.

Please let me know in case this is not the right branch against which to submit the change.