### PR TITLE
Fix #5082: Exception "too few key columns found for index" raises when attempt to create table with PK and immediatelly drop this PK within the same transaction

### DIFF
--- a/src/jrd/dfw.epp
+++ b/src/jrd/dfw.epp
@@ -3437,18 +3437,18 @@ static bool create_index(thread_db* tdbb, SSHORT phase, DeferredWork* work, jrd_
 		}
 		END_FOR
 
+		if (!relation)
+		{
+			// The record was not found in RDB$INDICES.
+			// Apparently the index was dropped in the same transaction.
+			return false;
+		}
+
 		if (key_count != idx.idx_count)
 		{
 			ERR_post(Arg::Gds(isc_no_meta_update) <<
 					 Arg::Gds(isc_key_field_err) << Arg::Str(work->dfw_name));
 			// Msg352: too few key columns found for index %s (incorrect column name?)
-		}
-
-		if (!relation)
-		{
-			ERR_post(Arg::Gds(isc_no_meta_update) <<
-					 Arg::Gds(isc_idx_create_err) << Arg::Str(work->dfw_name));
-			// Msg308: can't create index %s
 		}
 
 		// Make sure the relation info is all current


### PR DESCRIPTION
This commit also fixes #5173 and #3886.
The situation when the record is not found in RDB$INDICES was not handled correctly in create_index DFW.