### PR TITLE
Fix #7087: Database downgrade via gbak may be broken

### DIFF
--- a/src/burp/backup.epp
+++ b/src/burp/backup.epp
@@ -1961,6 +1961,7 @@ void put_boolean(att_type attribute, const FB_BOOLEAN value)
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 
 	put(tdgbl, attribute);
+	put(tdgbl, (UCHAR) 1);
 	put(tdgbl, value ? 1u : 0u);
 }
 

--- a/src/burp/burp.h
+++ b/src/burp/burp.h
@@ -252,7 +252,7 @@ enum att_type {
 	att_SQL_dialect,		// SQL dialect that it speaks
 	att_db_read_only,		// Is the database ReadOnly?
 	att_database_linger,	// Disconnection timeout
-	att_database_sql_security_depricated,	// can be removed later
+	att_database_sql_security_deprecated,	// can be removed later
 	att_replica_mode,		// replica mode
 	att_database_sql_security,	// default sql security value
 
@@ -276,7 +276,7 @@ enum att_type {
 	att_relation_flags,
 	att_relation_ext_file_name, // name of file for external tables
 	att_relation_type,
-	att_relation_sql_security_depricated,	// can be removed later
+	att_relation_sql_security_deprecated,	// can be removed later
 	att_relation_sql_security,
 
 	// Field attributes (used for both global and local fields)
@@ -411,7 +411,7 @@ enum att_type {
 	att_trig_engine_name,
 	att_trig_entrypoint,
 	att_trig_type2,
-	att_trig_sql_security_depricated,	// can be removed later
+	att_trig_sql_security_deprecated,	// can be removed later
 	att_trig_sql_security,
 
 	// Function attributes
@@ -436,7 +436,7 @@ enum att_type {
 	att_function_owner_name,
 	att_function_legacy_flag,
 	att_function_deterministic_flag,
-	att_function_sql_security_depricated,	// can be removed later
+	att_function_sql_security_deprecated,	// can be removed later
 	att_function_sql_security,
 
 	// Function argument attributes
@@ -533,7 +533,7 @@ enum att_type {
 	att_procedure_entrypoint,
 	att_procedure_package_name,
 	att_procedure_private_flag,
-	att_procedure_sql_security_depricated,	// can be removed later
+	att_procedure_sql_security_deprecated,	// can be removed later
 	att_procedure_sql_security,
 
 	// Stored procedure parameter attributes
@@ -635,7 +635,7 @@ enum att_type {
 	att_package_security_class,
 	att_package_owner_name,
 	att_package_description,
-	att_package_sql_security_depricated,	// can be removed later
+	att_package_sql_security_deprecated,	// can be removed later
 	att_package_sql_security,
 
 	// Database creators

--- a/src/burp/burp.h
+++ b/src/burp/burp.h
@@ -252,8 +252,9 @@ enum att_type {
 	att_SQL_dialect,		// SQL dialect that it speaks
 	att_db_read_only,		// Is the database ReadOnly?
 	att_database_linger,	// Disconnection timeout
-	att_database_sql_security,// default sql security value
+	att_database_sql_security_depricated,	// can be removed later
 	att_replica_mode,		// replica mode
+	att_database_sql_security,	// default sql security value
 
 	// Relation attributes
 
@@ -275,6 +276,7 @@ enum att_type {
 	att_relation_flags,
 	att_relation_ext_file_name, // name of file for external tables
 	att_relation_type,
+	att_relation_sql_security_depricated,	// can be removed later
 	att_relation_sql_security,
 
 	// Field attributes (used for both global and local fields)
@@ -409,6 +411,7 @@ enum att_type {
 	att_trig_engine_name,
 	att_trig_entrypoint,
 	att_trig_type2,
+	att_trig_sql_security_depricated,	// can be removed later
 	att_trig_sql_security,
 
 	// Function attributes
@@ -433,6 +436,7 @@ enum att_type {
 	att_function_owner_name,
 	att_function_legacy_flag,
 	att_function_deterministic_flag,
+	att_function_sql_security_depricated,	// can be removed later
 	att_function_sql_security,
 
 	// Function argument attributes
@@ -529,6 +533,7 @@ enum att_type {
 	att_procedure_entrypoint,
 	att_procedure_package_name,
 	att_procedure_private_flag,
+	att_procedure_sql_security_depricated,	// can be removed later
 	att_procedure_sql_security,
 
 	// Stored procedure parameter attributes
@@ -630,6 +635,7 @@ enum att_type {
 	att_package_security_class,
 	att_package_owner_name,
 	att_package_description,
+	att_package_sql_security_depricated,	// can be removed later
 	att_package_sql_security,
 
 	// Database creators

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -192,8 +192,13 @@ static inline UCHAR get(BurpGlobals* tdgbl)
 	return tdgbl->get();
 }
 
-static inline FB_BOOLEAN get_boolean(BurpGlobals* tdgbl)
+static inline FB_BOOLEAN get_boolean(BurpGlobals* tdgbl, bool depricated)
 {
+	if (!depricated)
+	{
+		const UCHAR length = get(tdgbl);
+		fb_assert(length == 1);
+	}
 	return get(tdgbl) ? FB_TRUE : FB_FALSE;
 }
 
@@ -5142,10 +5147,11 @@ bool get_function(BurpGlobals* tdgbl)
 						bad_attribute(scan_next_attr, attribute, 89);
 					break;
 
+				case att_function_sql_security_depricated:
 				case att_function_sql_security:
 					if (tdgbl->RESTORE_format >= 11)
 					{
-						X.RDB$SQL_SECURITY = get_boolean(tdgbl);
+						X.RDB$SQL_SECURITY = get_boolean(tdgbl, attribute == att_function_sql_security_depricated);
 						X.RDB$SQL_SECURITY.NULL = FALSE;
 					}
 					else
@@ -5274,9 +5280,10 @@ bool get_function(BurpGlobals* tdgbl)
 						bad_attribute(scan_next_attr, attribute, 89);
 					break;
 
+				case att_function_sql_security_depricated:
 				case att_function_sql_security:
 					if (tdgbl->RESTORE_format >= 11)
-						get_boolean(tdgbl);
+						get_boolean(tdgbl, attribute == att_function_sql_security_depricated);
 					else
 						bad_attribute(scan_next_attr, attribute, 89);
 					break;
@@ -7417,10 +7424,11 @@ bool get_package(BurpGlobals* tdgbl)
 				X.RDB$DESCRIPTION.NULL = FALSE;
 				break;
 
+			case att_package_sql_security_depricated:
 			case att_package_sql_security:
 				if (tdgbl->RESTORE_format >= 11)
 				{
-					X.RDB$SQL_SECURITY = get_boolean(tdgbl);
+					X.RDB$SQL_SECURITY = get_boolean(tdgbl, attribute == att_package_sql_security_depricated);
 					X.RDB$SQL_SECURITY.NULL = FALSE;
 				}
 				else
@@ -7634,10 +7642,11 @@ bool get_procedure(BurpGlobals* tdgbl)
 						bad_attribute(scan_next_attr, attribute, 290);
 					break;
 
+				case att_procedure_sql_security_depricated:
 				case att_procedure_sql_security:
 					if (tdgbl->RESTORE_format >= 11)
 					{
-						X.RDB$SQL_SECURITY = get_boolean(tdgbl);
+						X.RDB$SQL_SECURITY = get_boolean(tdgbl, attribute == att_procedure_sql_security_depricated);
 						X.RDB$SQL_SECURITY.NULL = FALSE;
 					}
 					else
@@ -7759,9 +7768,10 @@ bool get_procedure(BurpGlobals* tdgbl)
 						bad_attribute(scan_next_attr, attribute, 290);
 					break;
 
+				case att_procedure_sql_security_depricated:
 				case att_procedure_sql_security:
 					if (tdgbl->RESTORE_format >= 11)
-						get_boolean(tdgbl);
+						get_boolean(tdgbl, attribute == att_procedure_sql_security_depricated);
 					else
 						bad_attribute(scan_next_attr, attribute, 290);
 					break;
@@ -8443,9 +8453,10 @@ bool get_relation(BurpGlobals* tdgbl)
 				bad_attribute(scan_next_attr, attribute, 111);
 			break;
 
+		case att_relation_sql_security_depricated:
 		case att_relation_sql_security:
 			sql_security_null = false;
-			sql_security = get_boolean(tdgbl);
+			sql_security = get_boolean(tdgbl, attribute == att_relation_sql_security_depricated);
 			break;
 
 		default:
@@ -9784,10 +9795,11 @@ bool get_trigger(BurpGlobals* tdgbl)
 						bad_attribute(scan_next_attr, attribute, 134);
 					break;
 
+				case att_trig_sql_security_depricated:
 				case att_trig_sql_security:
 					if (tdgbl->RESTORE_format >= 11)
 					{
-						X.RDB$SQL_SECURITY = get_boolean(tdgbl);
+						X.RDB$SQL_SECURITY = get_boolean(tdgbl, attribute == att_trig_sql_security_depricated);
 						X.RDB$SQL_SECURITY.NULL = FALSE;
 					}
 					else
@@ -9930,9 +9942,10 @@ bool get_trigger(BurpGlobals* tdgbl)
 						bad_attribute(scan_next_attr, attribute, 134);
 					break;
 
+				case att_trig_sql_security_depricated:
 				case att_trig_sql_security:
 					if (tdgbl->RESTORE_format >= 11)
-						get_boolean(tdgbl);
+						get_boolean(tdgbl, attribute == att_trig_sql_security_depricated);
 					else
 						bad_attribute(scan_next_attr, attribute, 134);
 					break;
@@ -11009,6 +11022,7 @@ bool restore(BurpGlobals* tdgbl, Firebird::IProvider* provider, const TEXT* file
 			}
 			break;
 
+		case att_database_sql_security_depricated:
 		case att_database_sql_security:
 			if (tdgbl->RESTORE_format >= 11)
 			{
@@ -11017,7 +11031,7 @@ bool restore(BurpGlobals* tdgbl, Firebird::IProvider* provider, const TEXT* file
 					FOR (REQUEST_HANDLE req_handle5)
 						X IN RDB$DATABASE
 						MODIFY X USING
-							X.RDB$SQL_SECURITY = get_boolean(tdgbl);
+							X.RDB$SQL_SECURITY = get_boolean(tdgbl, attribute == att_database_sql_security_depricated);
 						END_MODIFY;
 						ON_ERROR
 							general_on_error();
@@ -11028,7 +11042,7 @@ bool restore(BurpGlobals* tdgbl, Firebird::IProvider* provider, const TEXT* file
 					END_ERROR;
 				}
 				else
-					get_boolean(tdgbl);
+					get_boolean(tdgbl, attribute == att_database_sql_security_depricated);
 			}
 			else
 			{

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -192,9 +192,9 @@ static inline UCHAR get(BurpGlobals* tdgbl)
 	return tdgbl->get();
 }
 
-static inline FB_BOOLEAN get_boolean(BurpGlobals* tdgbl, bool depricated)
+static inline FB_BOOLEAN get_boolean(BurpGlobals* tdgbl, bool deprecated)
 {
-	if (!depricated)
+	if (!deprecated)
 	{
 		const UCHAR length = get(tdgbl);
 		fb_assert(length == 1);
@@ -5147,11 +5147,11 @@ bool get_function(BurpGlobals* tdgbl)
 						bad_attribute(scan_next_attr, attribute, 89);
 					break;
 
-				case att_function_sql_security_depricated:
+				case att_function_sql_security_deprecated:
 				case att_function_sql_security:
 					if (tdgbl->RESTORE_format >= 11)
 					{
-						X.RDB$SQL_SECURITY = get_boolean(tdgbl, attribute == att_function_sql_security_depricated);
+						X.RDB$SQL_SECURITY = get_boolean(tdgbl, attribute == att_function_sql_security_deprecated);
 						X.RDB$SQL_SECURITY.NULL = FALSE;
 					}
 					else
@@ -5280,10 +5280,10 @@ bool get_function(BurpGlobals* tdgbl)
 						bad_attribute(scan_next_attr, attribute, 89);
 					break;
 
-				case att_function_sql_security_depricated:
+				case att_function_sql_security_deprecated:
 				case att_function_sql_security:
 					if (tdgbl->RESTORE_format >= 11)
-						get_boolean(tdgbl, attribute == att_function_sql_security_depricated);
+						get_boolean(tdgbl, attribute == att_function_sql_security_deprecated);
 					else
 						bad_attribute(scan_next_attr, attribute, 89);
 					break;
@@ -7424,11 +7424,11 @@ bool get_package(BurpGlobals* tdgbl)
 				X.RDB$DESCRIPTION.NULL = FALSE;
 				break;
 
-			case att_package_sql_security_depricated:
+			case att_package_sql_security_deprecated:
 			case att_package_sql_security:
 				if (tdgbl->RESTORE_format >= 11)
 				{
-					X.RDB$SQL_SECURITY = get_boolean(tdgbl, attribute == att_package_sql_security_depricated);
+					X.RDB$SQL_SECURITY = get_boolean(tdgbl, attribute == att_package_sql_security_deprecated);
 					X.RDB$SQL_SECURITY.NULL = FALSE;
 				}
 				else
@@ -7642,11 +7642,11 @@ bool get_procedure(BurpGlobals* tdgbl)
 						bad_attribute(scan_next_attr, attribute, 290);
 					break;
 
-				case att_procedure_sql_security_depricated:
+				case att_procedure_sql_security_deprecated:
 				case att_procedure_sql_security:
 					if (tdgbl->RESTORE_format >= 11)
 					{
-						X.RDB$SQL_SECURITY = get_boolean(tdgbl, attribute == att_procedure_sql_security_depricated);
+						X.RDB$SQL_SECURITY = get_boolean(tdgbl, attribute == att_procedure_sql_security_deprecated);
 						X.RDB$SQL_SECURITY.NULL = FALSE;
 					}
 					else
@@ -7768,10 +7768,10 @@ bool get_procedure(BurpGlobals* tdgbl)
 						bad_attribute(scan_next_attr, attribute, 290);
 					break;
 
-				case att_procedure_sql_security_depricated:
+				case att_procedure_sql_security_deprecated:
 				case att_procedure_sql_security:
 					if (tdgbl->RESTORE_format >= 11)
-						get_boolean(tdgbl, attribute == att_procedure_sql_security_depricated);
+						get_boolean(tdgbl, attribute == att_procedure_sql_security_deprecated);
 					else
 						bad_attribute(scan_next_attr, attribute, 290);
 					break;
@@ -8453,10 +8453,10 @@ bool get_relation(BurpGlobals* tdgbl)
 				bad_attribute(scan_next_attr, attribute, 111);
 			break;
 
-		case att_relation_sql_security_depricated:
+		case att_relation_sql_security_deprecated:
 		case att_relation_sql_security:
 			sql_security_null = false;
-			sql_security = get_boolean(tdgbl, attribute == att_relation_sql_security_depricated);
+			sql_security = get_boolean(tdgbl, attribute == att_relation_sql_security_deprecated);
 			break;
 
 		default:
@@ -9795,11 +9795,11 @@ bool get_trigger(BurpGlobals* tdgbl)
 						bad_attribute(scan_next_attr, attribute, 134);
 					break;
 
-				case att_trig_sql_security_depricated:
+				case att_trig_sql_security_deprecated:
 				case att_trig_sql_security:
 					if (tdgbl->RESTORE_format >= 11)
 					{
-						X.RDB$SQL_SECURITY = get_boolean(tdgbl, attribute == att_trig_sql_security_depricated);
+						X.RDB$SQL_SECURITY = get_boolean(tdgbl, attribute == att_trig_sql_security_deprecated);
 						X.RDB$SQL_SECURITY.NULL = FALSE;
 					}
 					else
@@ -9942,10 +9942,10 @@ bool get_trigger(BurpGlobals* tdgbl)
 						bad_attribute(scan_next_attr, attribute, 134);
 					break;
 
-				case att_trig_sql_security_depricated:
+				case att_trig_sql_security_deprecated:
 				case att_trig_sql_security:
 					if (tdgbl->RESTORE_format >= 11)
-						get_boolean(tdgbl, attribute == att_trig_sql_security_depricated);
+						get_boolean(tdgbl, attribute == att_trig_sql_security_deprecated);
 					else
 						bad_attribute(scan_next_attr, attribute, 134);
 					break;
@@ -11022,7 +11022,7 @@ bool restore(BurpGlobals* tdgbl, Firebird::IProvider* provider, const TEXT* file
 			}
 			break;
 
-		case att_database_sql_security_depricated:
+		case att_database_sql_security_deprecated:
 		case att_database_sql_security:
 			if (tdgbl->RESTORE_format >= 11)
 			{
@@ -11031,7 +11031,7 @@ bool restore(BurpGlobals* tdgbl, Firebird::IProvider* provider, const TEXT* file
 					FOR (REQUEST_HANDLE req_handle5)
 						X IN RDB$DATABASE
 						MODIFY X USING
-							X.RDB$SQL_SECURITY = get_boolean(tdgbl, attribute == att_database_sql_security_depricated);
+							X.RDB$SQL_SECURITY = get_boolean(tdgbl, attribute == att_database_sql_security_deprecated);
 						END_MODIFY;
 						ON_ERROR
 							general_on_error();
@@ -11042,7 +11042,7 @@ bool restore(BurpGlobals* tdgbl, Firebird::IProvider* provider, const TEXT* file
 					END_ERROR;
 				}
 				else
-					get_boolean(tdgbl, attribute == att_database_sql_security_depricated);
+					get_boolean(tdgbl, attribute == att_database_sql_security_deprecated);
 			}
 			else
 			{


### PR DESCRIPTION
Depricate existing boolean attributes.
Add length in {put/get}_boolean functions.
Add compatibility to read depricated attributes from earlier backups.