### PR TITLE
Fixed  #7255: READ COMMITTED READ CONSISTENCY mode is broken in Classic / SuperClassic on Linux

### DIFF
--- a/src/common/isc_s_proto.h
+++ b/src/common/isc_s_proto.h
@@ -185,9 +185,8 @@ class FileLock
 public:
 	enum LockMode {FLM_EXCLUSIVE, FLM_TRY_EXCLUSIVE, FLM_SHARED, FLM_TRY_SHARED};
 
-	typedef void InitFunction(int fd);
-	explicit FileLock(const char* fileName, InitFunction* init = NULL);		// main ctor
-	FileLock(const FileLock* main, int s);	// creates additional lock for existing file
+	explicit FileLock(const char* fileName);		// main ctor
+	FileLock(const FileLock* main, int s);			// creates additional lock for existing file
 	~FileLock();
 
 	// Main function to lock file
@@ -297,6 +296,8 @@ private:
 	IpcObject* sh_mem_callback;
 #ifdef WIN_NT
 	bool sh_mem_unlink;
+#else
+	bool sh_mem_unlink_called;
 #endif
 	void unlinkFile();
 	void internalUnmap();

--- a/src/jrd/tpc.cpp
+++ b/src/jrd/tpc.cpp
@@ -130,11 +130,11 @@ void TipCache::finalizeTpc(thread_db* tdbb)
 	// To avoid race conditions, this function might only
 	// be called during database shutdown when AST delivery is already disabled
 
-	// wait for all initializing processes (PR)
+	// wait for other processes
 	Lock lock(tdbb, 0, LCK_tpc_init);
 
-	if (!LCK_lock(tdbb, &lock, LCK_SW, LCK_WAIT))
-		ERR_bugcheck_msg("Unable to obtain TPC lock (SW)");
+	if (!LCK_lock(tdbb, &lock, LCK_EX, LCK_WAIT))
+		ERR_bugcheck_msg("Unable to obtain TPC lock (EX)");
 
 	// Release locks and deallocate all shared memory structures
 	if (m_blocks_memory.getFirst())
@@ -206,11 +206,11 @@ void TipCache::initializeTpc(thread_db *tdbb)
 	// Initialization can only be called on a TipCache that is not initialized
 	fb_assert(!m_transactionsPerBlock);
 
-	// wait for finalizers (SW) locks
+	// wait for other processes
 	Lock lock(tdbb, 0, LCK_tpc_init);
 
-	if (!LCK_lock(tdbb, &lock, LCK_PR, LCK_WAIT))
-		ERR_bugcheck_msg("Unable to obtain TPC lock (PR)");
+	if (!LCK_lock(tdbb, &lock, LCK_EX, LCK_WAIT))
+		ERR_bugcheck_msg("Unable to obtain TPC lock (EX)");
 
 	string fileName;
 


### PR DESCRIPTION
TPC-cache related shared files are always (no matter are there other DBBs using that file or not) deleted by TipCache::finalizeTpc(). That works fine on windows cause 'safe delete' technique is used in class SharedMemory. That is not a problem for SS cause there is always single DBB in it. But in Classic / SuperClassic non-windows it's severe problem breaking FB operation when READ CONSISTENCY is used in READ COMMITTED transactions (default mode for that transactions).

Sample in #7255 with newly created user is bright illustration for the bug.

I've decided to make deletion of shared files on linux safe (unlink only when last descriptor is closed), suppose it will be useful in other places where shared memory is used.
 