### PR TITLE
Make Android build work with modern NDK

### DIFF
--- a/builds/install/arch-specific/android/AfterUntar.sh
+++ b/builds/install/arch-specific/android/AfterUntar.sh
@@ -18,8 +18,9 @@ runAndCheckExit() {
     fi
 }
 
-runAndCheckExit "Build messages file (firebird.msg)" bin/build_file
-runAndCheckExit "Restore security database" "bin/gbak -rep security5.gbak security5.fdb"
+runAndCheckExit "Build messages file (firebird.msg)" "bin/build_file -f firebird.msg"
+runAndCheckExit "Creating security database" "echo create database 'security5.fdb' | bin/isql -q"
+runAndCheckExit "Creating security database metadata" "bin/isql -q security5.fdb -i security.sql"
 runAndCheckExit "Restore examples database (employee)" "bin/gbak -rep examples/empbuild/employee.gbak examples/empbuild/employee.fdb"
 
-rm -f security5.gbak examples/empbuild/employee.gbak AfterUntar.sh
+rm -f security.sql bin/build_file examples/empbuild/employee.gbak AfterUntar.sh

--- a/builds/install/arch-specific/android/BuildPackage.sh
+++ b/builds/install/arch-specific/android/BuildPackage.sh
@@ -12,7 +12,7 @@ Version=`grep ^FirebirdVersion ${MakeVersion}|awk '{print $3;}'`
 Release="Firebird-${Version}.${Build}-0.arm${arm}.tar.gz"
 Debug="Firebird-withDebugInfo-${Version}.${Build}-0.arm${arm}.tar.gz"
 Stripped=strip
-aStrip=${NDK}/toolchains/${cross}-4.9/prebuilt/linux-x86_64/bin/${cross}-strip
+aStrip=${NDK_TOOLCHAIN}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip
 fbRootDir=`pwd`
 
 runTar()

--- a/builds/install/arch-specific/android/BuildPackage.sh
+++ b/builds/install/arch-specific/android/BuildPackage.sh
@@ -6,13 +6,15 @@ bits=${1}
 arm=""
 [ "$bits" = "64" ] && arm=64
 
+[ -z "$NDK_TOOLCHAIN" ] && NDK_TOOLCHAIN=$NDK/toolchains/llvm/prebuilt/linux-x86_64
+
 MakeVersion=gen/Make.Version
 Build=`grep ^BuildNum ${MakeVersion}|awk '{print $3;}'`
 Version=`grep ^FirebirdVersion ${MakeVersion}|awk '{print $3;}'`
 Release="Firebird-${Version}.${Build}-0.arm${arm}.tar.gz"
 Debug="Firebird-withDebugInfo-${Version}.${Build}-0.arm${arm}.tar.gz"
 Stripped=strip
-aStrip=${NDK_TOOLCHAIN}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip
+aStrip=${NDK_TOOLCHAIN}/bin/llvm-strip
 fbRootDir=`pwd`
 
 runTar()

--- a/builds/install/arch-specific/android/BuildPackage.sh
+++ b/builds/install/arch-specific/android/BuildPackage.sh
@@ -20,12 +20,14 @@ fbRootDir=`pwd`
 runTar()
 {
 	tarfile=${1}
-	tar cvfz ${tarfile} --exclude '*.a' firebird
+	tar cvfz ${tarfile} --exclude '*.a' --exclude tests firebird
 }
 
 cd gen/Release
 rm -rf ${Stripped}
 cp ${fbRootDir}/builds/install/arch-specific/android/AfterUntar.sh firebird
+chmod +x firebird/AfterUntar.sh
+cp ${fbRootDir}/src/dbs/security.sql firebird
 echo .
 echo .
 echo "Compress with deb-info"
@@ -42,7 +44,7 @@ cd ${Stripped}
 echo .
 echo .
 echo "Strip"
-for file in `find firebird -executable -type f -print`
+for file in `find firebird -executable -type f -not -name "*.sh" -print`
 do
 	${aStrip} ${file}
 done

--- a/builds/posix/make.android.arm64
+++ b/builds/posix/make.android.arm64
@@ -1,6 +1,6 @@
 ifeq ($(NDK_TOOLCHAIN),)
 ifeq ($(NDK),)
-$(error Must export either NDK or NDK_TOOLCHAIN before building for Android
+$(error Must export either NDK or NDK_TOOLCHAIN before building for Android)
 endif
 endif
 

--- a/builds/posix/make.android.arm64
+++ b/builds/posix/make.android.arm64
@@ -4,9 +4,9 @@ $(error Must export standalone NDK_TOOLCHAIN location before building for Androi
 endif
 NDK_ROOT:=$(NDK_TOOLCHAIN)
 
-CROSS_SYSROOT:=$(NDK_TOOLCHAIN)/sysroot
-CROSS_PREFIX24:=$(NDK_TOOLCHAIN)/bin/aarch64-linux-android24-
-CROSS_PREFIX:=$(NDK_TOOLCHAIN)/bin/aarch64-linux-android-
+CROSS_SYSROOT:=$(NDK_TOOLCHAIN)/toolchains/llvm/prebuilt/linux-x86_64/sysroot
+CROSS_PREFIX24:=$(NDK_TOOLCHAIN)/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-
+CROSS_PREFIX:=$(NDK_TOOLCHAIN)/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-
 
 CROSS_FLAGS:=--sysroot=$(CROSS_SYSROOT) \
 			 -I$(CROSS_SYSROOT)/usr/include -I$(ROOT)/gen/cross

--- a/builds/posix/make.android.arm64
+++ b/builds/posix/make.android.arm64
@@ -1,12 +1,14 @@
-
 ifeq ($(NDK_TOOLCHAIN),)
-$(error Must export standalone NDK_TOOLCHAIN location before building for Android - use NDK's build/tools/make-standalone-toolchain.sh to build)
+ifeq ($(NDK),)
+$(error Must export either NDK or NDK_TOOLCHAIN before building for Android
 endif
-NDK_ROOT:=$(NDK_TOOLCHAIN)
+endif
 
-CROSS_SYSROOT:=$(NDK_TOOLCHAIN)/toolchains/llvm/prebuilt/linux-x86_64/sysroot
-CROSS_PREFIX24:=$(NDK_TOOLCHAIN)/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-
-CROSS_PREFIX:=$(NDK_TOOLCHAIN)/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-
+NDK_TOOLCHAIN ?= $(NDK)/toolchains/llvm/prebuilt/linux-x86_64
+
+CROSS_SYSROOT:=$(NDK_TOOLCHAIN)/sysroot
+CROSS_PREFIX24:=$(NDK_TOOLCHAIN)/bin/aarch64-linux-android24-
+CROSS_PREFIX:=$(NDK_TOOLCHAIN)/bin/llvm-
 
 CROSS_FLAGS:=--sysroot=$(CROSS_SYSROOT) \
 			 -I$(CROSS_SYSROOT)/usr/include -I$(ROOT)/gen/cross

--- a/builds/posix/make.android.arme
+++ b/builds/posix/make.android.arme
@@ -1,6 +1,6 @@
 ifeq ($(NDK_TOOLCHAIN),)
 ifeq ($(NDK),)
-$(error Must export either NDK or NDK_TOOLCHAIN before building for Android
+$(error Must export either NDK or NDK_TOOLCHAIN before building for Android)
 endif
 endif
 

--- a/builds/posix/make.android.arme
+++ b/builds/posix/make.android.arme
@@ -1,11 +1,14 @@
 ifeq ($(NDK_TOOLCHAIN),)
-$(error Must export standalone NDK_TOOLCHAIN location before building for Android - use NDK's build/tools/make-standalone-toolchain.sh to build)
+ifeq ($(NDK),)
+$(error Must export either NDK or NDK_TOOLCHAIN before building for Android
 endif
-NDK_ROOT:=$(NDK_TOOLCHAIN)
+endif
 
-CROSS_SYSROOT:=$(NDK_TOOLCHAIN)/toolchains/llvm/prebuilt/linux-x86_64/sysroot
-CROSS_PREFIX24:=$(NDK_TOOLCHAIN)/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi24-
-CROSS_PREFIX:=$(NDK_TOOLCHAIN)/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-
+NDK_TOOLCHAIN ?= $(NDK)/toolchains/llvm/prebuilt/linux-x86_64
+
+CROSS_SYSROOT:=$(NDK_TOOLCHAIN)/sysroot
+CROSS_PREFIX24:=$(NDK_TOOLCHAIN)/bin/armv7a-linux-androideabi24-
+CROSS_PREFIX:=$(NDK_TOOLCHAIN)/bin/llvm-
 
 CROSS_FLAGS:=--sysroot=$(CROSS_SYSROOT) \
 			 -I$(CROSS_SYSROOT)/usr/include -I$(ROOT)/gen/cross

--- a/builds/posix/make.android.arme
+++ b/builds/posix/make.android.arme
@@ -3,9 +3,9 @@ $(error Must export standalone NDK_TOOLCHAIN location before building for Androi
 endif
 NDK_ROOT:=$(NDK_TOOLCHAIN)
 
-CROSS_SYSROOT:=$(NDK_TOOLCHAIN)/sysroot
-CROSS_PREFIX24:=$(NDK_TOOLCHAIN)/bin/armv7a-linux-androideabi24-
-CROSS_PREFIX:=$(NDK_TOOLCHAIN)/bin/arm-linux-androideabi-
+CROSS_SYSROOT:=$(NDK_TOOLCHAIN)/toolchains/llvm/prebuilt/linux-x86_64/sysroot
+CROSS_PREFIX24:=$(NDK_TOOLCHAIN)/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi24-
+CROSS_PREFIX:=$(NDK_TOOLCHAIN)/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-
 
 CROSS_FLAGS:=--sysroot=$(CROSS_SYSROOT) \
 			 -I$(CROSS_SYSROOT)/usr/include -I$(ROOT)/gen/cross

--- a/builds/posix/make.android.x86
+++ b/builds/posix/make.android.x86
@@ -1,6 +1,6 @@
 ifeq ($(NDK_TOOLCHAIN),)
 ifeq ($(NDK),)
-$(error Must export either NDK or NDK_TOOLCHAIN before building for Android
+$(error Must export either NDK or NDK_TOOLCHAIN before building for Android)
 endif
 endif
 

--- a/builds/posix/make.android.x86
+++ b/builds/posix/make.android.x86
@@ -1,38 +1,20 @@
-
+ifeq ($(NDK_TOOLCHAIN),)
 ifeq ($(NDK),)
-$(error Must export NDK location before building for Android)
+$(error Must export either NDK or NDK_TOOLCHAIN before building for Android
 endif
-NDK_ROOT:=$(NDK)
-#NDK_LOG:=1
-include $(NDK)/build/core/init.mk
-
-TOOLCHAIN_DIR:=$(foreach chain, $(NDK_ALL_TOOLCHAINS), $(if $(findstring x86, $(chain)), $(chain), ))
-# Filter out clang
-TEMP_LIST_DIR := $(foreach chain, $(TOOLCHAIN_DIR), $(if $(findstring clang, $(chain)), , $(chain)))
-ifdef TEMP_LIST_DIR
-	TOOLCHAIN_DIR := $(TEMP_LIST_DIR)
 endif
 
-# Filter out x86_64
-TEMP_LIST_DIR := $(foreach chain, $(TOOLCHAIN_DIR), $(if $(findstring x86_64, $(chain)), , $(chain)))
-ifdef TEMP_LIST_DIR
-	TOOLCHAIN_DIR := $(TEMP_LIST_DIR)
-endif
+NDK_TOOLCHAIN ?= $(NDK)/toolchains/llvm/prebuilt/linux-x86_64
 
+CROSS_SYSROOT:=$(NDK_TOOLCHAIN)/sysroot
+CROSS_PREFIX24:=$(NDK_TOOLCHAIN)/bin/i686-linux-android24-
+CROSS_PREFIX:=$(NDK_TOOLCHAIN)/bin/llvm-
 
-# use freshmost compiler
-TOOLCHAIN_DIR:=$(lastword $(TOOLCHAIN_DIR))
+CROSS_FLAGS:=--sysroot=$(CROSS_SYSROOT) \
+			 -I$(CROSS_SYSROOT)/usr/include -I$(ROOT)/gen/cross
 
-ifeq ($(HOST_TAG64),)
-HOST_TAG64:=linux-x86
-endif
-NDK_TOOLCHAIN_VERSION:=$(shell echo $(TOOLCHAIN_DIR) | awk -F - '{print $$NF;}')
-
-CROSS_PLATFORM:=$(NDK)/platforms/android-24/arch-x86
-CROSS_PREFIX:=$(NDK)/toolchains/$(TOOLCHAIN_DIR)/prebuilt/$(HOST_TAG64)/bin/i686-linux-android-
-
-CXX:=$(CROSS_PREFIX)g++
-CC:=$(CROSS_PREFIX)gcc
+CXX:=$(CROSS_PREFIX24)clang++
+CC:=$(CROSS_PREFIX24)clang
 AR:=$(CROSS_PREFIX)ar
 AS:=$(CROSS_PREFIX)as
 LD:=$(CROSS_PREFIX)ld
@@ -42,12 +24,15 @@ OBJDUMP:=$(CROSS_PREFIX)objdump
 RANLIB:=$(CROSS_PREFIX)ranlib
 STRIP:=$(CROSS_PREFIX)strip
 
-COMMON_FLAGS=-ggdb -DFB_SEND_FLAGS=MSG_NOSIGNAL -DLINUX -DANDROID -pipe -MMD -fPIC -fmessage-length=0 \
-			 -I$(ROOT)/extern/libtommath --sysroot=$(CROSS_PLATFORM) \
-			 -I$(CROSS_PLATFORM)/usr/include -I$(ROOT)/gen/cross \
-			 -I$(NDK)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include \
-			 -I$(NDK)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/x86/include
+export CXX
+export CC
+export AR
+export CROSS_FLAGS
 
+COMMON_FLAGS=-ggdb -DFB_SEND_FLAGS=MSG_NOSIGNAL -DLINUX -DANDROID -pipe -MMD -fPIC -fmessage-length=0 \
+			 -I$(ROOT)/extern/libtommath -I$(ROOT)/extern/libtomcrypt/src/headers \
+			 $(CROSS_FLAGS) \
+			 -Wno-inline-new-delete
 
 OPTIMIZE_FLAGS=-fno-omit-frame-pointer
 WARN_FLAGS=-Werror=delete-incomplete -Wall -Wno-switch -Wno-parentheses -Wno-unknown-pragmas -Wno-unused-variable
@@ -57,9 +42,8 @@ DEV_FLAGS=$(COMMON_FLAGS) $(WARN_FLAGS)
 
 CROSS_CONFIG=android.x86
 
-LDFLAGS += --sysroot=$(CROSS_PLATFORM) -L$(NDK)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/x86 \
-	-L$(NDK)/sources/cxx-stl/gnu-libstdc++/libs/x86
-DroidLibs := -lm -ldl -lsupc++
+LDFLAGS += --sysroot=$(CROSS_SYSROOT) -static-libstdc++
+DroidLibs := -lm -ldl $(DECLIB) $(RE2LIB) $(I128LIB)
 
 LINK_LIBS = $(DroidLibs)
 STATICLINK_LIBS = $(DroidLibs)
@@ -83,3 +67,6 @@ $(ROOT)/gen/cross/unicode:
 	rm -rf $(ROOT)/gen/cross
 	mkdir $(ROOT)/gen/cross
 	ln -s $(UNICODE_DIR) cross/unicode
+
+# This file must be compiled with SSE4.2 support
+%/CRC32C.o: CXXFLAGS += -msse4

--- a/builds/posix/make.android.x86_64
+++ b/builds/posix/make.android.x86_64
@@ -1,30 +1,20 @@
-
+ifeq ($(NDK_TOOLCHAIN),)
 ifeq ($(NDK),)
-$(error Must export NDK location before building for Android)
+$(error Must export either NDK or NDK_TOOLCHAIN before building for Android
 endif
-NDK_ROOT:=$(NDK)
-#NDK_LOG:=1
-include $(NDK)/build/core/init.mk
-
-TOOLCHAIN_DIR:=$(foreach chain, $(NDK_ALL_TOOLCHAINS), $(if $(findstring x86_64, $(chain)), $(chain), ))
-# Filter out clang
-TEMP_LIST_DIR := $(foreach chain, $(TOOLCHAIN_DIR), $(if $(findstring clang, $(chain)), , $(chain)))
-ifdef TEMP_LIST_DIR
-	TOOLCHAIN_DIR := $(TEMP_LIST_DIR)
 endif
-# use freshmost compiler
-TOOLCHAIN_DIR:=$(lastword $(TOOLCHAIN_DIR))
 
-ifeq ($(HOST_TAG64),)
-HOST_TAG64:=linux-x86
-endif
-NDK_TOOLCHAIN_VERSION:=$(shell echo $(TOOLCHAIN_DIR) | awk -F - '{print $$NF;}')
+NDK_TOOLCHAIN ?= $(NDK)/toolchains/llvm/prebuilt/linux-x86_64
 
-CROSS_PLATFORM:=$(NDK)/platforms/android-24/arch-x86_64
-CROSS_PREFIX:=$(NDK)/toolchains/$(TOOLCHAIN_DIR)/prebuilt/$(HOST_TAG64)/bin/x86_64-linux-android-
+CROSS_SYSROOT:=$(NDK_TOOLCHAIN)/sysroot
+CROSS_PREFIX24:=$(NDK_TOOLCHAIN)/bin/x86_64-linux-android24-
+CROSS_PREFIX:=$(NDK_TOOLCHAIN)/bin/llvm-
 
-CXX:=$(CROSS_PREFIX)g++
-CC:=$(CROSS_PREFIX)gcc
+CROSS_FLAGS:=--sysroot=$(CROSS_SYSROOT) \
+			 -I$(CROSS_SYSROOT)/usr/include -I$(ROOT)/gen/cross
+
+CXX:=$(CROSS_PREFIX24)clang++
+CC:=$(CROSS_PREFIX24)clang
 AR:=$(CROSS_PREFIX)ar
 AS:=$(CROSS_PREFIX)as
 LD:=$(CROSS_PREFIX)ld
@@ -34,11 +24,15 @@ OBJDUMP:=$(CROSS_PREFIX)objdump
 RANLIB:=$(CROSS_PREFIX)ranlib
 STRIP:=$(CROSS_PREFIX)strip
 
+export CXX
+export CC
+export AR
+export CROSS_FLAGS
+
 COMMON_FLAGS=-ggdb -DFB_SEND_FLAGS=MSG_NOSIGNAL -DLINUX -DANDROID -DAMD64 -pipe -MMD -fPIC -fmessage-length=0 \
-			 -I$(ROOT)/extern/libtommath --sysroot=$(CROSS_PLATFORM) \
-			 -I$(CROSS_PLATFORM)/usr/include -I$(ROOT)/gen/cross \
-			 -I$(NDK)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/include \
-			 -I$(NDK)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/x86_64/include
+			 -I$(ROOT)/extern/libtommath -I$(ROOT)/extern/libtomcrypt/src/headers \
+			 $(CROSS_FLAGS) \
+			 -Wno-inline-new-delete
 
 OPTIMIZE_FLAGS=-fno-omit-frame-pointer
 WARN_FLAGS=-Werror=delete-incomplete -Wall -Wno-switch -Wno-parentheses -Wno-unknown-pragmas -Wno-unused-variable
@@ -48,9 +42,8 @@ DEV_FLAGS=$(COMMON_FLAGS) $(WARN_FLAGS)
 
 CROSS_CONFIG=android.x86_64
 
-LDFLAGS += --sysroot=$(CROSS_PLATFORM) -L$(NDK)/sources/cxx-stl/gnu-libstdc++/$(NDK_TOOLCHAIN_VERSION)/libs/x86_64 \
-	-L$(NDK)/sources/cxx-stl/gnu-libstdc++/libs/x86_64
-DroidLibs := -lm -ldl -lsupc++
+LDFLAGS += --sysroot=$(CROSS_SYSROOT) -static-libstdc++
+DroidLibs := -lm -ldl $(DECLIB) $(RE2LIB) $(I128LIB)
 
 LINK_LIBS = $(DroidLibs)
 STATICLINK_LIBS = $(DroidLibs)

--- a/builds/posix/make.android.x86_64
+++ b/builds/posix/make.android.x86_64
@@ -1,6 +1,6 @@
 ifeq ($(NDK_TOOLCHAIN),)
 ifeq ($(NDK),)
-$(error Must export either NDK or NDK_TOOLCHAIN before building for Android
+$(error Must export either NDK or NDK_TOOLCHAIN before building for Android)
 endif
 endif
 


### PR DESCRIPTION
Modern NDK does not recommend usage of `make_standalone_toolchain`.