### PR TITLE
Make gfix handle io errors and other changes

### DIFF
--- a/src/jrd/cch.cpp
+++ b/src/jrd/cch.cpp
@@ -945,9 +945,9 @@ void CCH_fetch_page(thread_db* tdbb, WIN* window, const bool read_shadow)
 		readFailed = !dbb->dbb_crypto_manager->read(tdbb, status, page, &io);
 		if (readFailed)
 		{
+			PAGE_LOCK_RELEASE(tdbb, bcb, bdb->bdb_lock);
 			if (read_shadow)
 			{
-				PAGE_LOCK_RELEASE(tdbb, bcb, bdb->bdb_lock);
 				CCH_unwind(tdbb, true);
 			}
 		}
@@ -978,9 +978,9 @@ void CCH_fetch_page(thread_db* tdbb, WIN* window, const bool read_shadow)
 			readFailed = !dbb->dbb_crypto_manager->read(tdbb, status, page, &io);
 			if (readFailed)
 			{
+				PAGE_LOCK_RELEASE(tdbb, bcb, bdb->bdb_lock);
 				if (read_shadow)
 				{
-					PAGE_LOCK_RELEASE(tdbb, bcb, bdb->bdb_lock);
 					CCH_unwind(tdbb, true);
 				}
 			}

--- a/src/jrd/cch.h
+++ b/src/jrd/cch.h
@@ -32,7 +32,6 @@
 #include "../common/ThreadStart.h"
 #ifdef SUPERSERVER_V2
 #include "../jrd/sbm.h"
-#include "../jrd/pag.h"
 #endif
 
 #include "../jrd/que.h"

--- a/src/jrd/pag.cpp
+++ b/src/jrd/pag.cpp
@@ -1504,7 +1504,7 @@ void PAG_init2(thread_db* tdbb, USHORT shadow_number)
 }
 
 
-SLONG PAG_last_page(thread_db* tdbb)
+ULONG PAG_last_page(thread_db* tdbb)
 {
 /**************************************
  *

--- a/src/jrd/pag_proto.h
+++ b/src/jrd/pag_proto.h
@@ -54,7 +54,7 @@ void	PAG_header(Jrd::thread_db*, bool);
 void	PAG_header_init(Jrd::thread_db*);
 void	PAG_init(Jrd::thread_db*);
 void	PAG_init2(Jrd::thread_db*, USHORT);
-SLONG	PAG_last_page(Jrd::thread_db* tdbb);
+ULONG	PAG_last_page(Jrd::thread_db* tdbb);
 void	PAG_release_page(Jrd::thread_db* tdbb, const Jrd::PageNumber&, const Jrd::PageNumber&);
 void	PAG_release_pages(Jrd::thread_db* tdbb, USHORT pageSpaceID, int cntRelease,
 			const ULONG* pgNums, const ULONG prior_page);

--- a/src/jrd/sdw.cpp
+++ b/src/jrd/sdw.cpp
@@ -456,7 +456,7 @@ void SDW_dump_pages(thread_db* tdbb)
 	SyncLockGuard guard(&dbb->dbb_shadow_sync, SYNC_EXCLUSIVE, "SDW_dump_pages");
 
 	gds__log("conditional shadow dumped for database %s", dbb->dbb_filename.c_str());
-	const SLONG max = PAG_last_page(tdbb);
+	const ULONG max = PAG_last_page(tdbb);
 
 	// mark the first shadow in the list because we don't
 	// want to start shadowing to any files that are added
@@ -468,15 +468,15 @@ void SDW_dump_pages(thread_db* tdbb)
 	window.win_flags = WIN_large_scan;
 	window.win_scans = 1;
 
-	for (SLONG page_number = HEADER_PAGE + 1; page_number <= max; page_number++)
+	for (ULONG page_number = HEADER_PAGE + 1; page_number <= max; page_number++)
 	{
 #ifdef SUPERSERVER_V2
 		if (!(page_number % dbb->dbb_prefetch_sequence))
 		{
-			SLONG pages[PREFETCH_MAX_PAGES];
+			ULONG pages[PREFETCH_MAX_PAGES];
 
-			SLONG number = page_number;
-			SLONG i = 0;
+			ULONG number = page_number;
+			ULONG i = 0;
 			while (i < dbb->dbb_prefetch_pages && number <= max) {
 				pages[i++] = number++;
 			}

--- a/src/jrd/validation.cpp
+++ b/src/jrd/validation.cpp
@@ -2838,7 +2838,7 @@ void Validation::checkDPinPP(jrd_rel* relation, ULONG page_number)
 	* Functional description
 	*	Check if data page presented in pointer page.
 	* If not we try to fix it by setting pointer page slot in the page_number.
-	* Early in walk_chain we observed that this page in related to the relation so we skip such kind of check here.
+	* Early in walk_chain we observed that this page is related to the relation so we skip such kind of check here.
 	**************************************/
 
 	WIN window(DB_PAGE_SPACE, page_number);
@@ -2895,11 +2895,10 @@ void Validation::checkDPinPP(jrd_rel* relation, ULONG page_number)
 				vdr_fixed++;
 			}
 		}
+		release_page(&window);
 	}
 	else
 		corrupt(VAL_DATA_PAGE_HASNO_PP, relation, page_number, dpage->dpg_sequence);
-
-	release_page(&window);
 }
 
 void Validation::checkDPinPIP(jrd_rel* relation, ULONG page_number)

--- a/src/jrd/validation.cpp
+++ b/src/jrd/validation.cpp
@@ -1252,11 +1252,12 @@ Validation::FETCH_CODE Validation::fetch_page(bool mark, ULONG page_number,
 		const ULONG page_scn = (*page_pointer)->pag_scn;
 
 		WIN scns_window(DB_PAGE_SPACE, scn_page_num);
-		scns_page* scns = (scns_page*) *page_pointer;
+		scns_page* scns;
 
-		if (scn_page_num != page_number) {
+		if (scn_page_num == page_number)
+			scns = (scns_page*) *page_pointer;
+		else
 			fetch_page(mark, scn_page_num, pag_scns, &scns_window, &scns);
-		}
 
 		if (scns->scn_pages[scn_slot] != page_scn)
 		{

--- a/src/jrd/validation.cpp
+++ b/src/jrd/validation.cpp
@@ -2855,7 +2855,7 @@ void Validation::checkDPinPP(jrd_rel* relation, ULONG page_number)
 	DECOMPOSE(sequence, dbb->dbb_dp_per_pp, pp_sequence, slot);
 
 	const vcl* vector = relation->getBasePages()->rel_pages;
-	pointer_page* ppage = 0;
+	pointer_page* ppage = NULL;
 	if (pp_sequence < vector->count())
 	{
 		fetch_page(false, (*vector)[pp_sequence], pag_pointer, &window, &ppage);
@@ -3042,16 +3042,21 @@ Validation::RTN Validation::walk_relation(jrd_rel* relation)
 
 			if (c.getFirst() && b.getFirst())
 			{
-				for (bool next = true; next; next = c.getNext())
+				while (true)
 				{
 					if (c.current() == b.current())
 						b.getNext();
-					else if ((c.current() < b.current()) || !b.getNext())
+					else if ( ( c.current() < b.current() ) || !b.getNext() )
 					{
 						//fprintf(stdout, "chain page was visited not via data pages %d\n", c.current());
 						checkDPinPP(relation, c.current());
 						checkDPinPIP(relation, c.current());
 					}
+					else
+						continue;
+
+					if (!c.getNext())
+						break;
 				}
 			}
 		}

--- a/src/jrd/validation.h
+++ b/src/jrd/validation.h
@@ -140,6 +140,7 @@ private:
 	int vdr_errors;
 	int vdr_warns;
 	int vdr_fixed;
+	int vdr_ignored;						// Counts a number of corrupts which mush not prevent orphan pages fixing
 	TraNumber vdr_max_transaction;
 	FB_UINT64 vdr_rel_backversion_counter;	// Counts slots w/rhd_chain
 	PageBitmap* vdr_backversion_pages;      // 1 bit per visited table page

--- a/src/jrd/validation.h
+++ b/src/jrd/validation.h
@@ -69,7 +69,8 @@ private:
 		fetch_ok,
 		//fetch_checksum,
 		fetch_type,
-		fetch_duplicate
+		fetch_duplicate,
+		fetch_io			// IO error while page reading
 	};
 
 	enum RTN
@@ -121,8 +122,12 @@ private:
 		VAL_DATA_PAGE_SLOT_BAD_VAL  = 37,
 		VAL_DATA_PAGE_HASNO_PP      = 38,
 		VAL_DATA_PAGE_SEC_PRI		= 39,
+		VAL_FETCH_PAGE_ERROR		= 40,
+		VAL_INDEX_PAGE_LOST			= 41,
+		VAL_PIP_PAGE_LOST			= 42,
+		VAL_SCN_PAGE_LOST			= 43,
 
-		VAL_MAX_ERROR				= 40
+		VAL_MAX_ERROR
 	};
 
 	struct MSG_ENTRY

--- a/src/utilities/gstat/dba.epp
+++ b/src/utilities/gstat/dba.epp
@@ -195,7 +195,7 @@ static void db_error(int);
 static USHORT get_format_length(ISC_STATUS*, isc_db_handle, isc_tr_handle, ISC_QUAD&);
 
 static dba_fil* db_open(const char*, USHORT);
-static const pag* db_read(SLONG page_number, bool ok_enc = false);
+static const pag* db_read(ULONG page_number, bool ok_enc = false);
 #ifdef WIN_NT
 static void db_close(void* file_desc);
 #else
@@ -264,7 +264,7 @@ public:
 	USHORT page_size;
 	USHORT dp_per_pp;
 	USHORT max_records;
-	SLONG page_number;
+	ULONG page_number;
 	pag* buffer1;
 	pag* buffer2;
 	pag* global_buffer;
@@ -616,8 +616,8 @@ int gstat(Firebird::UtilSvc* uSvc)
 	SCHAR temp[RAW_HEADER_SIZE];
 	tddba->page_size = sizeof(temp);
 	tddba->global_buffer = (pag*) temp;
-	tddba->page_number = -1;
-	const header_page* header = (const header_page*) db_read((SLONG) 0);
+	tddba->page_number = ~0u;
+	const header_page* header = (const header_page*) db_read(0);
 
 	uSvc->started();
 
@@ -642,7 +642,7 @@ int gstat(Firebird::UtilSvc* uSvc)
 	tddba->buffer1 = (pag*) alloc(tddba->page_size);
 	tddba->buffer2 = (pag*) alloc(tddba->page_size);
 	tddba->global_buffer = (pag*) alloc(tddba->page_size);
-	tddba->page_number = -1;
+	tddba->page_number = ~0u;
 
 	// gather continuation files
 
@@ -1331,7 +1331,7 @@ static void analyze_data( dba_rel* relation, bool sw_record)
 
 	pointer_page* ptr_page = (pointer_page*) tddba->buffer1;
 
-	for (SLONG next_pp = relation->rel_pointer_page; next_pp; next_pp = ptr_page->ppg_next)
+	for (ULONG next_pp = relation->rel_pointer_page; next_pp; next_pp = ptr_page->ppg_next)
 	{
 		++relation->rel_pointer_pages;
 		memcpy(ptr_page, (const SCHAR*) db_read(next_pp), tddba->page_size);
@@ -1477,13 +1477,13 @@ static void analyze_blob(dba_rel* relation, const blh* blob, int length)
 		{
 			relation->rel_blobs_level_2++;
 
-			SLONG pages[MAX_PAGE_SIZE / sizeof(SLONG)];
-			memcpy(pages, blob->blh_page, slots * sizeof(SLONG));
+			ULONG pages[MAX_PAGE_SIZE / sizeof(ULONG)];
+			memcpy(pages, blob->blh_page, slots * sizeof(ULONG));
 
 			for (int i = 0; i < slots; i++)
 			{
 				const blob_page* bpage = (const blob_page*) db_read(pages[i]);
-				relation->rel_blob_pages += bpage->blp_length / sizeof(SLONG);
+				relation->rel_blob_pages += bpage->blp_length / sizeof(ULONG);
 			}
 		}
 	}
@@ -1507,7 +1507,7 @@ static ULONG analyze_fragments(dba_rel* relation, const rhdf* header)
 
 	while (header->rhdf_flags & rhd_incomplete)
 	{
-		const SLONG f_page = header->rhdf_f_page;
+		const ULONG f_page = header->rhdf_f_page;
 		const USHORT f_line = header->rhdf_f_line;
 		const data_page* page = (const data_page*) db_read(f_page);
 		if (page->dpg_header.pag_type != pag_data || page->dpg_relation != relation->rel_id ||
@@ -1555,7 +1555,7 @@ static void analyze_index( const dba_rel* relation, dba_idx* index)
 
 	const index_root_page* index_root = (const index_root_page*) db_read(relation->rel_index_root);
 
-	SLONG page;
+	ULONG page;
 	if (index_root->irt_count <= index->idx_id ||
 		!(page = index_root->irt_rpt[index->idx_id].getRoot()))
 	{
@@ -1578,7 +1578,7 @@ static void analyze_index( const dba_rel* relation, dba_idx* index)
 	}
 
 	bool firstLeafNode = true;
-	SLONG number;
+	ULONG number;
 	FB_UINT64 duplicates = 0;
 
 	// Maximum key length is 1/4 of the used page-size
@@ -1701,7 +1701,7 @@ static ULONG analyze_versions( dba_rel* relation, const rhdf* header)
  **************************************/
 	//tdba* tddba = tdba::getSpecific();
 	ULONG space = 0, versions = 0;
-	SLONG b_page = header->rhdf_b_page;
+	ULONG b_page = header->rhdf_b_page;
 	USHORT b_line = header->rhdf_b_line;
 
 	while (b_page)
@@ -1912,7 +1912,7 @@ static dba_fil* db_open(const char* file_name, USHORT file_length)
 }
 
 
-static const pag* db_read( SLONG page_number, bool ok_enc)
+static const pag* db_read( ULONG page_number, bool ok_enc)
 {
 /**************************************
  *
@@ -1935,7 +1935,7 @@ static const pag* db_read( SLONG page_number, bool ok_enc)
 	tddba->page_number = page_number;
 
 	dba_fil* fil;
-	for (fil = tddba->files; page_number > (SLONG) fil->fil_max_page && fil->fil_next;)
+	for (fil = tddba->files; page_number > fil->fil_max_page && fil->fil_next;)
 	{
 		 fil = fil->fil_next;
 	}
@@ -2015,7 +2015,7 @@ static void db_error( int status)
  *
  **************************************/
 	tdba* tddba = tdba::getSpecific();
-	tddba->page_number = -1;
+	tddba->page_number = ~0u;
 
 	// FIXME: The strerror() function returns the appropriate description
 	// string, or an unknown error message if the error code is unknown.
@@ -2097,7 +2097,7 @@ static dba_fil* db_open(const char* file_name, USHORT file_length)
 }
 
 
-static const pag* db_read( SLONG page_number, bool ok_enc)
+static const pag* db_read( ULONG page_number, bool ok_enc)
 {
 /**************************************
  *
@@ -2117,7 +2117,7 @@ static const pag* db_read( SLONG page_number, bool ok_enc)
 	tddba->page_number = page_number;
 
 	dba_fil* fil;
-	for (fil = tddba->files; page_number > (SLONG) fil->fil_max_page && fil->fil_next;)
+	for (fil = tddba->files; page_number > fil->fil_max_page && fil->fil_next;)
 	{
 		fil = fil->fil_next;
 	}
@@ -2177,7 +2177,7 @@ static void dba_error(USHORT errcode, const SafeArg& arg)
  *
  **************************************/
 	tdba* tddba = tdba::getSpecific();
-	tddba->page_number = -1;
+	tddba->page_number = ~0u;
 
 	tddba->uSvc->setServiceStatus(GSTAT_MSG_FAC, errcode, arg);
 	if (!tddba->uSvc->isService())


### PR DESCRIPTION
1) Fix page number data type to ULONG.
2) Fix subtraction backversion pages from chain pages.
3) Fix call release_page according to fetch_page.
4) CCH_fetch handles I/O errors and returns NULL in buffer if read_shadow is not set.
- Check all calls of fetch_page to handle returned value.
- Add several corrupt messages.