### PR TITLE
Do not allow the AST thread to release EX lock on a relation while it's in the deleting state

### DIFF
--- a/src/jrd/dfw.epp
+++ b/src/jrd/dfw.epp
@@ -4955,6 +4955,7 @@ static bool delete_relation(thread_db* tdbb, SSHORT phase, DeferredWork* work, j
 	case 4:
 		relation = MET_lookup_relation_id(tdbb, work->dfw_id, true);
 		if (!relation) {
+			fb_assert(false);
 			return false;
 		}
 

--- a/src/jrd/met.epp
+++ b/src/jrd/met.epp
@@ -4468,7 +4468,7 @@ static int blocking_ast_relation(void* ast_object)
 
 			if (relation->rel_use_count)
 				relation->rel_flags |= REL_blocking;
-			else
+			else if (!(relation->rel_flags & REL_deleting))
 			{
 				relation->rel_flags &= ~REL_blocking;
 				relation->rel_flags |= REL_check_existence;


### PR DESCRIPTION
The problem is rarely reproduced by bugs.core_2879 test. Without the fix the phase 4 of delete_relation DFW may fail because MET_lookup_relation_id cannot find a relation.