### PR TITLE
Ensure the DDL trigger requests are cached

### DIFF
--- a/src/jrd/exe.cpp
+++ b/src/jrd/exe.cpp
@@ -560,19 +560,23 @@ void EXE_execute_ddl_triggers(thread_db* tdbb, jrd_tra* transaction, bool preTri
 	{
 		TrigVector triggers;
 		TrigVector* triggersPtr = &triggers;
+		HalfStaticArray<Trigger*, 4> cachedTriggers;
 
-		for (const auto& trigger : *attachment->att_ddl_triggers)
+		for (auto& trigger : *attachment->att_ddl_triggers)
 		{
 			const bool preTrigger = ((trigger.type & 0x1) == 0);
 
 			if ((trigger.type & (1LL << action)) && (preTriggers == preTrigger))
 			{
 				triggers.add() = trigger;
+				cachedTriggers.add(&trigger);
 			}
 		}
 
 		if (triggers.hasData())
 		{
+			FbLocalStatus tempStatus;
+
 			jrd_tra* const oldTransaction = tdbb->getTransaction();
 			tdbb->setTransaction(transaction);
 
@@ -580,14 +584,24 @@ void EXE_execute_ddl_triggers(thread_db* tdbb, jrd_tra* transaction, bool preTri
 			{
 				EXE_execute_triggers(tdbb, &triggersPtr, NULL, NULL, TRIGGER_DDL,
 					preTriggers ? StmtNode::PRE_TRIG : StmtNode::POST_TRIG);
-
-				tdbb->setTransaction(oldTransaction);
 			}
-			catch (const Exception&)
+			catch (const Exception& ex)
 			{
-				tdbb->setTransaction(oldTransaction);
-				throw;
+				ex.stuffException(&tempStatus);
 			}
+
+			tdbb->setTransaction(oldTransaction);
+
+			// Triggers could be compiled inside EXE_execute_triggers(),
+			// so ensure the new pointers are copied back to the cache
+			fb_assert(triggers.getCount() == cachedTriggers.getCount());
+			for (unsigned i = 0; i < triggers.getCount(); i++)
+			{
+				*cachedTriggers[i] = triggers[i];
+				triggers[i].extTrigger = nullptr; // avoid deletion inside d'tor
+			}
+
+			tempStatus.check();
 		}
 	}
 }


### PR DESCRIPTION
Currently, `EXE_execute_ddl_triggers()` composes a temporary vector of triggers and passes it to `EXE_execute_triggers()`. This may cause triggers to be compiled before first execution, but the resulting `statement` (and possibly `extTrigger`) is never moved to the original (cached) copy of the triggers. So (1) every time triggers are recompiled again and again, (2) they're leaking memory and resources/locks, (3) existing calls of `MET_release_triggers()` for `att_ddl_triggers` seem useless, as these triggers are never compiled. This PR fixes this problem, but as I could be missing something, I'd appreciate a review.