### PR TITLE
rebuild codes with configure --enable-regen-codes (new option)

### DIFF
--- a/builds/posix/Makefile.in
+++ b/builds/posix/Makefile.in
@@ -286,7 +286,7 @@ master_process:
 # even if gpre itself was not rebuilt
 	-$(RM) $(GPRE_CURRENT)
 	(cd $(BIN); $(LN) $(notdir $(GPRE)) $(notdir $(GPRE_CURRENT)))
-ifeq ($(IsDeveloper), Y)
+ifeq ($(RegenCodes),Y)
 # In developer mode we must regenerate various files in include/gen
 	$(MAKE) codes
 endif

--- a/builds/posix/make.defaults
+++ b/builds/posix/make.defaults
@@ -108,6 +108,11 @@ PLUSPLUS_FLAGS:= -fno-rtti -std=c++17
 # If this is defined then we use special rules useful for developers only
 IsDeveloper = @DEVEL_FLG@
 
+RegenCodes = @REGEN_CODES_FLG@
+ifeq ($(IsDeveloper),Y)
+RegenCodes := Y
+endif
+
 CpuType=@CPU_TYPE@
 PLATFORM=@PLATFORM@
 SFIO_EXAMPLES=@SFIO_EXAMPLES@

--- a/configure.ac
+++ b/configure.ac
@@ -529,6 +529,16 @@ AC_ARG_ENABLE(developer,
    esac])
 AC_SUBST(DEVEL_FLG)
 
+REGEN_CODES_FLG=$DEVEL_FLG
+AC_ARG_ENABLE(regen-codes,
+  [  --enable-regen-codes    re-generate codes (default same as --enable developer)],
+  [case "$enableval" in
+     yes) REGEN_CODES_FLG=Y;;
+     no)  REGEN_CODES_FLG=N;;
+     *)   AC_MSG_ERROR(bad value '${enableval}' for --enable-regen-codes);;
+   esac])
+AC_SUBST(REGEN_CODES_FLG)
+
 CROSS=
 IS_CROSS=N
 AC_ARG_WITH(cross-build,


### PR DESCRIPTION
This started as a Debian-specific patch to satisfy the need that all generated files are re-made during package build. Rebuilding makes the resulting files reproducible and guarantees that they are produced from sources and do not contain stray modifications.

Perhaps other distributions would find it useful, therefore including it in the upstream source seems the right thing to do.