### PR TITLE
use be.zip as timezone data source on big-endian platforms

### DIFF
--- a/builds/posix/Makefile.in
+++ b/builds/posix/Makefile.in
@@ -636,10 +636,9 @@ $(FIREBIRD_MSG) $(FIREBIRD)/include/firebird/impl/iberror_c.h:	$(BUILD_FILE)
 
 tzdata: $(FIREBIRD)/tzdata
 
-# FIXME: For big-endian, be.zip must be used.
-$(FIREBIRD)/tzdata: $(ROOT)/extern/icu/tzdata/le.zip
+$(FIREBIRD)/tzdata: $(ROOT)/extern/icu/tzdata/$(TZDATA_ZIP)
 	mkdir -p $(FIREBIRD)/tzdata
-	unzip -o $(ROOT)/extern/icu/tzdata/le.zip -d $(FIREBIRD)/tzdata
+	unzip -o $(ROOT)/extern/icu/tzdata/$(TZDATA_ZIP) -d $(FIREBIRD)/tzdata
 
 $(BUILD_FILE):	$(BUILD_Objects)
 	$(EXE_LINK) $(EXE_LINK_OPTIONS) $(LSB_UNDEF) $^ -o $@

--- a/builds/posix/make.defaults
+++ b/builds/posix/make.defaults
@@ -111,6 +111,7 @@ IsDeveloper = @DEVEL_FLG@
 
 CpuType=@CPU_TYPE@
 PLATFORM=@PLATFORM@
+TZDATA_ZIP=@TZDATA_ZIP@
 SFIO_EXAMPLES=@SFIO_EXAMPLES@
 
 # link with readline libraries - set by configure

--- a/configure.ac
+++ b/configure.ac
@@ -1071,7 +1071,15 @@ AC_LINK_IFELSE(
 AC_LANG_POP(C++)
 
 dnl Checks for typedefs, structures, and compiler characteristics.
-AC_C_BIGENDIAN
+AC_C_BIGENDIAN(
+	[
+		AC_DEFINE(WORDS_BIGENDIAN,1,[Words have most significant byte first])
+		AC_SUBST(TZDATA_ZIP,be.zip)
+	],
+	[
+		AC_SUBST(TZDATA_ZIP,le.zip)
+	]
+)
 AC_C_VOLATILE
 AC_TYPE_OFF_T
 AC_TYPE_SIZE_T


### PR DESCRIPTION
resolves "FIXME: For big-endian, be.zip must be used" in Makefile.in

the configure.ac usage of AC_C_BIGENDIAN is expanded so apart from defining `WORDS_BIGENDIAN` on big-endian platforms, it also defines `TZDATA_ZIP` to be `be.zip` or `le.zip` and that substitution is used later in the makefiles

my initial attempt was to use the result of the plain `AC_C_BIGENDIAN` check, but that is not propagated to the makefiles, just to `autoconf.h`

the patch also applies to 4.0-release (with small fuzz)