### PR TITLE
On error, SetFilePointer returns INVALID_SET_FILE_POINTER, not 0

### DIFF
--- a/src/common/isc_sync.cpp
+++ b/src/common/isc_sync.cpp
@@ -1640,7 +1640,7 @@ SharedMemoryBase::SharedMemoryBase(const TEXT* filename, ULONG length, IpcObject
 	}
 	else
 	{
-		if ((err != ERROR_ALREADY_EXISTS) || SetFilePointer(file_handle, 0, NULL, FILE_END) == 0)
+		if ((err != ERROR_ALREADY_EXISTS) || SetFilePointer(file_handle, 0, NULL, FILE_END) == INVALID_SET_FILE_POINTER)
 		{
 			CloseHandle(event_handle);
 			CloseHandle(file_handle);


### PR DESCRIPTION
Commit 0c73f2caef34af50f3069815c0329fbb9e105100 is described to
properly handle failures to map shared memory. It introduced this
check, obviously treating zero returned from SetFilePointer as an
error condition.

But according to [1], the error code is actually
INVALID_SET_FILE_POINTER; and it had been already checked in the
code also touched by the said commit.

This looks to be a problem I see locally testing an embedded database
in LibreOffice. The code creates a new 'fb12_trace.1' file, then this
check gives 0 (obviously, because the file is yet empty), and loops
indefinitely.

The change fixes the infinite loop.

[1] https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfilepointer