### PR TITLE
Improve build of external projects using same tools and flags specified by user.

### DIFF
--- a/builds/posix/Makefile.in
+++ b/builds/posix/Makefile.in
@@ -193,7 +193,7 @@ endif
 endif
 
 ifeq ($(TOMCRYPT_BUILD_FLG),Y)
-	CC="$(CC)" CFLAGS="$(CFLAGS)" $(TOM2TOM_FLAGS)" $(MAKE) -C $(ROOT)/extern/libtomcrypt -f makefile.shared GCC=$(GCC)
+	CC="$(CC)" CFLAGS="$(CFLAGS) $(TOM2TOM_FLAGS)" $(MAKE) -C $(ROOT)/extern/libtomcrypt -f makefile.shared GCC=$(GCC)
 
 ifeq ($(PLATFORM),DARWIN)
 	install_name_tool -id "@rpath/lib/libtomcrypt.dylib" $(TOMCRYPT)/.libs/libtomcrypt.1.dylib

--- a/builds/posix/Makefile.in
+++ b/builds/posix/Makefile.in
@@ -169,19 +169,19 @@ $(GEN_ROOT)/Make.Version : $(SRC_ROOT)/misc/writeBuildNum.sh
 #
 
 external:
-	$(MAKE) -C $(ROOT)/extern/btyacc
-	$(MAKE) -C $(ROOT)/extern/cloop TARGET=release WITH_FPC=0 BUILD_DIR=$(TMP_ROOT)/cloop OUT_DIR=$(GEN_ROOT)/$(TARGET)/cloop
+	CC="$(CC)" CFLAGS="$(CFLAGS)" $(MAKE) -C $(ROOT)/extern/btyacc
+	CXX="$(CXX)" CXXFLAGS="$(CXXFLAGS)" $(MAKE) -C $(ROOT)/extern/cloop TARGET=release WITH_FPC=0 BUILD_DIR=$(TMP_ROOT)/cloop OUT_DIR=$(GEN_ROOT)/$(TARGET)/cloop
 
-	$(MAKE) -C $(ROOT)/extern/decNumber
+	CC="$(CC)" CFLAGS="$(CFLAGS)" $(MAKE) -C $(ROOT)/extern/decNumber
 	ln -sf $(ROOT)/extern/decNumber/libdecFloat.a $(LIB)
 
 ifeq ($(RE2_BUILD_FLG),Y)
-	CXXFLAGS="-O3 -g -fPIC" $(MAKE) -C $(ROOT)/extern/re2
+	CXX="$(CXX)" CXXFLAGS="$(CXXFLAGS) -O3 -g -fPIC" $(MAKE) -C $(ROOT)/extern/re2
 	ln -sf $(ROOT)/extern/re2/obj/libre2.a $(LIB)
 endif
 
 ifeq ($(TOMMATH_BUILD_FLG),Y)
-	CFLAGS="$(CFLAGS)" $(MAKE) -C $(ROOT)/extern/libtommath -f makefile.shared GCC=$(GCC)
+	CC="$(CC)" CFLAGS="$(CFLAGS)" $(MAKE) -C $(ROOT)/extern/libtommath -f makefile.shared GCC=$(GCC)
 
 ifeq ($(PLATFORM),DARWIN)
 	install_name_tool -id "@rpath/lib/libtommath.dylib" $(TOMMATH)/.libs/libtommath.0.dylib
@@ -193,7 +193,7 @@ endif
 endif
 
 ifeq ($(TOMCRYPT_BUILD_FLG),Y)
-	CFLAGS="$(CFLAGS) $(TOM2TOM_FLAGS)" $(MAKE) -C $(ROOT)/extern/libtomcrypt -f makefile.shared GCC=$(GCC)
+	CC="$(CC)" CFLAGS="$(CFLAGS)" $(TOM2TOM_FLAGS)" $(MAKE) -C $(ROOT)/extern/libtomcrypt -f makefile.shared GCC=$(GCC)
 
 ifeq ($(PLATFORM),DARWIN)
 	install_name_tool -id "@rpath/lib/libtomcrypt.dylib" $(TOMCRYPT)/.libs/libtomcrypt.1.dylib
@@ -206,7 +206,7 @@ endif
 
 ifeq ($(STD_EDITLINE),false)
 ifeq ($(EDITLINE_FLG),Y)
-	$(MAKE) -f $(GEN_ROOT)/Makefile.extern.editline
+	CC="$(CC)" CFLAGS="$(CFLAGS)" $(MAKE) -f $(GEN_ROOT)/Makefile.extern.editline
 endif
 endif
 
@@ -329,7 +329,7 @@ cross2:
 	$(MAKE) tommath
 	$(MAKE) LTCSOURCE=-DLTC_SOURCE tomcrypt
 	$(MAKE) re2
-	$(MAKE) -C $(ROOT)/extern/decNumber
+	CC="$(CC)" CFLAGS="$(CFLAGS)" $(MAKE) -C $(ROOT)/extern/decNumber
 	ln -sf $(ROOT)/extern/decNumber/libdecFloat$(CROSS).a $(LIB)
 	$(MAKE) yvalve
 	$(MAKE) engine

--- a/builds/posix/Makefile.in.examples
+++ b/builds/posix/Makefile.in.examples
@@ -35,7 +35,7 @@ ROOT=$(shell cd ../..; pwd)
 	$(GPRE_CURRENT) $(GPRE_FLAGS) $< $@
 
 %.o: %.cpp
-	$(CC) $(WCXXFLAGS) -c $(firstword $<) -o $@
+	$(CXX) $(WCXXFLAGS) -c $(firstword $<) -o $@
 
 
 # Add the install include directory to the search path since the
@@ -100,7 +100,7 @@ all: examples
 examples:	$(FINAL_EMPDB) $(EXAMPLES_FB)/README $(EXTAUTH_PLUGIN)
 
 $(EXTAUTH_PLUGIN):	$(EXAMPLES_FB)/extauth/Makefile
-	$(MAKE) -C $(EXAMPLES_FB)/extauth OUT=$(EXAMPLES_FB)/prebuilt INTERMED=$(TMP_ROOT)/examples/extauth
+	CXX="$(CXX)" CXXFLAGS="$(CXXFLAGS)" $(MAKE) -C $(EXAMPLES_FB)/extauth OUT=$(EXAMPLES_FB)/prebuilt INTERMED=$(TMP_ROOT)/examples/extauth
 
 $(EXAMPLES_FB)/extauth/Makefile:
 ifeq ($(TOMCRYPT_BUILD_FLG),Y)

--- a/builds/posix/make.rules
+++ b/builds/posix/make.rules
@@ -106,7 +106,7 @@ $(OBJ)/%.cpp: $(SRC_ROOT)/%.epp
 	$(CC) $(WCFLAGS) -c $(firstword $<) -o $@
 
 %.o: %.cc
-	$(CC) $(WCFLAGS) -c $(firstword $<) -o $@
+	$(CXX) $(WCFLAGS) -c $(firstword $<) -o $@
 
 $(OBJ)/%.o: $(SRC_ROOT)/%.c
 	$(CC) $(WCFLAGS) -c $(firstword $<) -o $@
@@ -125,7 +125,7 @@ $(OBJ)/%.o: $(SRC_ROOT)/%.cpp
 	@sed $(INLINE_EDIT_SED) -e "1,2s/:/: \$$(wildcard/" -e "\$$s/\(.*\)/\\1)/" $(patsubst %.o,%.d,$@)
 
 $(OBJ)/%.o: $(ROOT)/%.cpp
-	$(CC) $(WCFLAGS) -c $(firstword $<) -o $@
+	$(CXX) $(WCFLAGS) -c $(firstword $<) -o $@
 	@sed $(INLINE_EDIT_SED) -e "1,2s/:/: \$$(wildcard/" -e "\$$s/\(.*\)/\\1)/" $(patsubst %.o,%.d,$@)
 
 .SUFFIXES: .epp .e


### PR DESCRIPTION
When using different tools in configure (CC= CXX=) these tools were not passed
to external projects, making them using different tools.