### PR TITLE
add Documentation key to systemd service file

### DIFF
--- a/builds/install/arch-specific/linux/firebird.service.in
+++ b/builds/install/arch-specific/linux/firebird.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Firebird Database Server
 After=syslog.target network.target
+Documentation=https://firebirdsql.org/en/firebird-rdbms/
 
 [Service]
 User=firebird


### PR DESCRIPTION
Simply adds a pointer to the documentation section on the web site to `firebird.service`.

Makes it possible to visit the docs section via `systemctl help firebird`

Debian package checker (`lintian`) makes a suggestion about it. I guess it would be useful to have it upstream too.