### PR TITLE
Fix crash when accessing already cleared memory in the sorting module

### DIFF
--- a/src/jrd/sort.cpp
+++ b/src/jrd/sort.cpp
@@ -689,10 +689,11 @@ void Sort::releaseBuffer()
 
 	SyncLockGuard guard(&m_dbb->dbb_sortbuf_sync, SYNC_EXCLUSIVE, "Sort::releaseBuffer");
 
-	if (m_size_memory == MAX_SORT_BUFFER_SIZE &&
-		(m_flags & scb_reuse_buffer) &&
+	if ((m_flags & scb_reuse_buffer) &&
 		m_dbb->dbb_sort_buffers.getCount() < MAX_CACHED_SORT_BUFFERS)
 	{
+		fb_assert(m_size_memory == MAX_SORT_BUFFER_SIZE);
+
 		m_dbb->dbb_sort_buffers.push(m_memory);
 	}
 	else

--- a/src/jrd/sort.cpp
+++ b/src/jrd/sort.cpp
@@ -200,7 +200,7 @@ Sort::Sort(Database* dbb,
 		m_longs = record_size >> SHIFTLONG;
 
 		m_min_alloc_size = record_size * MIN_RECORDS_TO_ALLOC;
-		m_max_alloc_size = MAX(record_size * MIN_RECORDS_TO_ALLOC, MAX_SORT_BUFFER_SIZE);
+		m_max_alloc_size = MAX(m_min_alloc_size, MAX_SORT_BUFFER_SIZE);
 
 		m_dup_callback = call_back;
 		m_dup_callback_arg = user_arg;
@@ -639,6 +639,7 @@ void Sort::allocateBuffer(MemoryPool& pool)
 			// The sort buffer cache has at least one big block, let's use it
 			m_size_memory = MAX_SORT_BUFFER_SIZE;
 			m_memory = m_dbb->dbb_sort_buffers.pop();
+			m_flags |= scb_reuse_buffer;
 			return;
 		}
 	}
@@ -655,6 +656,7 @@ void Sort::allocateBuffer(MemoryPool& pool)
 	{
 		m_size_memory = m_max_alloc_size;
 		m_memory = FB_NEW_POOL(*m_dbb->dbb_permanent) UCHAR[m_size_memory];
+		m_flags |= scb_reuse_buffer;
 	}
 	catch (const BadAlloc&)
 	{
@@ -666,6 +668,7 @@ void Sort::allocateBuffer(MemoryPool& pool)
 			{
 				m_size_memory /= 2;
 				m_memory = FB_NEW_POOL(pool) UCHAR[m_size_memory];
+				m_flags &= ~scb_reuse_buffer;
 				break;
 			}
 			catch (const BadAlloc&)
@@ -687,6 +690,7 @@ void Sort::releaseBuffer()
 	SyncLockGuard guard(&m_dbb->dbb_sortbuf_sync, SYNC_EXCLUSIVE, "Sort::releaseBuffer");
 
 	if (m_size_memory == MAX_SORT_BUFFER_SIZE &&
+		(m_flags & scb_reuse_buffer) &&
 		m_dbb->dbb_sort_buffers.getCount() < MAX_CACHED_SORT_BUFFERS)
 	{
 		m_dbb->dbb_sort_buffers.push(m_memory);

--- a/src/jrd/sort.h
+++ b/src/jrd/sort.h
@@ -336,6 +336,7 @@ private:
 // flags as set in m_flags
 
 const int scb_sorted = 1;	// stream has been sorted
+const int scb_reuse_buffer = 2;	// reuse buffer if possible
 
 class SortOwner
 {


### PR DESCRIPTION
Fix crash when accessing already cleared memory. In the following case:
- specific record size;
- the maximum size of the allocated map buffer is greater than MAX_SORT_BUFFER_SIZE;
- unable to allocate memory in dbb_permament pool, throw BadAlloc exception;
- buffer of size MAX_SORT_BUFFER_SIZE must be allocated in the owner's pool.

In the Sort::releaseBuffer procedure, the allocated buffer goes into the dbb_sort_buffers cache.
After the request is completed, the owner's pool is cleared and the pointer in dbb_sort_buffers cache will be corrupted. The next request, which will take the buffer from cache, throw with error.