### PR TITLE
Assertion failure when tracing is enabled

### DIFF
--- a/src/dsql/DsqlRequests.h
+++ b/src/dsql/DsqlRequests.h
@@ -241,6 +241,11 @@ public:
 		Firebird::IMessageMetadata* outMetadata, UCHAR* outMsg,
 		bool singleton) override;
 
+	bool isDml() const override
+	{
+		return true;
+	}
+
 private:
 	NestConst<TransactionNode> node;
 };


### PR DESCRIPTION
In the debug build I got the following error:
`Assertion (false) failure: ..\..\..\src\jrd\trace\TraceObjects.cpp 239`
when I tried to create a database via isql with the following trace configuration:
```
database
{
	enabled = true
	log_statement_start = true
	log_statement_finish = true
	time_threshold = 0
}
```
This started happening after a recent refactoring. So I tried to fix the problem.