### PR TITLE
small typo in error message (unsuccesful → unsuccessful)

### DIFF
--- a/src/remote/client/interface.cpp
+++ b/src/remote/client/interface.cpp
@@ -2029,7 +2029,7 @@ void Attachment::freeClientData(CheckStatusWrapper* status, bool force)
 
 		if (status->getState() & Firebird::IStatus::STATE_ERRORS)
 		{
-			iscLogStatus("REMOTE INTERFACE/gds__detach: Unsuccesful detach from "
+			iscLogStatus("REMOTE INTERFACE/gds__detach: Unsuccessful detach from "
 					"database.\n\tUncommitted work may have been lost.", status);
 			reset(status);
 		}


### PR DESCRIPTION
There were more in the original patch, the #6958 merge left them out.