### PR TITLE
Fix bug when uncommitted records may become visible after the database sweep

### DIFF
--- a/src/jrd/dpm.epp
+++ b/src/jrd/dpm.epp
@@ -1780,7 +1780,8 @@ bool DPM_next(thread_db* tdbb, record_param* rpb, USHORT lock_type, FindNextReco
 			const UCHAR* bits = (UCHAR*) (ppage->ppg_page + dbb->dbb_dp_per_pp);
 			if (page_number && !PPG_DP_BIT_TEST(bits, slot, ppg_dp_secondary) &&
 				!PPG_DP_BIT_TEST(bits, slot, ppg_dp_empty) &&
-				(!sweeper || !PPG_DP_BIT_TEST(bits, slot, ppg_dp_swept)) )
+				(!sweeper || tdbb->tdbb_flags & TDBB_dont_trust_swept_flag ||
+				 !PPG_DP_BIT_TEST(bits, slot, ppg_dp_swept)) )
 			{
 #ifdef SUPERSERVER_V2
 				// Perform sequential prefetch of relation's data pages.
@@ -2454,7 +2455,9 @@ static void check_swept(thread_db* tdbb, record_param* rpb)
 
 	const UCHAR* bits = (UCHAR*) (ppage->ppg_page + dbb->dbb_dp_per_pp);
 	if (slot >= ppage->ppg_count || !ppage->ppg_page[slot] ||
-		PPG_DP_BIT_TEST(bits, slot, ppg_dp_secondary | ppg_dp_swept))
+		PPG_DP_BIT_TEST(bits, slot, ppg_dp_secondary) ||
+		(!(tdbb->tdbb_flags & TDBB_dont_trust_swept_flag) &&
+		 PPG_DP_BIT_TEST(bits, slot, ppg_dp_swept)) )
 	{
 		CCH_RELEASE(tdbb, window);
 		return;

--- a/src/jrd/jrd.h
+++ b/src/jrd/jrd.h
@@ -498,6 +498,7 @@ const ULONG TDBB_reset_stack			= 2048;		// stack should be reset after stack ove
 const ULONG TDBB_dfw_cleanup			= 4096;		// DFW cleanup phase is active
 const ULONG TDBB_repl_in_progress		= 8192;		// Prevent recursion in replication
 const ULONG TDBB_replicator				= 16384;	// Replicator
+const ULONG TDBB_dont_trust_swept_flag	= 32768;	// DB in a state when we cannot trust ppg_dp_swept flag (see TRA_sweep)
 
 class thread_db : public Firebird::ThreadData
 {
@@ -830,7 +831,7 @@ public:
 
 	~ThreadSweepGuard()
 	{
-		m_tdbb->tdbb_flags &= ~TDBB_sweeper;
+		m_tdbb->tdbb_flags &= ~(TDBB_sweeper | TDBB_dont_trust_swept_flag);
 	}
 
 private:

--- a/src/jrd/vio.cpp
+++ b/src/jrd/vio.cpp
@@ -191,6 +191,7 @@ class SweepTask : public Task
 
 public:
 	SweepTask(thread_db* tdbb, MemoryPool* pool, TraceSweepEvent* traceSweep) : Task(),
+		m_dontTrustSweptFlag(tdbb->tdbb_flags & TDBB_dont_trust_swept_flag),
 		m_pool(pool),
 		m_dbb(NULL),
 		m_items(*m_pool),
@@ -309,6 +310,9 @@ public:
 			tdbb->setTransaction(m_tra);
 			tdbb->tdbb_flags |= TDBB_sweeper;
 
+			if (getSweepTask()->m_dontTrustSweptFlag)
+				tdbb->tdbb_flags |= TDBB_dont_trust_swept_flag;
+
 			return true;
 		}
 
@@ -341,6 +345,8 @@ public:
 	{
 		return m_items.getCount();
 	}
+
+	bool m_dontTrustSweptFlag;
 
 private:
 	// item is handled, get next portion of work and update RelInfo


### PR DESCRIPTION
When the server crash happens, the database might have pointer pages with flags which are not consistent with flags on data pages. If ppg_dp_swept is set for a data page which does not actually have dpg_swept set, then records on this page won't be garbage-collected, and they will become visible after OIT is advanced at the end of the sweep. Checking for dead transactions between OIT and OAT helps to determine if the server has been crashing recently. If it has, we cannot trust ppg_dp_swept flag.