### PR TITLE
extern/cloop: Missing dependencies of compilations on output directories

### DIFF
--- a/extern/cloop/Makefile
+++ b/extern/cloop/Makefile
@@ -54,10 +54,10 @@ vpath %.c $(SRC_DIRS)
 vpath %.cpp $(SRC_DIRS)
 
 define compile
-$1/%.o: %.c
+$1/%.o: %.c | $1
 	$(CC) -c $$(C_FLAGS) $$< -o $$@
 
-$1/%.o: %.cpp
+$1/%.o: %.cpp | $1
 	$(CXX) -c $$(CXX_FLAGS) $$< -o $$@
 endef
 


### PR DESCRIPTION
When building Firebird 3.0.7 as part of LibreOffice, we noticed occasional build
failures like <https://ci.libreoffice.org/job/gerrit_linux_clang_dbgutil/96392/>

> error: unable to open output file '/home/tdf/lode/jenkins/workspace/lo_gerrit/Config/linux_clang_dbgutil_64/workdir/UnpackedTarball/firebird/temp/Debug/cloop/release/tests/test1/CTest.o': 'No such file or directory'
> 1 error generated.
> Makefile:72: recipe for target '/home/tdf/lode/jenkins/workspace/lo_gerrit/Config/linux_clang_dbgutil_64/workdir/UnpackedTarball/firebird/temp/Debug/cloop/release/tests/test1/CTest.o' failed

and while target "all" depends on target "mkdirs" (which would create all those
directories) in extern/cloop/Makefile, there is no order among the dependencies
of "all", so no guarantee that the directories are already created when the
compilation recipes are executed.