### PR TITLE
Fix MacOS UDR and Legacy_UserManager plugins not working due to not exported entry point.

### DIFF
--- a/doc/Using_OO_API.html
+++ b/doc/Using_OO_API.html
@@ -1673,7 +1673,7 @@ only for some specific OS you can make this place a bit simpler. In
 minimum case the function should register module and all factories in
 plugin manager:</font></p>
 <p style="margin-bottom: 0cm"><font size="4" style="font-size: 14pt">extern
-&quot;C&quot; void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(IMaster*
+&quot;C&quot; FB_DLL_EXPORT void FB_PLUGIN_ENTRY_POINT(IMaster*
 master)</font></p>
 <p style="margin-bottom: 0cm"><font size="4" style="font-size: 14pt">{</font></p>
 <p style="margin-bottom: 0cm"><font size="4" style="font-size: 14pt">IPluginManager*

--- a/examples/dbcrypt/CryptKeyHolder.cpp
+++ b/examples/dbcrypt/CryptKeyHolder.cpp
@@ -298,7 +298,7 @@ Factory factory;
 
 } // anonymous namespace
 
-extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(IMaster* m)
+extern "C" FB_DLL_EXPORT void FB_PLUGIN_ENTRY_POINT(IMaster* m)
 {
 	master = m;
 	IPluginManager* pluginManager = master->getPluginManager();

--- a/examples/dbcrypt/DbCrypt.cpp
+++ b/examples/dbcrypt/DbCrypt.cpp
@@ -266,7 +266,7 @@ Factory factory;
 
 } // anonymous namespace
 
-extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(IMaster* master)
+extern "C" FB_DLL_EXPORT void FB_PLUGIN_ENTRY_POINT(IMaster* master)
 {
 	IPluginManager* pluginManager = master->getPluginManager();
 

--- a/examples/extauth/ExtAuth.cpp
+++ b/examples/extauth/ExtAuth.cpp
@@ -435,7 +435,7 @@ Factory<ExtAuthServer> serverFactory;
 } // anonymous namespace
 
 
-extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(IMaster* m)
+extern "C" FB_DLL_EXPORT void FB_PLUGIN_ENTRY_POINT(IMaster* m)
 {
 	master = m;
 	IPluginManager* pluginManager = master->getPluginManager();

--- a/examples/extauth/ExtAuth.cpp
+++ b/examples/extauth/ExtAuth.cpp
@@ -435,12 +435,6 @@ Factory<ExtAuthServer> serverFactory;
 } // anonymous namespace
 
 
-#if defined(_WIN32)
-#define FB_DLL_EXPORT __declspec(dllexport)
-#else
-#define FB_DLL_EXPORT
-#endif
-
 extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(IMaster* m)
 {
 	master = m;

--- a/examples/interfaces/ifaceExamples.h
+++ b/examples/interfaces/ifaceExamples.h
@@ -37,14 +37,6 @@ typedef int FbSampleAtomic;
 
 #include <firebird/Interface.h>
 
-#if defined(_WIN32)
-#define FB_DLL_EXPORT __declspec(dllexport)
-#elif defined(__APPLE__)
-#define FB_DLL_EXPORT __attribute__((visibility("default")))
-#else
-#define FB_DLL_EXPORT
-#endif
-
 using namespace Firebird;
 
 #define SAMPLES_DIALECT SQL_DIALECT_V6

--- a/examples/replication/fbSampleReplicator.cpp
+++ b/examples/replication/fbSampleReplicator.cpp
@@ -100,7 +100,7 @@ public:
 
 extern "C"
 {
-	void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(IMaster* m)
+	FB_DLL_EXPORT void FB_PLUGIN_ENTRY_POINT(IMaster* m)
 	{
 		master = m;
 		IPluginManager* pm = m->getPluginManager();

--- a/examples/replication/fbSampleReplicator.cpp
+++ b/examples/replication/fbSampleReplicator.cpp
@@ -100,14 +100,7 @@ public:
 
 extern "C"
 {
-#if defined(__WIN32__)
-	void __declspec(dllexport) FB_PLUGIN_ENTRY_POINT(IMaster* m);
-#else
-	void FB_PLUGIN_ENTRY_POINT(IMaster* m)
-		__attribute__((visibility("default")));
-#endif // __WIN32__
-
-	void FB_PLUGIN_ENTRY_POINT(IMaster* m)
+	void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(IMaster* m)
 	{
 		master = m;
 		IPluginManager* pm = m->getPluginManager();

--- a/src/auth/AuthDbg.cpp
+++ b/src/auth/AuthDbg.cpp
@@ -38,7 +38,7 @@
 static Firebird::SimpleFactory<Auth::DebugClient> clientFactory;
 static Firebird::SimpleFactory<Auth::DebugServer> serverFactory;
 
-extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
+extern "C" FB_DLL_EXPORT void FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
 {
 	Firebird::CachedMasterInterface::set(master);
 

--- a/src/auth/AuthDbg.cpp
+++ b/src/auth/AuthDbg.cpp
@@ -38,7 +38,7 @@
 static Firebird::SimpleFactory<Auth::DebugClient> clientFactory;
 static Firebird::SimpleFactory<Auth::DebugServer> serverFactory;
 
-extern "C" void FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
+extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
 {
 	Firebird::CachedMasterInterface::set(master);
 

--- a/src/auth/SecureRemotePassword/manage/SrpManagement.cpp
+++ b/src/auth/SecureRemotePassword/manage/SrpManagement.cpp
@@ -38,14 +38,6 @@
 #include "../common/classes/auto.h"
 #include "../common/classes/ParsedList.h"
 
-#ifndef FB_EXPORTED
-#if defined(DARWIN)
-#define FB_EXPORTED __attribute__((visibility("default")))
-#else
-#define FB_EXPORTED
-#endif // OS choice (DARWIN)
-#endif // FB_EXPORTED
-
 namespace {
 
 const unsigned int SZ_LOGIN = 31;
@@ -986,7 +978,7 @@ static Firebird::SimpleFactory<Auth::SrpManagement> factory;
 
 } // namespace Auth
 
-extern "C" void FB_EXPORTED FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
+extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
 {
 	Firebird::CachedMasterInterface::set(master);
 	Firebird::PluginManagerInterfacePtr()->registerPluginFactory(Firebird::IPluginManager::TYPE_AUTH_USER_MANAGEMENT, Auth::RemotePassword::plugName, &Auth::factory);

--- a/src/auth/SecureRemotePassword/manage/SrpManagement.cpp
+++ b/src/auth/SecureRemotePassword/manage/SrpManagement.cpp
@@ -978,7 +978,7 @@ static Firebird::SimpleFactory<Auth::SrpManagement> factory;
 
 } // namespace Auth
 
-extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
+extern "C" FB_DLL_EXPORT void FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
 {
 	Firebird::CachedMasterInterface::set(master);
 	Firebird::PluginManagerInterfacePtr()->registerPluginFactory(Firebird::IPluginManager::TYPE_AUTH_USER_MANAGEMENT, Auth::RemotePassword::plugName, &Auth::factory);

--- a/src/auth/SecurityDatabase/LegacyManagement.epp
+++ b/src/auth/SecurityDatabase/LegacyManagement.epp
@@ -762,7 +762,7 @@ int SecurityDatabaseManagement::execute(Firebird::CheckStatusWrapper* st, Firebi
 // register plugin
 static Firebird::SimpleFactory<Auth::SecurityDatabaseManagement> factory;
 
-extern "C" void FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
+extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
 {
 	Firebird::CachedMasterInterface::set(master);
 	Firebird::PluginManagerInterfacePtr()->registerPluginFactory(

--- a/src/auth/SecurityDatabase/LegacyManagement.epp
+++ b/src/auth/SecurityDatabase/LegacyManagement.epp
@@ -762,7 +762,7 @@ int SecurityDatabaseManagement::execute(Firebird::CheckStatusWrapper* st, Firebi
 // register plugin
 static Firebird::SimpleFactory<Auth::SecurityDatabaseManagement> factory;
 
-extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
+extern "C" FB_DLL_EXPORT void FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
 {
 	Firebird::CachedMasterInterface::set(master);
 	Firebird::PluginManagerInterfacePtr()->registerPluginFactory(

--- a/src/auth/SecurityDatabase/LegacyServer.cpp
+++ b/src/auth/SecurityDatabase/LegacyServer.cpp
@@ -411,7 +411,7 @@ void registerLegacyServer(IPluginManager* iPlugin)
 
 #ifdef PLUG_MODULE
 
-extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(IMaster* master)
+extern "C" FB_DLL_EXPORT void FB_PLUGIN_ENTRY_POINT(IMaster* master)
 {
 	CachedMasterInterface::set(master);
 

--- a/src/auth/SecurityDatabase/LegacyServer.cpp
+++ b/src/auth/SecurityDatabase/LegacyServer.cpp
@@ -411,7 +411,7 @@ void registerLegacyServer(IPluginManager* iPlugin)
 
 #ifdef PLUG_MODULE
 
-extern "C" void FB_EXPORTED FB_PLUGIN_ENTRY_POINT(IMaster* master)
+extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(IMaster* master)
 {
 	CachedMasterInterface::set(master);
 

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -252,7 +252,6 @@
 
 #define API_ROUTINE __attribute__((visibility("default")))
 #define API_ROUTINE_VARARG API_ROUTINE
-#define INTERNAL_API_ROUTINE API_ROUTINE
 
 #define O_DIRECT F_NOCACHE
 #endif /* Darwin Platforms */

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -253,7 +253,6 @@
 #define API_ROUTINE __attribute__((visibility("default")))
 #define API_ROUTINE_VARARG API_ROUTINE
 #define INTERNAL_API_ROUTINE API_ROUTINE
-#define FB_EXPORTED __attribute__((visibility("default")))
 
 #define O_DIRECT F_NOCACHE
 #endif /* Darwin Platforms */
@@ -601,10 +600,6 @@ extern "C" int remove(const char* path);
 
 #ifndef CLIB_ROUTINE
 #define CLIB_ROUTINE
-#endif
-
-#ifndef FB_EXPORTED
-#define FB_EXPORTED
 #endif
 
 #ifdef HAS_NOEXCEPT

--- a/src/extlib/ib_util.cpp
+++ b/src/extlib/ib_util.cpp
@@ -22,18 +22,16 @@
 #include "firebird.h"
 #include "ibase.h"
 
-typedef void* VoidPtr;
-
 
 // initialized by the engine
 static void* (*allocFunc)(long) = NULL;
 
-extern "C" void FB_DLL_EXPORT ib_util_init(void* (*aAllocFunc)(long))
+extern "C" FB_DLL_EXPORT void ib_util_init(void* (*aAllocFunc)(long))
 {
 	allocFunc = aAllocFunc;
 }
 
-extern "C" VoidPtr FB_DLL_EXPORT ib_util_malloc(long size)
+extern "C" FB_DLL_EXPORT void* ib_util_malloc(long size)
 {
 	return allocFunc ? allocFunc(size) : malloc(size);
 }

--- a/src/extlib/ib_util.cpp
+++ b/src/extlib/ib_util.cpp
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include "ib_util.h"
 #include "firebird.h"
+#include "ibase.h"
 
 typedef void* VoidPtr;
 
@@ -28,12 +29,12 @@ typedef void* VoidPtr;
 // initialized by the engine
 static void* (*allocFunc)(long) = NULL;
 
-extern "C" void FB_EXPORTED ib_util_init(void* (*aAllocFunc)(long))
+extern "C" void FB_DLL_EXPORT ib_util_init(void* (*aAllocFunc)(long))
 {
 	allocFunc = aAllocFunc;
 }
 
-extern "C" VoidPtr FB_EXPORTED ib_util_malloc(long size)
+extern "C" VoidPtr FB_DLL_EXPORT ib_util_malloc(long size)
 {
 	return allocFunc ? allocFunc(size) : malloc(size);
 }

--- a/src/extlib/ib_util.cpp
+++ b/src/extlib/ib_util.cpp
@@ -19,7 +19,6 @@
  */
 
 #include <stdlib.h>
-#include "ib_util.h"
 #include "firebird.h"
 #include "ibase.h"
 

--- a/src/include/firebird.h
+++ b/src/include/firebird.h
@@ -43,13 +43,6 @@
 #define DEBUG_GDS_ALLOC
 #endif
 
-#if defined(WIN_NT)
-#define FB_DLL_EXPORT __declspec(dllexport)
-#elif defined(DARWIN)
-#define FB_DLL_EXPORT API_ROUTINE
-#else
-#define FB_DLL_EXPORT
-#endif
 //#if defined(SOLX86)
 // this pragmas is used only with gcc 2.95!
 //#define __PRAGMA_REDEFINE_EXTNAME

--- a/src/include/firebird/UdrCppEngine.h
+++ b/src/include/firebird/UdrCppEngine.h
@@ -43,7 +43,7 @@
 		}	\
 	}	\
 	\
-	extern "C" FB_BOOLEAN* FB_UDR_PLUGIN_ENTRY_POINT(::Firebird::IStatus* status,	\
+	extern "C" FB_BOOLEAN* FB_DLL_EXPORT FB_UDR_PLUGIN_ENTRY_POINT(::Firebird::IStatus* status,	\
 		FB_BOOLEAN* theirUnloadFlag, ::Firebird::IUdrPlugin* udrPlugin)	\
 	{	\
 		::Firebird::Udr::FactoryRegistration::finish(status, udrPlugin);	\

--- a/src/include/firebird/UdrCppEngine.h
+++ b/src/include/firebird/UdrCppEngine.h
@@ -43,7 +43,7 @@
 		}	\
 	}	\
 	\
-	extern "C" FB_BOOLEAN* FB_DLL_EXPORT FB_UDR_PLUGIN_ENTRY_POINT(::Firebird::IStatus* status,	\
+	extern "C" FB_DLL_EXPORT FB_BOOLEAN* FB_UDR_PLUGIN_ENTRY_POINT(::Firebird::IStatus* status,	\
 		FB_BOOLEAN* theirUnloadFlag, ::Firebird::IUdrPlugin* udrPlugin)	\
 	{	\
 		::Firebird::Udr::FactoryRegistration::finish(status, udrPlugin);	\

--- a/src/include/ibase.h
+++ b/src/include/ibase.h
@@ -66,8 +66,12 @@
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__)
 #define FB_DLL_EXPORT __declspec(dllexport)
-#elif defined(__APPLE__) || defined(__linux__) || defined(unix) || defined(__unix__) || defined(__unix)
+#elif defined __has_attribute
+#if __has_attribute (visibility)
 #define FB_DLL_EXPORT __attribute__ ((visibility("default")))
+#else
+#define FB_DLL_EXPORT
+#endif
 #else
 #define FB_DLL_EXPORT
 #endif

--- a/src/include/ibase.h
+++ b/src/include/ibase.h
@@ -64,6 +64,14 @@
 #define FB_API_DEPRECATED
 #endif
 
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__)
+#define FB_DLL_EXPORT __declspec(dllexport)
+#elif defined(__APPLE__) || defined(__linux__) || defined(unix) || defined(__unix__) || defined(__unix)
+#define FB_DLL_EXPORT __attribute__ ((visibility("default")))
+#else
+#define FB_DLL_EXPORT
+#endif
+
 #include "./firebird/impl/types_pub.h"
 
 /***********************/

--- a/src/intl/ld.cpp
+++ b/src/intl/ld.cpp
@@ -468,7 +468,7 @@ struct
 };
 
 
-INTL_BOOL FB_DLL_EXPORT LD_lookup_charset(charset* cs, const ASCII* name, const ASCII* /*config_info*/)
+FB_DLL_EXPORT INTL_BOOL LD_lookup_charset(charset* cs, const ASCII* name, const ASCII* /*config_info*/)
 {
 	// ASF: We can't read config_info if version < INTL_VERSION_2,
 	// since it wasn't pushed in the stack by the engine.
@@ -491,7 +491,7 @@ INTL_BOOL FB_DLL_EXPORT LD_lookup_charset(charset* cs, const ASCII* name, const 
 }
 
 
-INTL_BOOL FB_DLL_EXPORT LD_lookup_texttype(texttype* tt, const ASCII* texttype_name, const ASCII* charset_name,
+FB_DLL_EXPORT INTL_BOOL LD_lookup_texttype(texttype* tt, const ASCII* texttype_name, const ASCII* charset_name,
 										   USHORT attributes, const UCHAR* specific_attributes,
 										   ULONG specific_attributes_length, INTL_BOOL ignore_attributes,
 										   const ASCII* config_info)
@@ -557,7 +557,7 @@ INTL_BOOL FB_DLL_EXPORT LD_lookup_texttype(texttype* tt, const ASCII* texttype_n
 }
 
 
-ULONG FB_DLL_EXPORT LD_setup_attributes(
+FB_DLL_EXPORT ULONG LD_setup_attributes(
 	const ASCII* textTypeName, const ASCII* charSetName, const ASCII* configInfo,
 	ULONG srcLen, const UCHAR* src, ULONG dstLen, UCHAR* dst)
 {
@@ -583,7 +583,7 @@ ULONG FB_DLL_EXPORT LD_setup_attributes(
 }
 
 
-void FB_DLL_EXPORT LD_version(USHORT* version)
+FB_DLL_EXPORT void LD_version(USHORT* version)
 {
 	// We support version 1 and 2.
 	if (*version != INTL_VERSION_1)

--- a/src/intl/ld.h
+++ b/src/intl/ld.h
@@ -55,14 +55,6 @@
 
 #define UINT16	USHORT
 
-#if defined(WIN_NT)
-#define FB_DLL_EXPORT __declspec(dllexport)
-#elif defined(DARWIN)
-#define FB_DLL_EXPORT API_ROUTINE
-#else
-#define FB_DLL_EXPORT
-#endif
-
 
 /* Following this line is LD.H from Borland Language Driver Kit */
 

--- a/src/intl/ld_proto.h
+++ b/src/intl/ld_proto.h
@@ -38,13 +38,13 @@ struct CsConvertImpl
 
 extern USHORT version;
 
-INTL_BOOL FB_DLL_EXPORT LD_lookup_charset(charset* cs, const ASCII* name, const ASCII* config_info);
-INTL_BOOL FB_DLL_EXPORT LD_lookup_texttype(texttype* tt, const ASCII* texttype_name, const ASCII* charset_name,
+FB_DLL_EXPORT INTL_BOOL LD_lookup_charset(charset* cs, const ASCII* name, const ASCII* config_info);
+FB_DLL_EXPORT INTL_BOOL LD_lookup_texttype(texttype* tt, const ASCII* texttype_name, const ASCII* charset_name,
 										   USHORT attributes, const UCHAR* specific_attributes,
 										   ULONG specific_attributes_length, INTL_BOOL ignore_attributes,
 										   const ASCII* config_info);
-void FB_DLL_EXPORT LD_version(USHORT* version);
-ULONG FB_DLL_EXPORT LD_setup_attributes(
+FB_DLL_EXPORT void LD_version(USHORT* version);
+FB_DLL_EXPORT ULONG LD_setup_attributes(
 	const ASCII* textTypeName, const ASCII* charSetName, const ASCII* configInfo,
 	ULONG srcLen, const UCHAR* src, ULONG dstLen, UCHAR* dst);
 

--- a/src/jrd/jrd.cpp
+++ b/src/jrd/jrd.cpp
@@ -465,7 +465,7 @@ void registerEngine(IPluginManager* iPlugin)
 
 } // namespace Jrd
 
-extern "C" void FB_EXPORTED FB_PLUGIN_ENTRY_POINT(IMaster* master)
+extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(IMaster* master)
 {
 	CachedMasterInterface::set(master);
 	registerEngine(PluginManagerInterfacePtr());

--- a/src/jrd/jrd.cpp
+++ b/src/jrd/jrd.cpp
@@ -465,7 +465,7 @@ void registerEngine(IPluginManager* iPlugin)
 
 } // namespace Jrd
 
-extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(IMaster* master)
+extern "C" FB_DLL_EXPORT void FB_PLUGIN_ENTRY_POINT(IMaster* master)
 {
 	CachedMasterInterface::set(master);
 	registerEngine(PluginManagerInterfacePtr());

--- a/src/plugins/crypt/chacha/ChaCha.cpp
+++ b/src/plugins/crypt/chacha/ChaCha.cpp
@@ -189,7 +189,7 @@ SimpleFactory<ChaCha<8> > factory64;
 
 } // anonymous namespace
 
-extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
+extern "C" FB_DLL_EXPORT void FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
 {
 	CachedMasterInterface::set(master);
 	PluginManagerInterfacePtr()->registerPluginFactory(IPluginManager::TYPE_WIRE_CRYPT, "ChaCha", &factory);

--- a/src/plugins/crypt/chacha/ChaCha.cpp
+++ b/src/plugins/crypt/chacha/ChaCha.cpp
@@ -189,7 +189,7 @@ SimpleFactory<ChaCha<8> > factory64;
 
 } // anonymous namespace
 
-extern "C" void FB_EXPORTED FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
+extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
 {
 	CachedMasterInterface::set(master);
 	PluginManagerInterfacePtr()->registerPluginFactory(IPluginManager::TYPE_WIRE_CRYPT, "ChaCha", &factory);

--- a/src/plugins/udr_engine/UdrEngine.cpp
+++ b/src/plugins/udr_engine/UdrEngine.cpp
@@ -718,7 +718,7 @@ class IExternalEngineFactoryImpl : public SimpleFactory<Engine>
 {
 } factory;
 
-extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(IMaster* master)
+extern "C" FB_DLL_EXPORT void FB_PLUGIN_ENTRY_POINT(IMaster* master)
 {
 	CachedMasterInterface::set(master);
 

--- a/src/plugins/udr_engine/UdrEngine.cpp
+++ b/src/plugins/udr_engine/UdrEngine.cpp
@@ -718,7 +718,7 @@ class IExternalEngineFactoryImpl : public SimpleFactory<Engine>
 {
 } factory;
 
-extern "C" void FB_EXPORTED FB_PLUGIN_ENTRY_POINT(IMaster* master)
+extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(IMaster* master)
 {
 	CachedMasterInterface::set(master);
 

--- a/src/remote/client/interface.cpp
+++ b/src/remote/client/interface.cpp
@@ -1046,7 +1046,7 @@ void registerRedirector(Firebird::IPluginManager* iPlugin)
 } // namespace Remote
 
 /*
-extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(IMaster* master)
+extern "C" FB_DLL_EXPORT void FB_PLUGIN_ENTRY_POINT(IMaster* master)
 {
 	IPluginManager* pi = master->getPluginManager();
 	registerRedirector(pi);

--- a/src/remote/client/interface.cpp
+++ b/src/remote/client/interface.cpp
@@ -1046,7 +1046,7 @@ void registerRedirector(Firebird::IPluginManager* iPlugin)
 } // namespace Remote
 
 /*
-extern "C" void FB_PLUGIN_ENTRY_POINT(IMaster* master)
+extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(IMaster* master)
 {
 	IPluginManager* pi = master->getPluginManager();
 	registerRedirector(pi);

--- a/src/utilities/ntrace/traceplugin.cpp
+++ b/src/utilities/ntrace/traceplugin.cpp
@@ -115,7 +115,7 @@ void registerTrace(Firebird::IPluginManager* iPlugin)
 }
 
 
-extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
+extern "C" FB_DLL_EXPORT void FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
 {
 	Firebird::CachedMasterInterface::set(master);
 	registerTrace(Firebird::PluginManagerInterfacePtr());

--- a/src/utilities/ntrace/traceplugin.cpp
+++ b/src/utilities/ntrace/traceplugin.cpp
@@ -115,7 +115,7 @@ void registerTrace(Firebird::IPluginManager* iPlugin)
 }
 
 
-extern "C" void FB_EXPORTED FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
+extern "C" void FB_DLL_EXPORT FB_PLUGIN_ENTRY_POINT(Firebird::IMaster* master)
 {
 	Firebird::CachedMasterInterface::set(master);
 	registerTrace(Firebird::PluginManagerInterfacePtr());

--- a/src/yvalve/gds.cpp
+++ b/src/yvalve/gds.cpp
@@ -3977,13 +3977,13 @@ static void sanitize(Firebird::string& locale)
 }
 
 
-void FB_EXPORTED gds__default_printer(void* /*arg*/, SSHORT offset, const TEXT* line)
+void FB_DLL_EXPORT gds__default_printer(void* /*arg*/, SSHORT offset, const TEXT* line)
 {
 	printf("%4d %s\n", offset, line);
 }
 
 
-void FB_EXPORTED gds__trace_printer(void* /*arg*/, SSHORT offset, const TEXT* line)
+void FB_DLL_EXPORT gds__trace_printer(void* /*arg*/, SSHORT offset, const TEXT* line)
 {
 	// Assume that line is not too long
 	char buffer[PRETTY_BUFFER_SIZE + 10];

--- a/src/yvalve/gds.cpp
+++ b/src/yvalve/gds.cpp
@@ -3977,13 +3977,13 @@ static void sanitize(Firebird::string& locale)
 }
 
 
-void FB_DLL_EXPORT gds__default_printer(void* /*arg*/, SSHORT offset, const TEXT* line)
+void API_ROUTINE_VARARG gds__default_printer(void* /*arg*/, SSHORT offset, const TEXT* line)
 {
 	printf("%4d %s\n", offset, line);
 }
 
 
-void FB_DLL_EXPORT gds__trace_printer(void* /*arg*/, SSHORT offset, const TEXT* line)
+void API_ROUTINE_VARARG gds__trace_printer(void* /*arg*/, SSHORT offset, const TEXT* line)
 {
 	// Assume that line is not too long
 	char buffer[PRETTY_BUFFER_SIZE + 10];

--- a/src/yvalve/gds_proto.h
+++ b/src/yvalve/gds_proto.h
@@ -134,8 +134,10 @@ SINT64	API_ROUTINE isc_portable_integer(const UCHAR*, SSHORT);
 void	gds__cleanup();
 void	gds__ulstr(char* buffer, FB_UINT64 value, const int minlen, const char filler);
 
-void	gds__default_printer(void*, SSHORT, const TEXT*);
-void	gds__trace_printer(void*, SSHORT, const TEXT*);
+// These functions uses cdecl convention in Windows, so use API_ROUTINE_VARARG instead of API_ROUTINE (stdcall).
+void	API_ROUTINE_VARARG gds__default_printer(void*, SSHORT, const TEXT*);
+void	API_ROUTINE_VARARG gds__trace_printer(void*, SSHORT, const TEXT*);
+
 #ifdef NOT_USED_OR_REPLACED
 void	gds__print_pool(Firebird::MemoryPool*, const TEXT*, ...);
 #endif

--- a/src/yvalve/gds_proto.h
+++ b/src/yvalve/gds_proto.h
@@ -134,8 +134,8 @@ SINT64	API_ROUTINE isc_portable_integer(const UCHAR*, SSHORT);
 void	gds__cleanup();
 void	gds__ulstr(char* buffer, FB_UINT64 value, const int minlen, const char filler);
 
-void	FB_EXPORTED gds__default_printer(void*, SSHORT, const TEXT*);
-void	FB_EXPORTED gds__trace_printer(void*, SSHORT, const TEXT*);
+void	gds__default_printer(void*, SSHORT, const TEXT*);
+void	gds__trace_printer(void*, SSHORT, const TEXT*);
 #ifdef NOT_USED_OR_REPLACED
 void	gds__print_pool(Firebird::MemoryPool*, const TEXT*, ...);
 #endif


### PR DESCRIPTION
Add FB_DLL_EXPORT to public headers.

Use default visibility also for Linux/Unix (in addition to MacOS) as
user application can also be compiled with -fvisibility=hidden.