### PR TITLE
Fix #6932: GTT's pages are not released while dropping it

### DIFF
--- a/src/jrd/dfw.epp
+++ b/src/jrd/dfw.epp
@@ -4915,6 +4915,13 @@ static bool delete_relation(thread_db* tdbb, SSHORT phase, DeferredWork* work, j
 		    EXT_fini(relation, false);
 		}
 
+		if (relation->isTemporary())
+		{
+			// release pages, allocated for current GTT instance
+			AutoSetRestoreFlag<ULONG> tmpSpace(&tdbb->tdbb_flags, TDBB_use_db_page_space, false);
+			relation->delPages(tdbb);
+		}
+
 		RelationPages* const relPages = relation->getBasePages();
 		if (relPages->rel_index_root) {
 			IDX_delete_indices(tdbb, relation, relPages);


### PR DESCRIPTION
It prevents a temp file from growing in cases when several GTTs are created, filled with data, and dropped.