### PR TITLE
Fix #7129 alter package SQL SECURITY option reset

### DIFF
--- a/src/dsql/PackageNodes.epp
+++ b/src/dsql/PackageNodes.epp
@@ -432,6 +432,8 @@ bool CreateAlterPackageNode::executeAlter(thread_db* tdbb, DsqlCompilerScratch* 
 				PKG.RDB$SQL_SECURITY.NULL = FALSE;
 				PKG.RDB$SQL_SECURITY = ssDefiner.value ? FB_TRUE : FB_FALSE;
 			}
+			else
+				PKG.RDB$SQL_SECURITY.NULL = TRUE;
 		END_MODIFY
 
 		owner = PKG.RDB$OWNER_NAME;


### PR DESCRIPTION
Fix setting package's RDB$SQL_SECURITY to null if SQL SECURITY option not set on ALTER PACKAGE forcing it to use default value.