### PR TITLE
[trace] Fix a missing transaction description in some statement_prepare records

### DIFF
--- a/src/dsql/dsql.cpp
+++ b/src/dsql/dsql.cpp
@@ -1543,7 +1543,10 @@ static dsql_req* prepareStatement(thread_db* tdbb, dsql_dbb* database, jrd_tra* 
 		scratchPool = database->createPool();
 
 		if (!transaction)		// Useful for session management statements
+		{
 			transaction = database->dbb_attachment->getSysTransaction();
+			trace.setTransaction(transaction);
+		}
 
 		DsqlCompilerScratch* scratch = FB_NEW_POOL(*scratchPool) DsqlCompilerScratch(*scratchPool, database,
 			transaction, statement);

--- a/src/jrd/trace/TraceDSQLHelpers.h
+++ b/src/jrd/trace/TraceDSQLHelpers.h
@@ -70,6 +70,11 @@ public:
 		m_request = request;
 	}
 
+	void setTransaction(jrd_tra* transaction)
+	{
+		m_transaction = transaction;
+	}
+
 	void prepare(ntrace_result_t result)
 	{
 		if (m_request) {
@@ -99,7 +104,7 @@ public:
 private:
 	bool m_need_trace;
 	Attachment* m_attachment;
-	jrd_tra* const m_transaction;
+	jrd_tra* m_transaction;
 	dsql_req* m_request;
 	SINT64 m_start_clock;
 	FB_SIZE_T m_string_len;


### PR DESCRIPTION
When NULL is passed to _Jrd::Attachment::prepareStatement_ instead of transaction, it is also passed to the **TraceDSQLPrepare**. 
https://github.com/FirebirdSQL/firebird/blob/35ee143b65404762dd02167688efd8495f429406/src/dsql/dsql.cpp#L1497
In this case a system transaction is used.
https://github.com/FirebirdSQL/firebird/blob/35ee143b65404762dd02167688efd8495f429406/src/dsql/dsql.cpp#L1545-L1546

But in **TraceDSQLPrepare** the transaction is still **NULL**. Because of this, there is no transaction description in the trace record.
For example, the situation occurs when creating a user after a recent [change](https://github.com/FirebirdSQL/firebird/commit/19a962dac9236e0bdeec21c13f9e0aa1298311d9#diff-ed3a6610c5fdf50f6b797d8246ba9d061145123109bd14de299bfa62121cae41R346) in SrpManagement.cpp.


I think this is an incorrect behavior and should be fixed.