### PR TITLE
Fix a bug when it was not allowed to execute DROP PACKAGE BODY for a package with a procedure even if a user has DROP ANY PACKAGE privilege

### DIFF
--- a/src/jrd/vio.cpp
+++ b/src/jrd/vio.cpp
@@ -2945,18 +2945,19 @@ bool VIO_modify(thread_db* tdbb, record_param* org_rpb, record_param* new_rpb, j
 			break;
 
 		case rel_procedures:
+			EVL_field(0, org_rpb->rpb_record, f_prc_name, &desc1);
 			if (!check_nullify_source(tdbb, org_rpb, new_rpb, f_prc_source))
 				protect_system_table_delupd(tdbb, relation, "UPDATE");
-
-			EVL_field(0, org_rpb->rpb_record, f_prc_name, &desc1);
-
-			if (EVL_field(0, org_rpb->rpb_record, f_prc_pkg_name, &desc2))
-			{
-				MOV_get_metaname(tdbb, &desc2, package_name);
-				SCL_check_package(tdbb, &desc2, SCL_alter);
-			}
 			else
-				SCL_check_procedure(tdbb, &desc1, SCL_alter);
+			{
+				if (EVL_field(0, org_rpb->rpb_record, f_prc_pkg_name, &desc2))
+				{
+					MOV_get_metaname(tdbb, &desc2, package_name);
+					SCL_check_package(tdbb, &desc2, SCL_alter);
+				}
+				else
+					SCL_check_procedure(tdbb, &desc1, SCL_alter);
+			}
 
 			check_class(tdbb, transaction, org_rpb, new_rpb, f_prc_class);
 			check_owner(tdbb, transaction, org_rpb, new_rpb, f_prc_owner);


### PR DESCRIPTION
How to reproduce:
1. `./isql -u sysdba -p masterkey`
```
CREATE DATABASE 'localhost:/tmp/data.fdb';

CREATE USER PackUser PASSWORD 'pass';

GRANT DROP ANY PACKAGE TO PackUser;
commit;

set term !;
CREATE PACKAGE TEST_DDL_PACK
AS BEGIN
PROCEDURE PROC1() RETURNS(C INTEGER);
END!

CREATE PACKAGE BODY TEST_DDL_PACK
AS BEGIN
PROCEDURE PROC1() RETURNS(C INTEGER)
  AS BEGIN
    c = 123;
    SUSPEND;
  END
END!
set term ;!`
```
2. `./isql localhost:/tmp/data.fdb -u PackUser -p pass`
```
SQL> DROP PACKAGE BODY TEST_DDL_PACK;
Statement failed, SQLSTATE = 28000
unsuccessful metadata update
-DROP PACKAGE BODY TEST_DDL_PACK failed
-no permission for ALTER access to PACKAGE TEST_DDL_PACK
-Effective user is PACKUSER
SQL> DROP PACKAGE TEST_DDL_PACK;
SQL> quit;
```
If a procedure is replaced by a function, there will be no error. The problem is in VIO_modify. I have no idea why the code in `case rel_procedures` differs from `case rel_funs`. Probably it was a mistake.