### PR TITLE
Explicitly set up architecture macros for FreeBSD

### DIFF
--- a/src/common/common.h
+++ b/src/common/common.h
@@ -269,7 +269,7 @@
 
 
 /*****************************************************
-* FreeBSD for Intel platforms
+* FreeBSD
 *****************************************************/
 #ifdef FREEBSD
 
@@ -281,7 +281,13 @@
 
 #ifdef AMD64
 #define FB_CPU CpuAmd
-#else
+#endif
+
+#ifdef PPC64EL
+#define FB_CPU CpuPowerPc64el
+#endif
+
+#if defined(i386) || defined(__i386) || defined(__i386__)
 #define I386
 #define FB_CPU CpuIntel
 #endif


### PR DESCRIPTION
While firebird currently seems to work fine on FreeBSD/powerpc64le, it's probably safer to set up explicitly in `common.h`.