### PR TITLE
Restore simpler signature for node methods

### DIFF
--- a/src/dsql/BoolNodes.cpp
+++ b/src/dsql/BoolNodes.cpp
@@ -142,22 +142,22 @@ bool BinaryBoolNode::dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode*
 	return blrOp == o->blrOp;
 }
 
-bool BinaryBoolNode::sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const
+bool BinaryBoolNode::sameAs(const ExprNode* other, bool ignoreStreams) const
 {
 	const BinaryBoolNode* const otherNode = nodeAs<BinaryBoolNode>(other);
 
 	if (!otherNode || blrOp != otherNode->blrOp)
 		return false;
 
-	if (arg1->sameAs(csb, otherNode->arg1, ignoreStreams) &&
-		arg2->sameAs(csb, otherNode->arg2, ignoreStreams))
+	if (arg1->sameAs(otherNode->arg1, ignoreStreams) &&
+		arg2->sameAs(otherNode->arg2, ignoreStreams))
 	{
 		return true;
 	}
 
 	// A AND B is equivalent to B AND A, ditto for A OR B and B OR A.
-	return arg1->sameAs(csb, otherNode->arg2, ignoreStreams) &&
-		arg2->sameAs(csb, otherNode->arg1, ignoreStreams);
+	return arg1->sameAs(otherNode->arg2, ignoreStreams) &&
+		arg2->sameAs(otherNode->arg1, ignoreStreams);
 }
 
 BoolExprNode* BinaryBoolNode::copy(thread_db* tdbb, NodeCopier& copier) const
@@ -492,20 +492,20 @@ bool ComparativeBoolNode::dsqlMatch(DsqlCompilerScratch* dsqlScratch, const Expr
 	return dsqlFlag == o->dsqlFlag && blrOp == o->blrOp;
 }
 
-bool ComparativeBoolNode::sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const
+bool ComparativeBoolNode::sameAs(const ExprNode* other, bool ignoreStreams) const
 {
 	const ComparativeBoolNode* const otherNode = nodeAs<ComparativeBoolNode>(other);
 
 	if (!otherNode || blrOp != otherNode->blrOp)
 		return false;
 
-	bool matching = arg1->sameAs(csb, otherNode->arg1, ignoreStreams) &&
-		arg2->sameAs(csb, otherNode->arg2, ignoreStreams);
+	bool matching = arg1->sameAs(otherNode->arg1, ignoreStreams) &&
+		arg2->sameAs(otherNode->arg2, ignoreStreams);
 
 	if (matching)
 	{
 		matching = (!arg3 == !otherNode->arg3) &&
-			(!arg3 || arg3->sameAs(csb, otherNode->arg3, ignoreStreams));
+			(!arg3 || arg3->sameAs(otherNode->arg3, ignoreStreams));
 
 		if (matching)
 			return true;
@@ -516,8 +516,8 @@ bool ComparativeBoolNode::sameAs(CompilerScratch* csb, const ExprNode* other, bo
 	if (blrOp == blr_eql || blrOp == blr_equiv || blrOp == blr_neq)
 	{
 		// A = B is equivalent to B = A, etc.
-		if (arg1->sameAs(csb, otherNode->arg2, ignoreStreams) &&
-			arg2->sameAs(csb, otherNode->arg1, ignoreStreams))
+		if (arg1->sameAs(otherNode->arg2, ignoreStreams) &&
+			arg2->sameAs(otherNode->arg1, ignoreStreams))
 		{
 			return true;
 		}
@@ -1505,9 +1505,9 @@ bool RseBoolNode::dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* ot
 	return blrOp == o->blrOp;
 }
 
-bool RseBoolNode::sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const
+bool RseBoolNode::sameAs(const ExprNode* other, bool ignoreStreams) const
 {
-	if (!BoolExprNode::sameAs(csb, other, ignoreStreams))
+	if (!BoolExprNode::sameAs(other, ignoreStreams))
 		return false;
 
 	const RseBoolNode* const otherNode = nodeAs<RseBoolNode>(other);

--- a/src/dsql/BoolNodes.h
+++ b/src/dsql/BoolNodes.h
@@ -53,7 +53,7 @@ public:
 
 	virtual BoolExprNode* copy(thread_db* tdbb, NodeCopier& copier) const;
 	virtual bool dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const;
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 	virtual bool execute(thread_db* tdbb, jrd_req* request) const;
 
 private:
@@ -95,14 +95,14 @@ public:
 	virtual BoolExprNode* dsqlPass(DsqlCompilerScratch* dsqlScratch);
 	virtual void genBlr(DsqlCompilerScratch* dsqlScratch);
 
-	virtual bool possiblyUnknown(OptimizerBlk* opt)
+	virtual bool possiblyUnknown()
 	{
-		return blrOp == blr_equiv ? true : BoolExprNode::possiblyUnknown(opt);
+		return blrOp == blr_equiv ? true : BoolExprNode::possiblyUnknown();
 	}
 
 	virtual BoolExprNode* copy(thread_db* tdbb, NodeCopier& copier) const;
 	virtual bool dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const;
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 	virtual BoolExprNode* pass1(thread_db* tdbb, CompilerScratch* csb);
 	virtual void pass2Boolean1(thread_db* tdbb, CompilerScratch* csb);
 	virtual void pass2Boolean2(thread_db* tdbb, CompilerScratch* csb);
@@ -143,7 +143,7 @@ public:
 	virtual BoolExprNode* dsqlPass(DsqlCompilerScratch* dsqlScratch);
 	virtual void genBlr(DsqlCompilerScratch* dsqlScratch);
 
-	virtual bool possiblyUnknown(OptimizerBlk* /*opt*/)
+	virtual bool possiblyUnknown()
 	{
 		return true;
 	}
@@ -176,7 +176,7 @@ public:
 	virtual BoolExprNode* dsqlPass(DsqlCompilerScratch* dsqlScratch);
 	virtual void genBlr(DsqlCompilerScratch* dsqlScratch);
 
-	virtual bool possiblyUnknown(OptimizerBlk* /*opt*/)
+	virtual bool possiblyUnknown()
 	{
 		return true;
 	}
@@ -224,14 +224,14 @@ public:
 		return true;
 	}
 
-	virtual bool possiblyUnknown(OptimizerBlk* /*opt*/)
+	virtual bool possiblyUnknown()
 	{
 		return true;
 	}
 
 	virtual BoolExprNode* copy(thread_db* tdbb, NodeCopier& copier) const;
 	virtual bool dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const;
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 	virtual BoolExprNode* pass1(thread_db* tdbb, CompilerScratch* csb);
 	virtual void pass2Boolean1(thread_db* tdbb, CompilerScratch* csb);
 	virtual void pass2Boolean2(thread_db* tdbb, CompilerScratch* csb);

--- a/src/dsql/ExprNodes.h
+++ b/src/dsql/ExprNodes.h
@@ -89,7 +89,7 @@ public:
 	virtual void getDesc(thread_db* tdbb, CompilerScratch* csb, dsc* desc);
 	virtual ValueExprNode* copy(thread_db* tdbb, NodeCopier& copier) const;
 	virtual bool dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const;
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 	virtual ValueExprNode* pass2(thread_db* tdbb, CompilerScratch* csb);
 	virtual dsc* execute(thread_db* tdbb, jrd_req* request) const;
 
@@ -266,7 +266,7 @@ public:
 	virtual void getDesc(thread_db* tdbb, CompilerScratch* csb, dsc* desc);
 	virtual ValueExprNode* copy(thread_db* tdbb, NodeCopier& copier) const;
 	virtual bool dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const;
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 	virtual ValueExprNode* pass1(thread_db* tdbb, CompilerScratch* csb);
 	virtual ValueExprNode* pass2(thread_db* tdbb, CompilerScratch* csb);
 	virtual dsc* execute(thread_db* tdbb, jrd_req* request) const;
@@ -308,11 +308,11 @@ public:
 
 	virtual void getDesc(thread_db* tdbb, CompilerScratch* csb, dsc* desc);
 	virtual ValueExprNode* copy(thread_db* tdbb, NodeCopier& copier) const;
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 	virtual ValueExprNode* pass2(thread_db* tdbb, CompilerScratch* csb);
 	virtual dsc* execute(thread_db* tdbb, jrd_req* request) const;
 
-	virtual bool possiblyUnknown(OptimizerBlk* /*opt*/)
+	virtual bool possiblyUnknown()
 	{
 		return true;
 	}
@@ -661,7 +661,7 @@ public:
 		fb_assert(false);
 	}
 
-	virtual void collectStreams(CompilerScratch* csb, SortedStreamList& streamList) const;
+	virtual void collectStreams(SortedStreamList& streamList) const;
 
 	virtual bool computable(CompilerScratch* csb, StreamType stream,
 		bool allowOnlyCurrentStream, ValueExprNode* value);
@@ -735,7 +735,7 @@ public:
 	virtual void getDesc(thread_db* tdbb, CompilerScratch* csb, dsc* desc);
 	virtual ValueExprNode* copy(thread_db* tdbb, NodeCopier& copier) const;
 	virtual bool dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const;
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 	virtual ValueExprNode* pass2(thread_db* tdbb, CompilerScratch* csb);
 	virtual dsc* execute(thread_db* tdbb, jrd_req* request) const;
 
@@ -769,25 +769,25 @@ public:
 	virtual void genBlr(DsqlCompilerScratch* dsqlScratch);
 	virtual void make(DsqlCompilerScratch* dsqlScratch, dsc* desc);
 	virtual bool dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const;
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 
 	void setDsqlDesc(const dsc& desc)
 	{
 		dsqlDesc = desc;
 	}
 
-	virtual bool possiblyUnknown(OptimizerBlk* /*opt*/)
+	virtual bool possiblyUnknown()
 	{
 		return false;
 	}
 
-	virtual void collectStreams(CompilerScratch* /*csb*/, SortedStreamList& streamList) const
+	virtual void collectStreams(SortedStreamList& streamList) const
 	{
 		if (!streamList.exist(fieldStream))
 			streamList.add(fieldStream);
 	}
 
-	virtual bool unmappable(CompilerScratch* /*csb*/, const MapNode* /*mapNode*/, StreamType /*shellStream*/)
+	virtual bool unmappable(const MapNode* /*mapNode*/, StreamType /*shellStream*/)
 	{
 		return true;
 	}
@@ -850,7 +850,7 @@ public:
 	virtual void getDesc(thread_db* tdbb, CompilerScratch* csb, dsc* desc);
 	virtual ValueExprNode* copy(thread_db* tdbb, NodeCopier& copier) const;
 	virtual bool dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const;
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 	virtual ValueExprNode* pass1(thread_db* tdbb, CompilerScratch* csb);
 	virtual ValueExprNode* pass2(thread_db* tdbb, CompilerScratch* csb);
 	virtual dsc* execute(thread_db* tdbb, jrd_req* request) const;
@@ -925,7 +925,7 @@ public:
 	virtual void getDesc(thread_db* tdbb, CompilerScratch* csb, dsc* desc);
 	virtual ValueExprNode* copy(thread_db* tdbb, NodeCopier& copier) const;
 	virtual bool dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const;
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 	virtual ValueExprNode* pass2(thread_db* tdbb, CompilerScratch* csb);
 	virtual dsc* execute(thread_db* tdbb, jrd_req* request) const;
 
@@ -1349,7 +1349,7 @@ public:
 			return this;
 		}
 
-		virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+		virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 		virtual Frame* pass1(thread_db* tdbb, CompilerScratch* csb);
 		virtual Frame* pass2(thread_db* tdbb, CompilerScratch* csb);
 		virtual Frame* copy(thread_db* tdbb, NodeCopier& copier) const;
@@ -1423,7 +1423,7 @@ public:
 			return this;
 		}
 
-		virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+		virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 		virtual FrameExtent* pass1(thread_db* tdbb, CompilerScratch* csb);
 		virtual FrameExtent* pass2(thread_db* tdbb, CompilerScratch* csb);
 		virtual FrameExtent* copy(thread_db* tdbb, NodeCopier& copier) const;
@@ -1642,12 +1642,12 @@ public:
 	virtual void genBlr(DsqlCompilerScratch* dsqlScratch);
 	virtual void make(DsqlCompilerScratch* dsqlScratch, dsc* desc);
 
-	virtual bool possiblyUnknown(OptimizerBlk* /*opt*/)
+	virtual bool possiblyUnknown()
 	{
 		return false;
 	}
 
-	virtual void collectStreams(CompilerScratch* /*csb*/, SortedStreamList& streamList) const
+	virtual void collectStreams(SortedStreamList& streamList) const
 	{
 		if (!streamList.exist(recStream))
 			streamList.add(recStream);
@@ -1662,7 +1662,7 @@ public:
 	virtual void getDesc(thread_db* tdbb, CompilerScratch* csb, dsc* desc);
 	virtual ValueExprNode* copy(thread_db* tdbb, NodeCopier& copier) const;
 	virtual bool dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const;
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 	virtual ValueExprNode* pass1(thread_db* tdbb, CompilerScratch* csb);
 	virtual ValueExprNode* pass2(thread_db* tdbb, CompilerScratch* csb);
 	virtual dsc* execute(thread_db* tdbb, jrd_req* request) const;
@@ -1833,7 +1833,7 @@ public:
 	virtual void getDesc(thread_db* tdbb, CompilerScratch* csb, dsc* desc);
 	virtual ValueExprNode* copy(thread_db* tdbb, NodeCopier& copier) const;
 	virtual bool dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const;
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 	virtual ValueExprNode* pass2(thread_db* tdbb, CompilerScratch* csb);
 	virtual dsc* execute(thread_db* tdbb, jrd_req* request) const;
 
@@ -1867,7 +1867,7 @@ public:
 	virtual void getDesc(thread_db* tdbb, CompilerScratch* csb, dsc* desc);
 	virtual ValueExprNode* copy(thread_db* tdbb, NodeCopier& copier) const;
 	virtual bool dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const;
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 	virtual ValueExprNode* pass2(thread_db* tdbb, CompilerScratch* csb);
 	virtual dsc* execute(thread_db* tdbb, jrd_req* request) const;
 
@@ -1900,17 +1900,17 @@ public:
 	virtual bool dsqlFieldFinder(FieldFinder& visitor);
 	virtual ValueExprNode* dsqlFieldRemapper(FieldRemapper& visitor);
 
-	virtual bool unmappable(CompilerScratch* /*csb*/, const MapNode* /*mapNode*/, StreamType /*shellStream*/)
+	virtual bool unmappable(const MapNode* /*mapNode*/, StreamType /*shellStream*/)
 	{
 		return false;
 	}
 
-	virtual bool possiblyUnknown(OptimizerBlk* /*opt*/)
+	virtual bool possiblyUnknown()
 	{
 		return true;
 	}
 
-	virtual void collectStreams(CompilerScratch* csb, SortedStreamList& streamList) const;
+	virtual void collectStreams(SortedStreamList& streamList) const;
 
 	virtual bool computable(CompilerScratch* csb, StreamType stream,
 		bool allowOnlyCurrentStream, ValueExprNode* value);
@@ -1920,7 +1920,7 @@ public:
 
 	virtual void getDesc(thread_db* tdbb, CompilerScratch* csb, dsc* desc);
 	virtual ValueExprNode* copy(thread_db* tdbb, NodeCopier& copier) const;
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 	virtual ValueExprNode* pass1(thread_db* tdbb, CompilerScratch* csb);
 	virtual ValueExprNode* pass2(thread_db* tdbb, CompilerScratch* csb);
 	virtual dsc* execute(thread_db* tdbb, jrd_req* request) const;
@@ -2037,7 +2037,7 @@ public:
 	virtual void getDesc(thread_db* tdbb, CompilerScratch* csb, dsc* desc);
 	virtual ValueExprNode* copy(thread_db* tdbb, NodeCopier& copier) const;
 	virtual bool dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const;
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 	virtual ValueExprNode* pass2(thread_db* tdbb, CompilerScratch* csb);
 	virtual dsc* execute(thread_db* tdbb, jrd_req* request) const;
 
@@ -2076,7 +2076,7 @@ public:
 	virtual void getDesc(thread_db* tdbb, CompilerScratch* csb, dsc* desc);
 	virtual ValueExprNode* copy(thread_db* tdbb, NodeCopier& copier) const;
 	virtual bool dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const;
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 	virtual ValueExprNode* pass2(thread_db* tdbb, CompilerScratch* csb);
 	virtual dsc* execute(thread_db* tdbb, jrd_req* request) const;
 
@@ -2114,7 +2114,7 @@ public:
 	virtual void genBlr(DsqlCompilerScratch* dsqlScratch);
 	virtual void make(DsqlCompilerScratch* dsqlScratch, dsc* desc);
 
-	virtual bool possiblyUnknown(OptimizerBlk* /*opt*/)
+	virtual bool possiblyUnknown()
 	{
 		return true;
 	}
@@ -2122,7 +2122,7 @@ public:
 	virtual void getDesc(thread_db* tdbb, CompilerScratch* csb, dsc* desc);
 	virtual ValueExprNode* copy(thread_db* tdbb, NodeCopier& copier) const;
 	virtual bool dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const;
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 	virtual ValueExprNode* pass1(thread_db* tdbb, CompilerScratch* csb);
 	virtual ValueExprNode* pass2(thread_db* tdbb, CompilerScratch* csb);
 	virtual dsc* execute(thread_db* tdbb, jrd_req* request) const;
@@ -2163,14 +2163,14 @@ public:
 	virtual void genBlr(DsqlCompilerScratch* dsqlScratch);
 	virtual void make(DsqlCompilerScratch* dsqlScratch, dsc* desc);
 
-	virtual bool possiblyUnknown(OptimizerBlk* /*opt*/)
+	virtual bool possiblyUnknown()
 	{
 		return true;
 	}
 
 	virtual void getDesc(thread_db* tdbb, CompilerScratch* csb, dsc* desc);
 	virtual ValueExprNode* copy(thread_db* tdbb, NodeCopier& copier) const;
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 	virtual ValueExprNode* pass2(thread_db* tdbb, CompilerScratch* csb);
 	virtual dsc* execute(thread_db* tdbb, jrd_req* request) const;
 

--- a/src/dsql/Nodes.h
+++ b/src/dsql/Nodes.h
@@ -396,11 +396,16 @@ template <typename To, typename From> static bool nodeIs(const NestConst<From>& 
 }
 
 
-class NodeRefsHolder : public Firebird::PermanentStorage
+class NodeRefsHolder : public Firebird::AutoStorage
 {
 public:
-	NodeRefsHolder(MemoryPool& pool)
-		: PermanentStorage(pool),
+	NodeRefsHolder()
+		: refs(getPool())
+	{
+	}
+
+	explicit NodeRefsHolder(MemoryPool& pool)
+		: AutoStorage(pool),
 		  refs(pool)
 	{
 	}
@@ -654,18 +659,18 @@ public:
 	}
 
 	// Check if expression could return NULL or expression can turn NULL into a true/false.
-	virtual bool possiblyUnknown(OptimizerBlk* opt);
+	virtual bool possiblyUnknown();
 
 	// Verify if this node is allowed in an unmapped boolean.
-	virtual bool unmappable(CompilerScratch* csb, const MapNode* mapNode, StreamType shellStream);
+	virtual bool unmappable(const MapNode* mapNode, StreamType shellStream);
 
 	// Return all streams referenced by the expression.
-	virtual void collectStreams(CompilerScratch* csb, SortedStreamList& streamList) const;
+	virtual void collectStreams(SortedStreamList& streamList) const;
 
-	virtual bool findStream(CompilerScratch* csb, StreamType stream)
+	virtual bool findStream(StreamType stream)
 	{
 		SortedStreamList streams;
-		collectStreams(csb, streams);
+		collectStreams(streams);
 
 		return streams.exist(stream);
 	}
@@ -679,7 +684,7 @@ public:
 	}
 
 	// Determine if two expression trees are the same.
-	virtual bool sameAs(CompilerScratch* csb, const ExprNode* other, bool ignoreStreams) const;
+	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 
 	// See if node is presently computable.
 	// A node is said to be computable, if all the streams involved
@@ -1022,19 +1027,19 @@ public:
 
 	virtual AggNode* pass2(thread_db* tdbb, CompilerScratch* csb);
 
-	virtual bool possiblyUnknown(OptimizerBlk* /*opt*/)
+	virtual bool possiblyUnknown()
 	{
 		return true;
 	}
 
-	virtual void collectStreams(CompilerScratch* /*csb*/, SortedStreamList& /*streamList*/) const
+	virtual void collectStreams(SortedStreamList& /*streamList*/) const
 	{
 		// ASF: Although in v2.5 the visitor happens normally for the node childs, nod_count has
 		// been set to 0 in CMP_pass2, so that doesn't happens.
 		return;
 	}
 
-	virtual bool unmappable(CompilerScratch* /*csb*/, const MapNode* /*mapNode*/, StreamType /*shellStream*/)
+	virtual bool unmappable(const MapNode* /*mapNode*/, StreamType /*shellStream*/)
 	{
 		return false;
 	}
@@ -1155,23 +1160,23 @@ public:
 		fb_assert(false);
 	}
 
-	virtual bool possiblyUnknown(OptimizerBlk* /*opt*/)
+	virtual bool possiblyUnknown()
 	{
 		return true;
 	}
 
-	virtual bool unmappable(CompilerScratch* /*csb*/, const MapNode* /*mapNode*/, StreamType /*shellStream*/)
+	virtual bool unmappable(const MapNode* /*mapNode*/, StreamType /*shellStream*/)
 	{
 		return false;
 	}
 
-	virtual void collectStreams(CompilerScratch* /*csb*/, SortedStreamList& streamList) const
+	virtual void collectStreams(SortedStreamList& streamList) const
 	{
 		if (!streamList.exist(getStream()))
 			streamList.add(getStream());
 	}
 
-	virtual bool sameAs(CompilerScratch* /*csb*/, const ExprNode* /*other*/, bool /*ignoreStreams*/) const
+	virtual bool sameAs(const ExprNode* /*other*/, bool /*ignoreStreams*/) const
 	{
 		return false;
 	}

--- a/src/jrd/Optimizer.cpp
+++ b/src/jrd/Optimizer.cpp
@@ -69,7 +69,7 @@ namespace
 		{
 			// The desired expression can be hidden inside a derived expression node,
 			// so try to recover it (see CORE-4118).
-			while (!idx->idx_expression->sameAs(csb, node, true))
+			while (!idx->idx_expression->sameAs(node, true))
 			{
 				DerivedExprNode* const derivedExpr = nodeAs<DerivedExprNode>(node);
 				CastNode* const cast = nodeAs<CastNode>(node);
@@ -83,8 +83,8 @@ namespace
 			}
 
 			SortedStreamList exprStreams, nodeStreams;
-			idx->idx_expression->collectStreams(csb, exprStreams);
-			node->collectStreams(csb, nodeStreams);
+			idx->idx_expression->collectStreams(exprStreams);
+			node->collectStreams(nodeStreams);
 
 			if (exprStreams.getCount() == 1 && exprStreams[0] == 0 &&
 				nodeStreams.getCount() == 1 && nodeStreams[0] == stream)
@@ -748,10 +748,10 @@ void OptimizerRetrieval::analyzeNavigation(const InversionCandidateList& inversi
 					ValueExprNode* const node1 = cmpNode->arg1;
 					ValueExprNode* const node2 = cmpNode->arg2;
 
-					if (node1->sameAs(csb, orgNode, false))
+					if (node1->sameAs(orgNode, false))
 						nodes.add(node2);
 
-					if (node2->sameAs(csb, orgNode, false))
+					if (node2->sameAs(orgNode, false))
 						nodes.add(node1);
 				}
 			}

--- a/src/jrd/RecordSourceNodes.cpp
+++ b/src/jrd/RecordSourceNodes.cpp
@@ -1338,15 +1338,15 @@ void ProcedureSourceNode::findDependentFromStreams(const OptimizerRetrieval* opt
 		targetList->findDependentFromStreams(optRet, streamList);
 }
 
-void ProcedureSourceNode::collectStreams(CompilerScratch* csb, SortedStreamList& streamList) const
+void ProcedureSourceNode::collectStreams(SortedStreamList& streamList) const
 {
-	RecordSourceNode::collectStreams(csb, streamList);
+	RecordSourceNode::collectStreams(streamList);
 
 	if (sourceList)
-		sourceList->collectStreams(csb, streamList);
+		sourceList->collectStreams(streamList);
 
 	if (targetList)
-		targetList->collectStreams(csb, streamList);
+		targetList->collectStreams(streamList);
 }
 
 
@@ -2413,7 +2413,7 @@ bool WindowSourceNode::containsStream(StreamType checkStream) const
 	return false;
 }
 
-void WindowSourceNode::collectStreams(CompilerScratch* /*csb*/, SortedStreamList& streamList) const
+void WindowSourceNode::collectStreams(SortedStreamList& streamList) const
 {
 	for (ObjectsArray<Window>::const_iterator window = windows.begin();
 		 window != windows.end();
@@ -3431,27 +3431,27 @@ void RseNode::findDependentFromStreams(const OptimizerRetrieval* optRet,
 		(*ptr)->findDependentFromStreams(optRet, streamList);
 }
 
-void RseNode::collectStreams(CompilerScratch* csb, SortedStreamList& streamList) const
+void RseNode::collectStreams(SortedStreamList& streamList) const
 {
 	if (rse_first)
-		rse_first->collectStreams(csb, streamList);
+		rse_first->collectStreams(streamList);
 
 	if (rse_skip)
-		rse_skip->collectStreams(csb, streamList);
+		rse_skip->collectStreams(streamList);
 
 	if (rse_boolean)
-		rse_boolean->collectStreams(csb, streamList);
+		rse_boolean->collectStreams(streamList);
 
 	// ASF: The legacy code used to visit rse_sorted and rse_projection, but the nod_sort was never
 	// handled.
-	// rse_sorted->collectStreams(csb, streamList);
-	// rse_projection->collectStreams(csb, streamList);
+	// rse_sorted->collectStreams(streamList);
+	// rse_projection->collectStreams(streamList);
 
 	const NestConst<RecordSourceNode>* ptr;
 	const NestConst<RecordSourceNode>* end;
 
 	for (ptr = rse_relations.begin(), end = rse_relations.end(); ptr != end; ++ptr)
-		(*ptr)->collectStreams(csb, streamList);
+		(*ptr)->collectStreams(streamList);
 }
 
 
@@ -3839,7 +3839,7 @@ static void genDeliverUnmapped(CompilerScratch* csb, BoolExprNodeStack* deliverS
 					// Check also the expression inside the map, because aggregate
 					// functions aren't allowed to be delivered to the WHERE clause.
 					ValueExprNode* value = map->sourceList[fieldId];
-					okNode = value->unmappable(csb, map, shellStream);
+					okNode = value->unmappable(map, shellStream);
 
 					if (okNode)
 						*newChildren[indexArg] = map->sourceList[fieldId];
@@ -3847,7 +3847,7 @@ static void genDeliverUnmapped(CompilerScratch* csb, BoolExprNodeStack* deliverS
 			}
 			else
 			{
-				if ((okNode = children[indexArg]->unmappable(csb, map, shellStream)))
+				if ((okNode = children[indexArg]->unmappable(map, shellStream)))
 					*newChildren[indexArg] = children[indexArg];
 			}
 		}

--- a/src/jrd/RecordSourceNodes.h
+++ b/src/jrd/RecordSourceNodes.h
@@ -484,7 +484,7 @@ public:
 	virtual void findDependentFromStreams(const OptimizerRetrieval* optRet,
 		SortedStreamList* streamList);
 
-	virtual void collectStreams(CompilerScratch* csb, SortedStreamList& streamList) const;
+	virtual void collectStreams(SortedStreamList& streamList) const;
 
 	virtual RecordSource* compile(thread_db* tdbb, OptimizerBlk* opt, bool innerSubStream);
 
@@ -703,7 +703,7 @@ public:
 	virtual RecordSourceNode* pass2(thread_db* tdbb, CompilerScratch* csb);
 	virtual void pass2Rse(thread_db* tdbb, CompilerScratch* csb);
 	virtual bool containsStream(StreamType checkStream) const;
-	virtual void collectStreams(CompilerScratch* csb, SortedStreamList& streamList) const;
+	virtual void collectStreams(SortedStreamList& streamList) const;
 
 	virtual void computeDbKeyStreams(StreamList& /*streamList*/) const
 	{
@@ -836,7 +836,7 @@ public:
 	virtual void findDependentFromStreams(const OptimizerRetrieval* optRet,
 		SortedStreamList* streamList);
 
-	virtual void collectStreams(CompilerScratch* csb, SortedStreamList& streamList) const;
+	virtual void collectStreams(SortedStreamList& streamList) const;
 
 	virtual RecordSource* compile(thread_db* tdbb, OptimizerBlk* opt, bool innerSubStream);
 

--- a/src/jrd/opt.cpp
+++ b/src/jrd/opt.cpp
@@ -179,10 +179,10 @@ namespace
 				csb->csb_rpt[*iter].deactivate();
 		}
 
-		bool isReferenced(CompilerScratch* csb, const ExprNode* node) const
+		bool isReferenced(const ExprNode* node) const
 		{
 			SortedStreamList nodeStreams;
-			node->collectStreams(csb, nodeStreams);
+			node->collectStreams(nodeStreams);
 
 			if (!nodeStreams.hasData())
 				return false;
@@ -558,7 +558,7 @@ RecordSource* OPT_compile(thread_db* tdbb, CompilerScratch* csb, RseNode* rse,
 		{
 			BoolExprNode* const node = iter.object();
 
-			if (rse->rse_jointype != blr_inner && node->possiblyUnknown(opt))
+			if (rse->rse_jointype != blr_inner && node->possiblyUnknown())
 			{
 				// parent missing conjunctions shouldn't be
 				// distributed to FULL OUTER JOIN streams at all
@@ -1232,7 +1232,7 @@ static void check_sorts(CompilerScratch* csb, RseNode* rse)
 				// This position doesn't use a simple field, thus we should
 				// check the expression internals.
 				SortedStreamList streams;
-				(*sort_ptr)->collectStreams(csb, streams);
+				(*sort_ptr)->collectStreams(streams);
 
 				// We can use this sort only if there's a single stream
 				// referenced by the expression.
@@ -2413,7 +2413,7 @@ static RecordSource* gen_retrieval(thread_db*     tdbb,
 			// that are local to this stream. The remaining ones are left in piece
 			// as possible candidates for a merge/hash join.
 
-			if ((inversion && node->findStream(csb, stream)) ||
+			if ((inversion && node->findStream(stream)) ||
 				(!inversion && node->computable(csb, stream, true)))
 			{
 				compose(*tdbb->getDefaultPool(), &boolean, node);
@@ -2902,9 +2902,9 @@ static bool gen_equi_join(thread_db* tdbb, OptimizerBlk* opt, RiverList& org_riv
 		{
 			River* const river1 = *iter1;
 
-			if (!river1->isReferenced(csb, node1))
+			if (!river1->isReferenced(node1))
 			{
-				if (!river1->isReferenced(csb, node2))
+				if (!river1->isReferenced(node2))
 					continue;
 
 				ValueExprNode* const temp = node1;
@@ -2918,7 +2918,7 @@ static bool gen_equi_join(thread_db* tdbb, OptimizerBlk* opt, RiverList& org_riv
 			{
 				River* const river2 = *iter2;
 
-				if (river2->isReferenced(csb, node2))
+				if (river2->isReferenced(node2))
 				{
 					for (eq_class = classes; eq_class < last_class; eq_class += cnt)
 					{


### PR DESCRIPTION
I suggest to use auto pool for NodeRefsHolder to reduce the nodes complexity and minimize the dependencies. With HalfStaticArray inside, TLS will be accessed extremely rare and csb_pool is usually already the default pool for the modified methods, so virtually nothing actually changes.