### PR TITLE
Introduce the external memory pool

### DIFF
--- a/builds/posix/prefix.hpux_aCC
+++ b/builds/posix/prefix.hpux_aCC
@@ -21,7 +21,7 @@
 # Notes:
 
 # Firebird requires the HP-UX Atomic APIs ("AtomicAPI" bundle), released as an
-# optional Software Pack (SPK) for HP-UX 11i v2 or v3. 
+# optional Software Pack (SPK) for HP-UX 11i v2 or v3.
 
 # Before attempting the HPUX build, you must export necessary
 # CFLAGS and CXXFLAGS to be picked up by the configure process and
@@ -60,15 +60,12 @@ COMMON_FLAGS= -DHP11 -DHPUX -D_XOPEN_SOURCE_EXTENDED -D_HP_ATOMIC_INLINE \
 
 # Flags specific to production or debug build...
 # -z, disallow dereferencing of null pointers at runtime
-# -DLIBC_CALLS_NEW, Firebird macro, used when C++ runtime can call
-#   redefined by us operator new before initialization of global variables.
-#   Required on IA-64, but evidently only by debug build!?
 
 ifeq ($(shell uname -m),ia64)
 # ...for IA-64
 PROD_FLAGS= +O2 +Onolimit +Ofltacc=strict +Ofenvaccess \
 	$(COMMON_FLAGS)
-DEV_FLAGS= -g -z -DLIBC_CALLS_NEW \
+DEV_FLAGS= -g -z \
 	$(COMMON_FLAGS)
 else
 # ...for PA-RISC

--- a/src/auth/SecureRemotePassword/Message.h
+++ b/src/auth/SecureRemotePassword/Message.h
@@ -234,7 +234,7 @@ private:
 	{
 		unsigned l = aMeta->getMessageLength(&statusWrapper);
 		check(&statusWrapper);
-		buffer = new unsigned char[l];
+		buffer = FB_NEW unsigned char[l];
 	}
 
 public:
@@ -336,7 +336,7 @@ public:
 
 		if (!charBuffer)
 		{
-			charBuffer = new char[size + 1];
+			charBuffer = FB_NEW char[size + 1];
 		}
 		getStrValue(charBuffer);
 		return charBuffer;

--- a/src/common/classes/init.h
+++ b/src/common/classes/init.h
@@ -304,12 +304,12 @@ template <typename T>
 class StaticInstanceAllocator
 {
 private:
-	char buf[sizeof(T) + FB_ALIGNMENT];
+	alignas(alignof(T)) char buf[sizeof(T)];
 
 public:
 	T* create()
 	{
-		return new((void*) FB_ALIGN(buf, FB_ALIGNMENT)) T();
+		return new(buf) T();
 	}
 
 	static void destroy(T*)

--- a/src/common/classes/locks.h
+++ b/src/common/classes/locks.h
@@ -331,6 +331,13 @@ public:
 		lock->enter(aReason);
 	}
 
+	RaiiLockGuard(M* aLock, const char* aReason)
+		: lock(aLock)
+	{
+		if (lock)
+			lock->enter(aReason);
+	}
+
 	~RaiiLockGuard()
 	{
 		try

--- a/src/common/os/os_utils.h
+++ b/src/common/os/os_utils.h
@@ -81,6 +81,8 @@ namespace os_utils
 
 	bool isIPv6supported();
 
+	bool getCurrentModulePath(char* buffer, size_t bufferSize);
+
 	// force descriptor to have O_CLOEXEC set
 	int open(const char* pathname, int flags, mode_t mode = DEFAULT_OPEN_MODE);
 	void setCloseOnExec(int fd);	// posix only

--- a/src/common/os/posix/os_utils.cpp
+++ b/src/common/os/posix/os_utils.cpp
@@ -43,6 +43,14 @@
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
+
+#ifdef HAVE_DLADDR
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <dlfcn.h>
+#endif	// HAVE_DLADDR
+
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #endif
@@ -333,6 +341,21 @@ bool isIPv6supported()
 #else
 	return true;
 #endif
+}
+
+bool getCurrentModulePath(char* buffer, size_t bufferSize)
+{
+#ifdef HAVE_DLADDR
+	Dl_info path;
+
+	if (dladdr((void*) &getCurrentModulePath, &path))
+	{
+		strncpy(buffer, path.dli_fname, bufferSize);
+		return true;
+	}
+#endif
+
+	return false;
 }
 
 // setting flag is not absolutely required, therefore ignore errors here

--- a/src/common/os/win32/os_utils.cpp
+++ b/src/common/os/win32/os_utils.cpp
@@ -380,6 +380,23 @@ bool isIPv6supported()
 	return false;
 }
 
+bool getCurrentModulePath(char* buffer, size_t bufferSize)
+{
+	HMODULE hmod = 0;
+
+	GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+		(LPCTSTR) &getCurrentModulePath,
+		&hmod);
+
+	if (hmod)
+	{
+		GetModuleFileName(hmod, buffer, bufferSize);
+		return true;
+	}
+
+	return false;
+}
+
 int open(const char* pathname, int flags, mode_t mode)
 {
 	return ::_open(pathname, flags, mode);

--- a/src/dsql/DdlNodes.epp
+++ b/src/dsql/DdlNodes.epp
@@ -11519,7 +11519,7 @@ void GrantRevokeNode::grantRevoke(thread_db* tdbb, jrd_tra* transaction, const G
 	const MetaName objName(object ? object->second : "");
 	bool crdb = false;
 
-	AutoPtr<char, ArrayDelete> privileges(new char[MAX(strlen(ALL_PRIVILEGES), strlen(privs ? privs : "")) + 1]);
+	AutoPtr<char, ArrayDelete> privileges(FB_NEW char[MAX(strlen(ALL_PRIVILEGES), strlen(privs ? privs : "")) + 1]);
 	strcpy(privileges, privs ? privs : "");
 
 	if (strcmp(privileges, "A") == 0)

--- a/src/yvalve/why.cpp
+++ b/src/yvalve/why.cpp
@@ -137,12 +137,8 @@ private:
 
 	// Fool-proof requested by Alex
 	// Private memory operators to be sure that this class is used in heap only with launcher
-#ifdef DEBUG_GDS_ALLOC
-	void* operator new (size_t s, const char* file, int line) { return MemoryPool::globalAlloc(s, file, line); }
-	void operator delete (void* mem, const char* file, int line) { MemoryPool::globalFree(mem); }
-#else
-	void* operator new (size_t s) { return MemoryPool::globalAlloc(s); }
-#endif
+	void* operator new (size_t s, Firebird::MemoryPool& pool ALLOC_PARAMS) { return pool.allocate(s ALLOC_PASS_ARGS); }
+	void operator delete (void* mem, Firebird::MemoryPool& ALLOC_PARAMS) { MemoryPool::globalFree(mem); }
 	void operator delete (void* mem) { MemoryPool::globalFree(mem); }
 
 public:


### PR DESCRIPTION
Standard new operator will alloc memory from the external pool.

FB_NEW will alloc memory from the default pool.

The difference of the external pool to the default pool is that
the external pool is only freed during unload when there is no
memory allocated from it.

If the external pool destructor is called before objects that
allocated memory from it, it's placed in special DYING state.

When in DYING state its desallocation is deferred to the moment
the last memory allocated is freed from it.