### PR TITLE
drop StandartError=syslog from firebird.service

### DIFF
--- a/builds/install/arch-specific/linux/firebird.service.in
+++ b/builds/install/arch-specific/linux/firebird.service.in
@@ -7,7 +7,6 @@ User=firebird
 Group=firebird
 Type=forking
 ExecStart=@FB_SBINDIR@/fbguard -daemon -forever
-StandardError=syslog
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
`syslog` is no longer documented in recent systemd (checked version 247,
systemd.exec(5)).

The default is to log to the journal, which is the sourced by syslog
(if present) so the setting would really be a noop anyway.