### PR TITLE
Solaris port

### DIFF
--- a/src/common/isc_s_proto.h
+++ b/src/common/isc_s_proto.h
@@ -188,7 +188,7 @@ class FileLock
 	friend class CountedRWLock;
 
 public:
-	enum LockMode {FLM_EXCLUSIVE, FLM_TRY_EXCLUSIVE, FLM_SHARED, FLM_TRY_SHARED};
+	enum LockMode {FLM_EXCLUSIVE, FLM_TRY_EXCLUSIVE, FLM_SHARED};
 
 	typedef void InitFunction(int fd);
 	explicit FileLock(const char* fileName, InitFunction* init = NULL);		// main ctor

--- a/src/common/isc_s_proto.h
+++ b/src/common/isc_s_proto.h
@@ -181,9 +181,12 @@ public:
 #endif
 
 class CountedFd;
+class CountedRWLock;
 
 class FileLock
 {
+	friend class CountedRWLock;
+
 public:
 	enum LockMode {FLM_EXCLUSIVE, FLM_TRY_EXCLUSIVE, FLM_SHARED, FLM_TRY_SHARED};
 


### PR DESCRIPTION
Solaris is using more strict rules in pthread_rwlock - lock can be removed only from the thread where it was asserted. That breaks CountedRWLock used in FileLock to control multiple locks on a file from single process. 

Suggested solution is use of SyncObject instead. 

