### PR TITLE
Dependencies check fixes

### DIFF
--- a/src/jrd/RecordSourceNodes.cpp
+++ b/src/jrd/RecordSourceNodes.cpp
@@ -479,7 +479,7 @@ RelationSourceNode* RelationSourceNode::parse(thread_db* tdbb, CompilerScratch* 
 				PAR_name(csb, *aliasString);
 			}
 
-			if (!(node->relation = MET_lookup_relation_id(tdbb, id, false)))
+			if (!(node->relation = MET_lookup_relation_id(tdbb, id, false, false)))
 				name.printf("id %d", id);
 
 			break;
@@ -496,7 +496,7 @@ RelationSourceNode* RelationSourceNode::parse(thread_db* tdbb, CompilerScratch* 
 				PAR_name(csb, *aliasString);
 			}
 
-			node->relation = MET_lookup_relation(tdbb, name);
+			node->relation = MET_lookup_relation(tdbb, name, false);
 			break;
 		}
 

--- a/src/jrd/dfw.epp
+++ b/src/jrd/dfw.epp
@@ -722,6 +722,7 @@ namespace
 						return false;
 
 					routine->flags &= ~Routine::FLAG_BEING_ALTERED;
+					routine->flags |= Routine::FLAG_OBSOLETE;
 
 					if (routine->existenceLock)
 						LCK_convert(tdbb, routine->existenceLock, LCK_SR, transaction->getLockWait());
@@ -872,6 +873,8 @@ namespace
 					routine = lookupById(tdbb, work->dfw_id, false, true, 0);
 					if (!routine)
 						return false;
+
+					routine->flags |= Routine::FLAG_OBSOLETE;
 
 					if (routine->existenceLock)
 						LCK_convert(tdbb, routine->existenceLock, LCK_SR, transaction->getLockWait());

--- a/src/jrd/dfw.epp
+++ b/src/jrd/dfw.epp
@@ -721,6 +721,8 @@ namespace
 					if (!routine)
 						return false;
 
+					routine->flags &= ~Routine::FLAG_BEING_ALTERED;
+
 					if (routine->existenceLock)
 						LCK_convert(tdbb, routine->existenceLock, LCK_SR, transaction->getLockWait());
 

--- a/src/jrd/met.epp
+++ b/src/jrd/met.epp
@@ -2834,7 +2834,7 @@ jrd_prc* MET_lookup_procedure_id(thread_db* tdbb, USHORT id,
 }
 
 
-jrd_rel* MET_lookup_relation(thread_db* tdbb, const MetaName& name)
+jrd_rel* MET_lookup_relation(thread_db* tdbb, const MetaName& name, bool return_deleting)
 {
 /**************************************
  *
@@ -2863,7 +2863,12 @@ jrd_rel* MET_lookup_relation(thread_db* tdbb, const MetaName& name)
 		if (relation)
 		{
 			if (relation->rel_flags & REL_deleting)
+			{
+				if (!return_deleting)
+					continue;
+
 				CheckoutLockGuard guard(tdbb, relation->rel_drop_mutex, FB_FUNCTION);
+			}
 
 			if (!(relation->rel_flags & REL_deleted))
 			{
@@ -2931,7 +2936,7 @@ jrd_rel* MET_lookup_relation(thread_db* tdbb, const MetaName& name)
 }
 
 
-jrd_rel* MET_lookup_relation_id(thread_db* tdbb, SLONG id, bool return_deleted)
+jrd_rel* MET_lookup_relation_id(thread_db* tdbb, SLONG id, bool return_deleted, bool return_deleting)
 {
 /**************************************
  *
@@ -2960,7 +2965,12 @@ jrd_rel* MET_lookup_relation_id(thread_db* tdbb, SLONG id, bool return_deleted)
 	if (vector && (id < (SLONG) vector->count()) && (relation = (*vector)[id]))
 	{
 		if (relation->rel_flags & REL_deleting)
+		{
+			if (!return_deleting)
+				return NULL;
+
 			CheckoutLockGuard guard(tdbb, relation->rel_drop_mutex, FB_FUNCTION);
+		}
 
 		if (relation->rel_flags & REL_deleted)
 			return return_deleted ? relation : NULL;

--- a/src/jrd/met_proto.h
+++ b/src/jrd/met_proto.h
@@ -111,8 +111,8 @@ SLONG		MET_lookup_index_name(Jrd::thread_db*, const Firebird::MetaName&, SLONG*,
 bool		MET_lookup_partner(Jrd::thread_db*, Jrd::jrd_rel*, struct Jrd::index_desc*, const TEXT*);
 Jrd::jrd_prc*	MET_lookup_procedure(Jrd::thread_db*, const Firebird::QualifiedName&, bool);
 Jrd::jrd_prc*	MET_lookup_procedure_id(Jrd::thread_db*, USHORT, bool, bool, USHORT);
-Jrd::jrd_rel*	MET_lookup_relation(Jrd::thread_db*, const Firebird::MetaName&);
-Jrd::jrd_rel*	MET_lookup_relation_id(Jrd::thread_db*, SLONG, bool);
+Jrd::jrd_rel*	MET_lookup_relation(Jrd::thread_db*, const Firebird::MetaName&, bool return_deleting = true);
+Jrd::jrd_rel*	MET_lookup_relation_id(Jrd::thread_db*, SLONG, bool, bool return_deleting = true);
 Jrd::DmlNode*	MET_parse_blob(Jrd::thread_db*, Jrd::jrd_rel*, Jrd::bid*, Jrd::CompilerScratch**,
 							   Jrd::JrdStatement**, bool, bool);
 void		MET_parse_sys_trigger(Jrd::thread_db*, Jrd::jrd_rel*);


### PR DESCRIPTION
1. The first commit fixes this script:

set autoddl off;

create table test (id numeric);
commit;

create view v_test (id) as select id from test;
commit;

drop view v_test;
create or alter view v_test (id) as select id from test;
drop table test;
commit;


The last commit fails and the transaction should be rolled back but the test table is already broken. It happens because the phase 4 of delete_relation DFW cannot be rolled back. It's already completed by the moment of the exception. With the fix the exception will occur at the phase 3.

2. The second commit fixes this:

set autoddl off;

create table test (id numeric);
commit;

create table test1 (id numeric);
commit;

set term ^;

create procedure NEW_PROCEDURE
returns (
    OUT integer)
as
begin
  select first 1 id from test into out;
  suspend;
end^
commit^

alter procedure NEW_PROCEDURE
returns (
    OUT integer)
as
begin
  select first 1 id from test1 into out;
  suspend;
end^

drop table test1^
commit^

set term ;^

rollback;

drop table test1;
commit;

drop procedure NEW_PROCEDURE;
commit;

drop table test;
commit;


The last commit should work without any errors but it fails because the test table still depends on NEW_PROCEDURE even though the procedure is deleted. The test1 table is also broken here (like in the first script).

I would also suggest to add a commit where the phase 4 of delete_relation DFW is moved to the phase 6 (modifyRoutine DFW has the phase 5, and exceptions may occur there as well). Or maybe it should be moved to the post commit stage but it seems wrong.