### PR TITLE
add AF_INET_* support for FreeBSD

### DIFF
--- a/src/remote/SockAddr.h
+++ b/src/remote/SockAddr.h
@@ -106,10 +106,12 @@ public:
 
 #define AF_INET6_POSIX		10
 #define AF_INET6_WINDOWS	23
+#define AF_INET6_FREEBSD	28
 #define AF_INET6_DARWIN		30
 
 #if AF_INET6 == AF_INET6_POSIX
 #elif AF_INET6 == AF_INET6_WINDOWS
+#elif AF_INET6 == AF_INET6_FREEBSD
 #elif AF_INET6 == AF_INET6_DARWIN
 #else
 #error Unknown value of AF_INET6 !
@@ -125,6 +127,7 @@ inline void SockAddr::checkAndFixFamily()
 
 	case AF_INET6_POSIX:
 	case AF_INET6_WINDOWS:
+	case AF_INET6_FREEBSD:
 	case AF_INET6_DARWIN:
 		data.sock.sa_family = AF_INET6;
 		fb_assert(len == sizeof(sockaddr_in6));


### PR DESCRIPTION
While working on Debian packages for firebird 4, I encountered a patch that really should have been included in firebird 3. It adds support for FreeBSD in `SockAddr.h`.

The build is tested on Debian infrastructure as part of firebird 3 package builds on the kFreeBSD architecture and should be safe.

Applies cleanly to `v4.0-release` too.