### PR TITLE
Make gfix handle io errors, fix errors

### DIFF
--- a/src/common/classes/sparse_bitmap.h
+++ b/src/common/classes/sparse_bitmap.h
@@ -856,7 +856,7 @@ SparseBitmap<T, InternalTypes>::bit_subtract(SparseBitmap<T, InternalTypes>** bi
 
 	bool map1Found = map1->tree.getFirst();
 	if (!map1Found)
-		return bitmap1;	// or NULL?
+		return NULL;
 
 	bool map2Found = map2->tree.getFirst();
 	if (!map2Found)

--- a/src/common/classes/tests/SparseBitmapTest.cpp
+++ b/src/common/classes/tests/SparseBitmapTest.cpp
@@ -1,0 +1,149 @@
+#include "firebird.h"
+#include "boost/test/unit_test.hpp"
+#include "../common/classes/alloc.h"
+#include "../common/classes/tree.h"
+#include "../common/classes/sparse_bitmap.h"
+
+using namespace Firebird;
+
+BOOST_AUTO_TEST_SUITE(CommonSuite)
+BOOST_AUTO_TEST_SUITE(SparseBitmapSuite)
+
+
+BOOST_AUTO_TEST_SUITE(SparseBitmapTests)
+
+BOOST_AUTO_TEST_CASE(ConstructionWithMemoryPool)
+{
+	SparseBitmap<ULONG> bitmap(*getDefaultMemoryPool());
+
+	bitmap.set(0);
+	bitmap.set(100);
+	bitmap.set(10000);
+
+	for (size_t i = 0; i <= 10100; i++)
+	{
+		switch (i)
+		{
+			case 0:
+			case 100:
+			case 10000:
+				BOOST_TEST(bitmap.test(i) == true);
+				break;
+			default:
+				BOOST_TEST(bitmap.test(i) == false);
+		}
+	}
+}
+
+BOOST_AUTO_TEST_CASE(bitOr)
+{
+	SparseBitmap<ULONG> A(*getDefaultMemoryPool());
+	SparseBitmap<ULONG> B(*getDefaultMemoryPool());
+
+	A.set(1);
+	A.set(100);
+	A.set(10000);
+
+	B.set(10);
+	B.set(100);
+	B.set(1000);
+
+
+	auto bitmapA = &A;
+	auto bitmapB = &B;
+
+	auto C = *SparseBitmap<ULONG>::bit_or(&bitmapA, &bitmapB);
+	BOOST_TEST(C != nullptr);
+
+	for (size_t i = 0; i <= 10100; i++)
+	{
+		switch (i)
+		{
+			case 1:
+			case 10:
+			case 100:
+			case 1000:
+			case 10000:
+				BOOST_TEST(C->test(i) == true);
+				break;
+			default:
+				BOOST_TEST(C->test(i) == false);
+		}
+	}
+}
+
+BOOST_AUTO_TEST_CASE(bitAnd)
+{
+	SparseBitmap<ULONG> A(*getDefaultMemoryPool());
+	SparseBitmap<ULONG> B(*getDefaultMemoryPool());
+
+	A.set(1);
+	A.set(100);
+	A.set(10000);
+
+	B.set(10);
+	B.set(100);
+	B.set(1000);
+
+
+	auto bitmapA = &A;
+	auto bitmapB = &B;
+
+	auto C = *SparseBitmap<ULONG>::bit_and(&bitmapA, &bitmapB);
+	BOOST_TEST(C != nullptr);
+
+	for (size_t i = 0; i <= 10100; i++)
+	{
+		switch (i)
+		{
+			case 100:
+				BOOST_TEST(C->test(i) == true);
+				break;
+			default:
+				BOOST_TEST(C->test(i) == false);
+		}
+	}
+}
+
+BOOST_AUTO_TEST_CASE(bitSubtract)
+{
+	SparseBitmap<ULONG> A(*getDefaultMemoryPool());
+	SparseBitmap<ULONG> B(*getDefaultMemoryPool());
+
+	A.set(1);
+	A.set(100);
+	A.set(101);
+	A.set(10000);
+
+	B.set(10);
+	B.set(100);
+	B.set(1000);
+
+
+	auto bitmapA = &A;
+	auto bitmapB = &B;
+
+	auto C = *SparseBitmap<ULONG>::bit_subtract(&bitmapA, &bitmapB);
+	BOOST_TEST(C != nullptr);
+
+	for (size_t i = 0; i <= 10100; i++)
+	{
+		switch (i)
+		{
+			case 1:
+			case 101:
+			case 10000:
+				BOOST_TEST(C->test(i) == true);
+				break;
+			default:
+				BOOST_TEST(C->test(i) == false);
+		}
+	}
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()	// SortedArrayTests
+
+
+BOOST_AUTO_TEST_SUITE_END()	// ArraySuite
+BOOST_AUTO_TEST_SUITE_END()	// CommonSuite

--- a/src/jrd/cch.cpp
+++ b/src/jrd/cch.cpp
@@ -808,6 +808,8 @@ pag* CCH_fetch(thread_db* tdbb, WIN* window, int lock_type, SCHAR page_type, int
 	case lsLocked:
 		CCH_TRACE(("FE PAGE %d:%06d", window->win_page.getPageSpaceID(), window->win_page.getPageNum()));
 		CCH_fetch_page(tdbb, window, read_shadow);	// must read page from disk
+		if (!window->win_bdb)						// read failed
+			return NULL;
 		if (syncType != SYNC_EXCLUSIVE)
 			bdb->downgrade(syncType);
 		break;
@@ -1006,6 +1008,8 @@ void CCH_fetch_page(thread_db* tdbb, WIN* window, const bool read_shadow)
 			bdb->bdb_page.getPageSpaceID(), bdb->bdb_page.getPageNum(), bak_state, diff_page));
 	}
 
+	bool readFailed = false;
+
 	// In merge mode, if we are reading past beyond old end of file and page is in .delta file
 	// then we maintain actual page in difference file. Always read it from there.
 	if (isTempPage || bak_state == Ods::hdr_nbak_normal || !diff_page)
@@ -1017,9 +1021,10 @@ void CCH_fetch_page(thread_db* tdbb, WIN* window, const bool read_shadow)
 
 		// Read page from disk as normal
 		Pio io(file, bdb, isTempPage, read_shadow, pageSpace);
-		if (!dbb->dbb_crypto_manager->read(tdbb, status, page, &io))
+		readFailed = !dbb->dbb_crypto_manager->read(tdbb, status, page, &io);
+		if (readFailed)
 		{
-			if (read_shadow && !isTempPage)
+			if (read_shadow)
 			{
 				PAGE_LOCK_RELEASE(tdbb, bcb, bdb->bdb_lock);
 				CCH_unwind(tdbb, true);
@@ -1032,7 +1037,8 @@ void CCH_fetch_page(thread_db* tdbb, WIN* window, const bool read_shadow)
 	{
 		NBAK_TRACE(("Reading page %d, state=%d, diff page=%d from DIFFERENCE",
 			bdb->bdb_page, bak_state, diff_page));
-		if (!bm->readDifference(tdbb, diff_page, page))
+		readFailed = !bm->readDifference(tdbb, diff_page, page);
+		if (readFailed)
 		{
 			PAGE_LOCK_RELEASE(tdbb, bcb, bdb->bdb_lock);
 			CCH_unwind(tdbb, true);
@@ -1050,7 +1056,8 @@ void CCH_fetch_page(thread_db* tdbb, WIN* window, const bool read_shadow)
 				bdb->bdb_page, bak_state, diff_page));
 
 			Pio io(file, bdb, false, read_shadow, pageSpace);
-			if (!dbb->dbb_crypto_manager->read(tdbb, status, page, &io))
+			readFailed = !dbb->dbb_crypto_manager->read(tdbb, status, page, &io);
+			if (readFailed)
 			{
 				if (read_shadow)
 				{
@@ -1061,8 +1068,20 @@ void CCH_fetch_page(thread_db* tdbb, WIN* window, const bool read_shadow)
 		}
 	}
 
-	bdb->bdb_flags &= ~(BDB_not_valid | BDB_read_pending);
-	window->win_buffer = bdb->bdb_buffer;
+	if (readFailed)
+	{
+		bdb->bdb_flags |= BDB_not_valid;
+		bdb->bdb_flags &= ~(BDB_writer | BDB_read_pending);
+		bdb->release(tdbb, true);
+
+		window->win_buffer = NULL;
+		window->win_bdb = NULL;
+	}
+	else
+	{
+		bdb->bdb_flags &= ~(BDB_not_valid | BDB_read_pending);
+		window->win_buffer = bdb->bdb_buffer;
+	}
 }
 
 

--- a/src/jrd/cch.cpp
+++ b/src/jrd/cch.cpp
@@ -1024,9 +1024,9 @@ void CCH_fetch_page(thread_db* tdbb, WIN* window, const bool read_shadow)
 		readFailed = !dbb->dbb_crypto_manager->read(tdbb, status, page, &io);
 		if (readFailed)
 		{
+			PAGE_LOCK_RELEASE(tdbb, bcb, bdb->bdb_lock);
 			if (read_shadow)
 			{
-				PAGE_LOCK_RELEASE(tdbb, bcb, bdb->bdb_lock);
 				CCH_unwind(tdbb, true);
 			}
 		}
@@ -1059,9 +1059,9 @@ void CCH_fetch_page(thread_db* tdbb, WIN* window, const bool read_shadow)
 			readFailed = !dbb->dbb_crypto_manager->read(tdbb, status, page, &io);
 			if (readFailed)
 			{
+				PAGE_LOCK_RELEASE(tdbb, bcb, bdb->bdb_lock);
 				if (read_shadow)
 				{
-					PAGE_LOCK_RELEASE(tdbb, bcb, bdb->bdb_lock);
 					CCH_unwind(tdbb, true);
 				}
 			}

--- a/src/jrd/cch.h
+++ b/src/jrd/cch.h
@@ -32,7 +32,6 @@
 #include "../common/ThreadStart.h"
 #ifdef SUPERSERVER_V2
 #include "../jrd/sbm.h"
-#include "../jrd/pag.h"
 #endif
 
 #include "../jrd/que.h"

--- a/src/jrd/pag.cpp
+++ b/src/jrd/pag.cpp
@@ -1504,7 +1504,7 @@ void PAG_init2(thread_db* tdbb, USHORT shadow_number)
 }
 
 
-SLONG PAG_last_page(thread_db* tdbb)
+ULONG PAG_last_page(thread_db* tdbb)
 {
 /**************************************
  *

--- a/src/jrd/pag_proto.h
+++ b/src/jrd/pag_proto.h
@@ -54,7 +54,7 @@ void	PAG_header(Jrd::thread_db*, bool);
 void	PAG_header_init(Jrd::thread_db*);
 void	PAG_init(Jrd::thread_db*);
 void	PAG_init2(Jrd::thread_db*, USHORT);
-SLONG	PAG_last_page(Jrd::thread_db* tdbb);
+ULONG	PAG_last_page(Jrd::thread_db* tdbb);
 void	PAG_release_page(Jrd::thread_db* tdbb, const Jrd::PageNumber&, const Jrd::PageNumber&);
 void	PAG_release_pages(Jrd::thread_db* tdbb, USHORT pageSpaceID, int cntRelease,
 			const ULONG* pgNums, const ULONG prior_page);

--- a/src/jrd/sdw.cpp
+++ b/src/jrd/sdw.cpp
@@ -456,7 +456,7 @@ void SDW_dump_pages(thread_db* tdbb)
 	SyncLockGuard guard(&dbb->dbb_shadow_sync, SYNC_EXCLUSIVE, "SDW_dump_pages");
 
 	gds__log("conditional shadow dumped for database %s", dbb->dbb_filename.c_str());
-	const SLONG max = PAG_last_page(tdbb);
+	const ULONG max = PAG_last_page(tdbb);
 
 	// mark the first shadow in the list because we don't
 	// want to start shadowing to any files that are added
@@ -468,15 +468,15 @@ void SDW_dump_pages(thread_db* tdbb)
 	window.win_flags = WIN_large_scan;
 	window.win_scans = 1;
 
-	for (SLONG page_number = HEADER_PAGE + 1; page_number <= max; page_number++)
+	for (ULONG page_number = HEADER_PAGE + 1; page_number <= max; page_number++)
 	{
 #ifdef SUPERSERVER_V2
 		if (!(page_number % dbb->dbb_prefetch_sequence))
 		{
-			SLONG pages[PREFETCH_MAX_PAGES];
+			ULONG pages[PREFETCH_MAX_PAGES];
 
-			SLONG number = page_number;
-			SLONG i = 0;
+			ULONG number = page_number;
+			ULONG i = 0;
 			while (i < dbb->dbb_prefetch_pages && number <= max) {
 				pages[i++] = number++;
 			}

--- a/src/jrd/validation.cpp
+++ b/src/jrd/validation.cpp
@@ -2906,7 +2906,7 @@ void Validation::checkDPinPP(jrd_rel* relation, ULONG page_number)
 	* Functional description
 	*	Check if data page presented in pointer page.
 	* If not we try to fix it by setting pointer page slot in the page_number.
-	* Early in walk_chain we observed that this page in related to the relation so we skip such kind of check here.
+	* Early in walk_chain we observed that this page is related to the relation so we skip such kind of check here.
 	**************************************/
 
 	WIN window(DB_PAGE_SPACE, page_number);
@@ -2963,11 +2963,10 @@ void Validation::checkDPinPP(jrd_rel* relation, ULONG page_number)
 				vdr_fixed++;
 			}
 		}
+		release_page(&window);
 	}
 	else
 		corrupt(VAL_DATA_PAGE_HASNO_PP, relation, page_number, dpage->dpg_sequence);
-
-	release_page(&window);
 }
 
 void Validation::checkDPinPIP(jrd_rel* relation, ULONG page_number)

--- a/src/jrd/validation.cpp
+++ b/src/jrd/validation.cpp
@@ -1053,7 +1053,7 @@ bool Validation::run(thread_db* tdbb, USHORT flags)
 		cleanup();
 
 		gds__log("Database: %s\n\tValidation finished: %d errors, %d warnings, %d fixed, %d ignored",
-			fileName.c_str(), vdr_errors, vdr_warns, vdr_fixed);
+			fileName.c_str(), vdr_errors, vdr_warns, vdr_fixed, vdr_ignored);
 	}	// try
 	catch (const Firebird::Exception& ex)
 	{

--- a/src/jrd/validation.cpp
+++ b/src/jrd/validation.cpp
@@ -2923,7 +2923,7 @@ void Validation::checkDPinPP(jrd_rel* relation, ULONG page_number)
 	DECOMPOSE(sequence, dbb->dbb_dp_per_pp, pp_sequence, slot);
 
 	const vcl* vector = relation->getBasePages()->rel_pages;
-	pointer_page* ppage = 0;
+	pointer_page* ppage = NULL;
 	if (pp_sequence < vector->count())
 	{
 		fetch_page(false, (*vector)[pp_sequence], pag_pointer, &window, &ppage);
@@ -3122,16 +3122,21 @@ Validation::RTN Validation::walk_relation(jrd_rel* relation)
 
 			if (c.getFirst() && b.getFirst())
 			{
-				for (bool next = true; next; next = c.getNext())
+				while (true)
 				{
 					if (c.current() == b.current())
 						b.getNext();
-					else if ((c.current() < b.current()) || !b.getNext())
+					else if ( ( c.current() < b.current() ) || !b.getNext() )
 					{
 						//fprintf(stdout, "chain page was visited not via data pages %d\n", c.current());
 						checkDPinPP(relation, c.current());
 						checkDPinPIP(relation, c.current());
 					}
+					else
+						continue;
+
+					if (!c.getNext())
+						break;
 				}
 			}
 		}

--- a/src/jrd/validation.cpp
+++ b/src/jrd/validation.cpp
@@ -861,6 +861,7 @@ Validation::Validation(thread_db* tdbb, UtilSvc* uSvc)
 	vdr_errors = 0;
 	vdr_warns = 0;
 	vdr_fixed = 0;
+	vdr_ignored = 0;
 	vdr_max_transaction = 0;
 	vdr_rel_backversion_counter = 0;
 	vdr_backversion_pages = NULL;
@@ -1022,7 +1023,7 @@ bool Validation::run(thread_db* tdbb, USHORT flags)
 		vdr_flags = flags;
 
 		// initialize validate errors
-		vdr_errors = vdr_warns = vdr_fixed = 0;
+		vdr_errors = vdr_warns = vdr_fixed = vdr_ignored = 0;
 		for (USHORT i = 0; i < VAL_MAX_ERROR; i++)
 			vdr_err_counts[i] = 0;
 
@@ -1031,7 +1032,7 @@ bool Validation::run(thread_db* tdbb, USHORT flags)
 		gds__log("Database: %s\n\tValidation started", fileName.c_str());
 
 		walk_database();
-		if (vdr_errors || vdr_warns)
+		if ( (vdr_errors + vdr_warns) > (vdr_fixed + vdr_ignored))
 			vdr_flags &= ~VDR_update;
 
 		if (!(vdr_flags & VDR_online) && !(vdr_flags & VDR_partial)) {
@@ -1047,7 +1048,7 @@ bool Validation::run(thread_db* tdbb, USHORT flags)
 
 		cleanup();
 
-		gds__log("Database: %s\n\tValidation finished: %d errors, %d warnings, %d fixed",
+		gds__log("Database: %s\n\tValidation finished: %d errors, %d warnings, %d fixed, %d ignored",
 			fileName.c_str(), vdr_errors, vdr_warns, vdr_fixed);
 	}	// try
 	catch (const Firebird::Exception& ex)
@@ -1160,6 +1161,14 @@ Validation::RTN Validation::corrupt(int err_code, const jrd_rel* relation, ...)
 
 	s.append("\n");
 	output(s.c_str());
+
+	switch (err_code)
+	{
+		case VAL_REL_CHAIN_ORPHANS:
+		case VAL_INDEX_MISSING_ROWS:
+		case VAL_INDEX_BAD_LEFT_SIBLING:
+			vdr_ignored++;
+	}
 
 	return rtn_corrupt;
 }

--- a/src/jrd/validation.cpp
+++ b/src/jrd/validation.cpp
@@ -848,7 +848,11 @@ const Validation::MSG_ENTRY Validation::vdr_msg_table[VAL_MAX_ERROR] =
 	{true, isc_info_ppage_errors,	"Data page %" ULONGFORMAT" is not in PP (%" ULONGFORMAT"). Slot (%d) is not found"},
 	{true, isc_info_ppage_errors,	"Data page %" ULONGFORMAT" is not in PP (%" ULONGFORMAT"). Slot (%d) has value %" ULONGFORMAT},
 	{true, isc_info_ppage_errors,	"Pointer page is not found for data page %" ULONGFORMAT". dpg_sequence (%" ULONGFORMAT") is invalid"},
-	{true, isc_info_dpage_errors,	"Data page %" ULONGFORMAT" {sequence %" ULONGFORMAT"} marked as secondary but contains primary record versions"}
+	{true, isc_info_dpage_errors,	"Data page %" ULONGFORMAT" {sequence %" ULONGFORMAT"} marked as secondary but contains primary record versions"},
+	{true, isc_info_page_errors,	"Fetch page %" ULONGFORMAT" error"},
+	{true, isc_info_page_errors,	"Index %d has unreadable page %" ULONGFORMAT". File: %s, line: %d\n\t"},
+	{true, isc_info_page_errors,	"Page inventory page %" ULONGFORMAT" {sequence %" ULONGFORMAT"} read error"},
+	{true, isc_info_page_errors,	"SCN page %" ULONGFORMAT" {sequence %" ULONGFORMAT"} read error"}
 };
 
 Validation::Validation(thread_db* tdbb, UtilSvc* uSvc)
@@ -1215,9 +1219,18 @@ Validation::FETCH_CODE Validation::fetch_page(bool mark, ULONG page_number,
 	}
 	else
 	{
+		// I/O error must not be written into status vector and reported in gfix
+		// It's handled in a caller of the function.
+		ThreadStatusGuard status_vector(vdr_tdbb);
 		*page_pointer = CCH_FETCH_NO_SHADOW(vdr_tdbb, window,
 			(vdr_flags & VDR_online ? LCK_read : LCK_write),
 			0);
+
+		if (!*page_pointer)
+		{
+			corrupt(VAL_FETCH_PAGE_ERROR, 0, page_number);
+			return fetch_io;
+		}
 
 		vdr_used_bdbs.add(UsedBdb(window->win_bdb));
 	}
@@ -1274,7 +1287,8 @@ Validation::FETCH_CODE Validation::fetch_page(bool mark, ULONG page_number,
 		if (scn_page_num == page_number)
 			scns = (scns_page*) *page_pointer;
 		else
-			fetch_page(mark, scn_page_num, pag_scns, &scns_window, &scns);
+			if (fetch_page(mark, scn_page_num, pag_scns, &scns_window, &scns) == fetch_io)
+				return fetch_io;
 
 		if (scns->scn_pages[scn_slot] != page_scn)
 		{
@@ -1342,7 +1356,8 @@ void Validation::garbage_collect()
 	{
 		const ULONG page_number = sequence ? sequence * pageSpaceMgr.pagesPerPIP - 1 : pageSpace->pipFirst;
 		page_inv_page* page = 0;
-		fetch_page(false, page_number, pag_pages, &window, &page);
+		if (fetch_page(false, page_number, pag_pages, &window, &page) == fetch_io)
+			return;	// stop any garbage collecting in non healthy database
 		UCHAR* p = page->pip_bits;
 		const UCHAR* const end = p + pageSpaceMgr.bytesBitPIP;
 		while (p < end && number < vdr_max_page)
@@ -1485,8 +1500,10 @@ Validation::RTN Validation::walk_blob(jrd_rel* relation, const blh* header, USHO
 	}
 
 	// Level 1 blobs are a little more complicated
-	WIN window1(DB_PAGE_SPACE, -1), window2(DB_PAGE_SPACE, -1);
-	window1.win_flags = window2.win_flags = WIN_garbage_collector;
+	WIN window1(DB_PAGE_SPACE, -1);
+	WIN window2(DB_PAGE_SPACE, -1);
+	window1.win_flags = WIN_garbage_collector;
+	window2.win_flags = WIN_garbage_collector;
 
 	const ULONG* pages1 = header->blh_page;
 	const ULONG* const end1 = pages1 + ((USHORT) (length - BLH_SIZE) >> SHIFTLONG);
@@ -1495,7 +1512,8 @@ Validation::RTN Validation::walk_blob(jrd_rel* relation, const blh* header, USHO
 	for (; pages1 < end1; pages1++)
 	{
 		blob_page* page1 = 0;
-		fetch_page(true, *pages1, pag_blob, &window1, &page1);
+		if (fetch_page(true, *pages1, pag_blob, &window1, &page1) == fetch_io)
+			return corrupt(VAL_BLOB_CORRUPT, relation, number.getValue());
 		if (page1->blp_lead_page != header->blh_lead_page) {
 			corrupt(VAL_BLOB_INCONSISTENT, relation, number.getValue());
 		}
@@ -1514,7 +1532,12 @@ Validation::RTN Validation::walk_blob(jrd_rel* relation, const blh* header, USHO
 			for (; pages2 < end2; pages2++, sequence++)
 			{
 				blob_page* page2 = 0;
-				fetch_page(true, *pages2, pag_blob, &window2, &page2);
+				if (fetch_page(true, *pages2, pag_blob, &window2, &page2) == fetch_io)
+				{
+					corrupt(VAL_BLOB_CORRUPT, relation, number.getValue());
+					release_page(&window1);
+					return rtn_corrupt;
+				}
 				if (page2->blp_lead_page != header->blh_lead_page || page2->blp_sequence != sequence)
 				{
 					corrupt(VAL_BLOB_CORRUPT, relation, number.getValue());
@@ -1565,7 +1588,8 @@ Validation::RTN Validation::walk_chain(jrd_rel* relation, const rhd* header,
 #endif
 		vdr_rel_chain_counter++;
 		data_page* page = 0;
-		fetch_page(true, page_number, pag_data, &window, &page);
+		if (fetch_page(true, page_number, pag_data, &window, &page) == fetch_io)
+			return corrupt(VAL_REC_CHAIN_BROKEN, relation, head_number.getValue());
 
 		if (page->dpg_relation != relation->rel_id)
 		{
@@ -1621,7 +1645,8 @@ void Validation::walk_database()
 	DPM_scan_pages(vdr_tdbb);
 	WIN window(DB_PAGE_SPACE, -1);
 	header_page* page = 0;
-	fetch_page(true, HEADER_PAGE, pag_header, &window, &page);
+	if (fetch_page(true, HEADER_PAGE, pag_header, &window, &page) == fetch_io)
+		return;
  	TraNumber next = vdr_max_transaction = Ods::getNT(page);
 
 	if (vdr_flags & VDR_online) {
@@ -1712,7 +1737,8 @@ Validation::RTN Validation::walk_data_page(jrd_rel* relation, ULONG page_number,
 	window.win_flags = WIN_garbage_collector;
 
 	data_page* page = 0;
-	fetch_page(true, page_number, pag_data, &window, &page);
+	if (fetch_page(true, page_number, pag_data, &window, &page) == fetch_io)
+		return rtn_corrupt;
 
 #ifdef DEBUG_VAL_VERBOSE
 	if (VAL_debug_level)
@@ -1951,8 +1977,8 @@ void Validation::walk_generators()
 #endif
 				// It doesn't make a difference generator_page or pointer_page because it's not used.
 				generator_page* page = NULL;
-				fetch_page(true, *ptr, pag_ids, &window, &page);
-				release_page(&window);
+				if (fetch_page(true, *ptr, pag_ids, &window, &page) != fetch_io)
+					release_page(&window);
 			}
 		}
 	}
@@ -1979,7 +2005,8 @@ void Validation::walk_header(ULONG page_num)
 #endif
 		WIN window(DB_PAGE_SPACE, -1);
 		header_page* page = 0;
-		fetch_page(true, page_num, pag_header, &window, &page);
+		if (fetch_page(true, page_num, pag_header, &window, &page) == fetch_io)
+			return;	// corrupt(VAL_BROKEN_HDR_CHAIN, ...)?
 		page_num = page->hdr_next_page;
 		release_page(&window);
 	}
@@ -2052,7 +2079,8 @@ Validation::RTN Validation::walk_index(jrd_rel* relation, index_root_page& root_
 		window.win_flags = WIN_garbage_collector;
 
 		btree_page* page = 0;
-		fetch_page(true, next, pag_index, &window, &page);
+		if (fetch_page(true, next, pag_index, &window, &page) == fetch_io)
+			return corrupt(VAL_INDEX_PAGE_LOST, relation, id + 1, next, __FILE__, __LINE__);
 
 		// remember each page for circular reference detection
 		visited_pages.set(next);
@@ -2294,72 +2322,80 @@ Validation::RTN Validation::walk_index(jrd_rel* relation, index_root_page& root_
 				down_window.win_flags = WIN_garbage_collector;
 
 				btree_page* down_page = 0;
-				fetch_page(false, down_number, pag_index, &down_window, &down_page);
-				const bool downLeafPage = (down_page->btr_level == 0);
 
-				// make sure the initial key is greater than the pointer key
-				UCHAR* downPointer = down_page->btr_nodes + down_page->btr_jump_size;
-
-				IndexNode downNode;
-				downPointer = downNode.readNode(downPointer, downLeafPage);
-
-				p = downNode.data;
-				q = key.key_data;
-				l = MIN(key.key_length, downNode.length);
-				for (; l; l--, p++, q++)
+				if (fetch_page(false, down_number, pag_index, &down_window, &down_page) == fetch_io)
 				{
-					if (*p < *q)
+					// We can skip the page for now. Probably later we will step on it again.
+					corrupt(VAL_INDEX_PAGE_LOST, relation, id + 1, down_number, __FILE__, __LINE__);
+				}
+				else
+				{
+					const bool downLeafPage = (down_page->btr_level == 0);
+
+					// make sure the initial key is greater than the pointer key
+					UCHAR* downPointer = down_page->btr_nodes + down_page->btr_jump_size;
+
+					IndexNode downNode;
+					downPointer = downNode.readNode(downPointer, downLeafPage);
+
+					p = downNode.data;
+					q = key.key_data;
+					l = MIN(key.key_length, downNode.length);
+					for (; l; l--, p++, q++)
 					{
-						corrupt(VAL_INDEX_PAGE_CORRUPT, relation,
-								id + 1, next, page->btr_level, (ULONG) (node.nodePointer - (UCHAR*) page),
-								__FILE__, __LINE__);
+						if (*p < *q)
+						{
+							corrupt(VAL_INDEX_PAGE_CORRUPT, relation,
+									id + 1, next, page->btr_level, (ULONG) (node.nodePointer - (UCHAR*) page),
+									__FILE__, __LINE__);
+						}
+						else if (*p > *q)
+							break;
 					}
-					else if (*p > *q)
-						break;
-				}
 
-				// Only check record-number if this isn't the first page in
-				// the level and it isn't a MARKER.
-				// Also don't check on primary/unique keys, because duplicates aren't
-				// sorted on recordnumber, except for NULL keys.
-				if (down_page->btr_left_sibling &&
-					!(downNode.isEndBucket || downNode.isEndLevel) && (!unique || nullKeyNode))
-				{
-					// Check record number if key is equal with node on
-					// pointer page. In that case record number on page
-					// down should be same or larger.
-					if ((l == 0) && (key.key_length == downNode.length) &&
-						(downNode.recordNumber < down_record_number))
+					// Only check record-number if this isn't the first page in
+					// the level and it isn't a MARKER.
+					// Also don't check on primary/unique keys, because duplicates aren't
+					// sorted on recordnumber, except for NULL keys.
+					if (down_page->btr_left_sibling &&
+						!(downNode.isEndBucket || downNode.isEndLevel) && (!unique || nullKeyNode))
 					{
-						corrupt(VAL_INDEX_PAGE_CORRUPT, relation,
-								id + 1, next, page->btr_level, (ULONG) (node.nodePointer - (UCHAR*) page),
-								__FILE__, __LINE__);
+						// Check record number if key is equal with node on
+						// pointer page. In that case record number on page
+						// down should be same or larger.
+						if ((l == 0) && (key.key_length == downNode.length) &&
+							(downNode.recordNumber < down_record_number))
+						{
+							corrupt(VAL_INDEX_PAGE_CORRUPT, relation,
+									id + 1, next, page->btr_level, (ULONG) (node.nodePointer - (UCHAR*) page),
+									__FILE__, __LINE__);
+						}
 					}
+
+					// check the left and right sibling pointers against the parent pointers
+					if (previous_number != down_page->btr_left_sibling)
+					{
+						corrupt(VAL_INDEX_BAD_LEFT_SIBLING, relation,
+								id + 1, next, page->btr_level, (ULONG) (node.nodePointer - (UCHAR*) page));
+					}
+
+					downNode.readNode(pointer, leafPage);
+					const ULONG next_number = downNode.pageNumber;
+
+					if (!(downNode.isEndBucket || downNode.isEndLevel) &&
+						(next_number != down_page->btr_sibling))
+					{
+						corrupt(VAL_INDEX_MISSES_NODE, relation,
+								id + 1, next, page->btr_level, (ULONG) (node.nodePointer - (UCHAR*) page));
+					}
+
+					if (downNode.isEndLevel && down_page->btr_sibling) {
+						corrupt(VAL_INDEX_ORPHAN_CHILD, relation, id + 1, next);
+					}
+					previous_number = down_number;
+
+					release_page(&down_window);
 				}
-
-				// check the left and right sibling pointers against the parent pointers
-				if (previous_number != down_page->btr_left_sibling)
-				{
-					corrupt(VAL_INDEX_BAD_LEFT_SIBLING, relation,
-							id + 1, next, page->btr_level, (ULONG) (node.nodePointer - (UCHAR*) page));
-				}
-
-				downNode.readNode(pointer, leafPage);
-				const ULONG next_number = downNode.pageNumber;
-
-				if (!(downNode.isEndBucket || downNode.isEndLevel) &&
-					(next_number != down_page->btr_sibling))
-				{
-					corrupt(VAL_INDEX_MISSES_NODE, relation,
-							id + 1, next, page->btr_level, (ULONG) (node.nodePointer - (UCHAR*) page));
-				}
-
-				if (downNode.isEndLevel && down_page->btr_sibling) {
-					corrupt(VAL_INDEX_ORPHAN_CHILD, relation, id + 1, next);
-				}
-				previous_number = down_number;
-
-				release_page(&down_window);
 			}
 		}
 
@@ -2465,7 +2501,11 @@ void Validation::walk_pip()
 			fprintf(stdout, "walk_pip: page %d\n", page_number);
 #endif
 		WIN window(DB_PAGE_SPACE, -1);
-		fetch_page(true, page_number, pag_pages, &window, &page);
+		if (fetch_page(true, page_number, pag_pages, &window, &page) == fetch_io)
+		{
+			corrupt(VAL_PIP_PAGE_LOST, NULL, page_number, sequence);
+			break;	// it's possible to continue but may lead to infinity loop w/o limiting sequence
+		}
 
 		ULONG pipMin = MAX_ULONG;
 		ULONG pipExtent = MAX_ULONG;
@@ -2588,7 +2628,8 @@ Validation::RTN Validation::walk_pointer_page(jrd_rel* relation, ULONG sequence)
 	WIN window(DB_PAGE_SPACE, -1);
 	window.win_flags = WIN_garbage_collector;
 
-	fetch_page(true, (*vector)[sequence], pag_pointer, &window, &page);
+	if (fetch_page(true, (*vector)[sequence], pag_pointer, &window, &page) == fetch_io)
+		return corrupt(VAL_P_PAGE_LOST, relation, sequence);
 
 #ifdef DEBUG_VAL_VERBOSE
 	if (VAL_debug_level)
@@ -2705,7 +2746,9 @@ Validation::RTN Validation::walk_pointer_page(jrd_rel* relation, ULONG sequence)
 				return corrupt(VAL_P_PAGE_LOST, relation, sequence);
 			}
 
-			fetch_page(false, (*vector)[sequence], pag_pointer, &window, &page);
+			const ULONG ppgNext = page->ppg_next;
+			if (fetch_page(false, (*vector)[sequence], pag_pointer, &window, &page) == fetch_io)
+				return corrupt(VAL_P_PAGE_INCONSISTENT, relation, ppgNext, sequence);
 
 			++sequence;
 			const bool error = (sequence >= vector->count()) ||
@@ -2816,7 +2859,8 @@ Validation::RTN Validation::walk_record(jrd_rel* relation, const rhd* header, US
 		WIN window(DB_PAGE_SPACE, -1);
 		window.win_flags = WIN_garbage_collector;
 
-		fetch_page(true, page_number, pag_data, &window, &page);
+		if (fetch_page(true, page_number, pag_data, &window, &page) == fetch_io)
+			return corrupt(VAL_REC_FRAGMENT_CORRUPT, relation, number.getValue());
 
 		const data_page::dpg_repeat* line = &page->dpg_rpt[line_number];
 
@@ -2914,14 +2958,15 @@ void Validation::checkDPinPP(jrd_rel* relation, ULONG page_number)
 	/**************************************
 	*
 	* Functional description
-	*	Check if data page presented in pointer page.
-	* If not we try to fix it by setting pointer page slot in the page_number.
+	*	Check if data page is presented in pointer page.
+	* If it does not we try to fix it by setting the pointer page slot in the page_number.
 	* Early in walk_chain we observed that this page is related to the relation so we skip such kind of check here.
 	**************************************/
 
 	WIN window(DB_PAGE_SPACE, page_number);
 	data_page* dpage;
-	fetch_page(false, page_number, pag_data, &window, &dpage);
+	if (fetch_page(false, page_number, pag_data, &window, &dpage) == fetch_io)
+		return;	// error was reported in fetch_page. There is nothing to add.
 	const ULONG sequence = dpage->dpg_sequence;
 	const bool dpEmpty = (dpage->dpg_count == 0);
 	release_page(&window);
@@ -2935,7 +2980,8 @@ void Validation::checkDPinPP(jrd_rel* relation, ULONG page_number)
 	pointer_page* ppage = NULL;
 	if (pp_sequence < vector->count())
 	{
-		fetch_page(false, (*vector)[pp_sequence], pag_pointer, &window, &ppage);
+		if (fetch_page(false, (*vector)[pp_sequence], pag_pointer, &window, &ppage) == fetch_io)
+			return;	// error was reported in fetch_page. There is nothing to add.
 		if (slot >= ppage->ppg_count)
 		{
 			corrupt(VAL_DATA_PAGE_SLOT_NOT_FOUND, relation, page_number, window.win_page.getPageNum(), slot);
@@ -3000,7 +3046,8 @@ void Validation::checkDPinPIP(jrd_rel* relation, ULONG page_number)
 	WIN pip_window(DB_PAGE_SPACE, (sequence == 0) ? pageSpace->pipFirst : sequence * pageMgr.pagesPerPIP - 1);
 
 	page_inv_page* pages;
-	fetch_page(false, pip_window.win_page.getPageNum(), pag_pages, &pip_window, &pages);
+	if (fetch_page(false, pip_window.win_page.getPageNum(), pag_pages, &pip_window, &pages) == fetch_io)
+		return;	// error was reported in fetch_page. There is nothing to add.
 	if (pages->pip_bits[relative_bit >> 3] & (1 << (relative_bit & 7)))
 	{
 		corrupt(VAL_DATA_PAGE_ISNT_IN_PIP, relation, page_number, pip_window.win_page.getPageNum(), relative_bit);
@@ -3076,7 +3123,13 @@ Validation::RTN Validation::walk_relation(jrd_rel* relation)
 
 		WIN window(DB_PAGE_SPACE, -1);
 		header_page* page = NULL;
-		fetch_page(false, HEADER_PAGE, pag_header, &window, &page);
+		if (fetch_page(false, HEADER_PAGE, pag_header, &window, &page) == fetch_io)
+		{
+			output("Cannot read header page\n");
+			vdr_errors++;
+			return rtn_ok;	// Return OK like above
+		}
+
 		vdr_max_transaction = Ods::getNT(page);
 		release_page(&window);
 	}
@@ -3220,7 +3273,9 @@ Validation::RTN Validation::walk_root(jrd_rel* relation, bool getInfo)
 
 	index_root_page* page = 0;
 	WIN window(DB_PAGE_SPACE, -1);
-	fetch_page(!getInfo, relPages->rel_index_root, pag_root, &window, &page);
+
+	if (fetch_page(!getInfo, relPages->rel_index_root, pag_root, &window, &page) == fetch_io)
+		return corrupt(VAL_INDEX_ROOT_MISSING, relation);
 
 	for (USHORT i = 0; i < page->irt_count; i++)
 	{
@@ -3231,7 +3286,8 @@ Validation::RTN Validation::walk_root(jrd_rel* relation, bool getInfo)
 
 		release_page(&window);
 		MET_lookup_index(vdr_tdbb, index, relation->rel_name, i + 1);
-		fetch_page(false, relPages->rel_index_root, pag_root, &window, &page);
+		if (fetch_page(false, relPages->rel_index_root, pag_root, &window, &page) == fetch_io)
+			continue;
 
 		if (vdr_idx_incl)
 		{
@@ -3303,7 +3359,11 @@ Validation::RTN Validation::walk_tip(TraNumber transaction)
 		}
 
 		WIN window(DB_PAGE_SPACE, -1);
-		fetch_page(true, (*vector)[sequence], pag_transactions, &window, &page);
+		if (fetch_page(true, (*vector)[sequence], pag_transactions, &window, &page) == fetch_io)
+		{
+			corrupt(VAL_TIP_LOST_SEQUENCE, 0, sequence);
+			continue;
+		}
 
 #ifdef DEBUG_VAL_VERBOSE
 		if (VAL_debug_level)
@@ -3346,7 +3406,11 @@ Validation::RTN Validation::walk_scns()
 		const ULONG scnPage = pageSpace->getSCNPageNum(sequence);
 		WIN scnWindow(pageSpace->pageSpaceID, scnPage);
 		scns_page* scns = NULL;
-		fetch_page(true, scnPage, pag_scns, &scnWindow, &scns);
+		if (fetch_page(true, scnPage, pag_scns, &scnWindow, &scns) == fetch_io)
+		{
+			corrupt(VAL_SCN_PAGE_LOST, 0, scnPage, sequence);
+			continue;
+		}
 
 		if (scns->scn_sequence != sequence)
 		{

--- a/src/jrd/validation.cpp
+++ b/src/jrd/validation.cpp
@@ -1260,11 +1260,12 @@ Validation::FETCH_CODE Validation::fetch_page(bool mark, ULONG page_number,
 		const ULONG page_scn = (*page_pointer)->pag_scn;
 
 		WIN scns_window(DB_PAGE_SPACE, scn_page_num);
-		scns_page* scns = (scns_page*) *page_pointer;
+		scns_page* scns;
 
-		if (scn_page_num != page_number) {
+		if (scn_page_num == page_number)
+			scns = (scns_page*) *page_pointer;
+		else
 			fetch_page(mark, scn_page_num, pag_scns, &scns_window, &scns);
-		}
 
 		if (scns->scn_pages[scn_slot] != page_scn)
 		{

--- a/src/jrd/validation.h
+++ b/src/jrd/validation.h
@@ -150,6 +150,7 @@ private:
 	int vdr_errors;
 	int vdr_warns;
 	int vdr_fixed;
+	int vdr_ignored;						// Counts a number of corrupts which mush not prevent orphan pages fixing
 	TraNumber vdr_max_transaction;
 	FB_UINT64 vdr_rel_backversion_counter;	// Counts slots w/rhd_chain
 	PageBitmap* vdr_backversion_pages;		// 1 bit per visited table page

--- a/src/jrd/validation.h
+++ b/src/jrd/validation.h
@@ -69,7 +69,8 @@ private:
 		fetch_ok,
 		//fetch_checksum,
 		fetch_type,
-		fetch_duplicate
+		fetch_duplicate,
+		fetch_io			// IO error while page reading
 	};
 
 	enum RTN
@@ -131,8 +132,12 @@ private:
 		VAL_DATA_PAGE_SLOT_BAD_VAL  = 37,
 		VAL_DATA_PAGE_HASNO_PP      = 38,
 		VAL_DATA_PAGE_SEC_PRI		= 39,
+		VAL_FETCH_PAGE_ERROR		= 40,
+		VAL_INDEX_PAGE_LOST			= 41,
+		VAL_PIP_PAGE_LOST			= 42,
+		VAL_SCN_PAGE_LOST			= 43,
 
-		VAL_MAX_ERROR				= 40
+		VAL_MAX_ERROR
 	};
 
 	struct MSG_ENTRY

--- a/src/utilities/gstat/dba.epp
+++ b/src/utilities/gstat/dba.epp
@@ -195,7 +195,7 @@ static void db_error(int);
 static USHORT get_format_length(ISC_STATUS*, isc_db_handle, isc_tr_handle, ISC_QUAD&);
 
 static dba_fil* db_open(const char*, USHORT);
-static const pag* db_read(SLONG page_number, bool ok_enc = false);
+static const pag* db_read(ULONG page_number, bool ok_enc = false);
 #ifdef WIN_NT
 static void db_close(void* file_desc);
 #else
@@ -264,7 +264,7 @@ public:
 	USHORT page_size;
 	USHORT dp_per_pp;
 	USHORT max_records;
-	SLONG page_number;
+	ULONG page_number;
 	pag* buffer1;
 	pag* buffer2;
 	pag* global_buffer;
@@ -615,8 +615,8 @@ int gstat(Firebird::UtilSvc* uSvc)
 	SCHAR temp[RAW_HEADER_SIZE];
 	tddba->page_size = sizeof(temp);
 	tddba->global_buffer = (pag*) temp;
-	tddba->page_number = -1;
-	const header_page* header = (const header_page*) db_read((SLONG) 0);
+	tddba->page_number = ~0u;
+	const header_page* header = (const header_page*) db_read(0);
 
 	uSvc->started();
 
@@ -641,7 +641,7 @@ int gstat(Firebird::UtilSvc* uSvc)
 	tddba->buffer1 = (pag*) alloc(tddba->page_size);
 	tddba->buffer2 = (pag*) alloc(tddba->page_size);
 	tddba->global_buffer = (pag*) alloc(tddba->page_size);
-	tddba->page_number = -1;
+	tddba->page_number = ~0u;
 
 	// gather continuation files
 
@@ -1331,7 +1331,7 @@ static void analyze_data( dba_rel* relation, bool sw_record)
 
 	pointer_page* ptr_page = (pointer_page*) tddba->buffer1;
 
-	for (SLONG next_pp = relation->rel_pointer_page; next_pp; next_pp = ptr_page->ppg_next)
+	for (ULONG next_pp = relation->rel_pointer_page; next_pp; next_pp = ptr_page->ppg_next)
 	{
 		++relation->rel_pointer_pages;
 		memcpy(ptr_page, (const SCHAR*) db_read(next_pp), tddba->page_size);
@@ -1477,13 +1477,13 @@ static void analyze_blob(dba_rel* relation, const blh* blob, int length)
 		{
 			relation->rel_blobs_level_2++;
 
-			SLONG pages[MAX_PAGE_SIZE / sizeof(SLONG)];
-			memcpy(pages, blob->blh_page, slots * sizeof(SLONG));
+			ULONG pages[MAX_PAGE_SIZE / sizeof(ULONG)];
+			memcpy(pages, blob->blh_page, slots * sizeof(ULONG));
 
 			for (int i = 0; i < slots; i++)
 			{
 				const blob_page* bpage = (const blob_page*) db_read(pages[i]);
-				relation->rel_blob_pages += bpage->blp_length / sizeof(SLONG);
+				relation->rel_blob_pages += bpage->blp_length / sizeof(ULONG);
 			}
 		}
 	}
@@ -1507,7 +1507,7 @@ static ULONG analyze_fragments(dba_rel* relation, const rhdf* header)
 
 	while (header->rhdf_flags & rhd_incomplete)
 	{
-		const SLONG f_page = header->rhdf_f_page;
+		const ULONG f_page = header->rhdf_f_page;
 		const USHORT f_line = header->rhdf_f_line;
 		const data_page* page = (const data_page*) db_read(f_page);
 		if (page->dpg_header.pag_type != pag_data || page->dpg_relation != relation->rel_id ||
@@ -1555,7 +1555,7 @@ static void analyze_index( const dba_rel* relation, dba_idx* index)
 
 	const index_root_page* index_root = (const index_root_page*) db_read(relation->rel_index_root);
 
-	SLONG page;
+	ULONG page;
 	if (index_root->irt_count <= index->idx_id ||
 		!(page = index_root->irt_rpt[index->idx_id].getRoot()))
 	{
@@ -1578,7 +1578,7 @@ static void analyze_index( const dba_rel* relation, dba_idx* index)
 	}
 
 	bool firstLeafNode = true;
-	SLONG number;
+	ULONG number;
 	FB_UINT64 duplicates = 0;
 
 	// Maximum key length is 1/4 of the used page-size
@@ -1701,7 +1701,7 @@ static ULONG analyze_versions( dba_rel* relation, const rhdf* header)
  **************************************/
 	//tdba* tddba = tdba::getSpecific();
 	ULONG space = 0, versions = 0;
-	SLONG b_page = header->rhdf_b_page;
+	ULONG b_page = header->rhdf_b_page;
 	USHORT b_line = header->rhdf_b_line;
 
 	while (b_page)
@@ -1912,7 +1912,7 @@ static dba_fil* db_open(const char* file_name, USHORT file_length)
 }
 
 
-static const pag* db_read( SLONG page_number, bool ok_enc)
+static const pag* db_read( ULONG page_number, bool ok_enc)
 {
 /**************************************
  *
@@ -1935,7 +1935,7 @@ static const pag* db_read( SLONG page_number, bool ok_enc)
 	tddba->page_number = page_number;
 
 	dba_fil* fil;
-	for (fil = tddba->files; page_number > (SLONG) fil->fil_max_page && fil->fil_next;)
+	for (fil = tddba->files; page_number > fil->fil_max_page && fil->fil_next;)
 	{
 		 fil = fil->fil_next;
 	}
@@ -2015,7 +2015,7 @@ static void db_error( int status)
  *
  **************************************/
 	tdba* tddba = tdba::getSpecific();
-	tddba->page_number = -1;
+	tddba->page_number = ~0u;
 
 	// FIXME: The strerror() function returns the appropriate description
 	// string, or an unknown error message if the error code is unknown.
@@ -2097,7 +2097,7 @@ static dba_fil* db_open(const char* file_name, USHORT file_length)
 }
 
 
-static const pag* db_read( SLONG page_number, bool ok_enc)
+static const pag* db_read( ULONG page_number, bool ok_enc)
 {
 /**************************************
  *
@@ -2117,7 +2117,7 @@ static const pag* db_read( SLONG page_number, bool ok_enc)
 	tddba->page_number = page_number;
 
 	dba_fil* fil;
-	for (fil = tddba->files; page_number > (SLONG) fil->fil_max_page && fil->fil_next;)
+	for (fil = tddba->files; page_number > fil->fil_max_page && fil->fil_next;)
 	{
 		fil = fil->fil_next;
 	}
@@ -2177,7 +2177,7 @@ static void dba_error(USHORT errcode, const SafeArg& arg)
  *
  **************************************/
 	tdba* tddba = tdba::getSpecific();
-	tddba->page_number = -1;
+	tddba->page_number = ~0u;
 
 	tddba->uSvc->setServiceStatus(GSTAT_MSG_FAC, errcode, arg);
 	if (!tddba->uSvc->isService())


### PR DESCRIPTION
Fix page number data type to ULONG.
Fix call release_page according to fetch_page.
CCH_fetch handles I/O errors and returns NULL in buffer if read_shadow is not set.
Check all calls of fetch_page to handle returned value.
Add several corrupt messages.