### PR TITLE
Fix possible SUBSTRING()'s crash with UTF-8 encoding (#7434)

### DIFF
--- a/src/jrd/SimilarToMatcher.h
+++ b/src/jrd/SimilarToMatcher.h
@@ -1732,7 +1732,7 @@ public:
 		const UCHAR* originalPatternPos = originalPatternStr;
 
 		const CharType* lastStart = reinterpret_cast<const CharType*>(patternStr);
-		const CharType* end = lastStart + patternLen;
+		const CharType* end = reinterpret_cast<const CharType*>(patternStr + patternLen);
 		unsigned lengths[3];
 		unsigned lengthsNum = 0;
 		UCHAR dummy[sizeof(ULONG) * 2];


### PR DESCRIPTION
Fix regex pattern end calculation in case of multi-byte characters set