### PR TITLE
Get full scale of a floating number in Scientific notation (#7488 fix)

### DIFF
--- a/src/common/cvt.cpp
+++ b/src/common/cvt.cpp
@@ -1268,7 +1268,7 @@ bool CVT_get_boolean(const dsc* desc, ErrorFunction err)
 }
 
 
-double CVT_get_double(const dsc* desc, DecimalStatus decSt, ErrorFunction err, bool* getNumericOverflow)
+double CVT_get_double(const dsc* desc, DecimalStatus decSt, ErrorFunction err, bool* getNumericOverflow, SSHORT* descScale)
 {
 /**************************************
  *
@@ -1492,6 +1492,9 @@ double CVT_get_double(const dsc* desc, DecimalStatus decSt, ErrorFunction err, b
 
 				err(Arg::Gds(isc_arith_except) << Arg::Gds(isc_numeric_out_of_range));
 			}
+
+			if (descScale)
+				*descScale = static_cast<SSHORT>(scale);
 		}
 		return value;
 
@@ -1517,6 +1520,9 @@ double CVT_get_double(const dsc* desc, DecimalStatus decSt, ErrorFunction err, b
 		value *= CVT_power_of_ten(dscale);
 	else if (dscale < 0)
 		value /= CVT_power_of_ten(-dscale);
+
+	if (descScale)
+		*descScale = static_cast<SSHORT>(dscale);
 
 	return value;
 }

--- a/src/common/cvt.h
+++ b/src/common/cvt.h
@@ -89,7 +89,7 @@ void CVT_conversion_error(const dsc*, ErrorFunction);
 double CVT_power_of_ten(const int);
 SLONG CVT_get_long(const dsc*, SSHORT, Firebird::DecimalStatus, ErrorFunction);
 bool CVT_get_boolean(const dsc*, ErrorFunction);
-double CVT_get_double(const dsc*, Firebird::DecimalStatus, ErrorFunction, bool* getNumericOverflow = nullptr);
+double CVT_get_double(const dsc*, Firebird::DecimalStatus, ErrorFunction, bool* getNumericOverflow = nullptr, SSHORT* = nullptr);
 Firebird::Decimal64 CVT_get_dec64(const dsc*, Firebird::DecimalStatus, ErrorFunction);
 Firebird::Decimal128 CVT_get_dec128(const dsc*, Firebird::DecimalStatus, ErrorFunction);
 Firebird::Int128 CVT_get_int128(const dsc*, SSHORT, Firebird::DecimalStatus, ErrorFunction);

--- a/src/jrd/cvt.cpp
+++ b/src/jrd/cvt.cpp
@@ -280,7 +280,7 @@ UCHAR CVT_get_numeric(const UCHAR* string, const USHORT length, SSHORT* scale, v
 		((value < 0) && (sign != -1)))) // MAX_SINT64+1 wrapped around
 	{
 		// convert to double
-		*(double*) ptr = CVT_get_double(&desc, 0, ERR_post, &over);
+		*(double*) ptr = CVT_get_double(&desc, 0, ERR_post, &over, scale);
 		if (!over)
 			return dtype_double;
 	}

--- a/src/jrd/tests/DscConvertTest.cpp
+++ b/src/jrd/tests/DscConvertTest.cpp
@@ -1,0 +1,35 @@
+#include "firebird.h"
+#include "boost/test/unit_test.hpp"
+
+#include "../jrd/cvt_proto.h"
+
+using namespace Firebird;
+using namespace Jrd;
+
+BOOST_AUTO_TEST_SUITE(EngineSuite)
+BOOST_AUTO_TEST_SUITE(DscConvertTests)
+
+
+void toDoubleTest(const string& input, double expectedValue, SSHORT expectedScale)
+{
+	double outputValue;
+	SSHORT outputScale = 0;
+	SSHORT type = CVT_get_numeric((const UCHAR*)input.c_str(), input.length(), &outputScale, (void*)(&outputValue));
+	BOOST_TEST(type == dtype_double);
+	BOOST_TEST(outputValue == expectedValue);
+	BOOST_TEST(outputScale == expectedScale);
+}
+
+BOOST_AUTO_TEST_CASE(TextToDouble)
+{
+	toDoubleTest("345.12e-2", 3.4512, 4);
+	toDoubleTest("34512e-4", 3.4512, 4);
+	toDoubleTest("34.512e-1", 3.4512, 4);
+	toDoubleTest("3.4512e0", 3.4512, 4);
+	toDoubleTest("0.34512e1", 3.4512, 4);
+	toDoubleTest("0.034512e2", 3.4512, 4);
+	toDoubleTest("0.0034512e3", 3.4512, 4);
+}
+
+BOOST_AUTO_TEST_SUITE_END()	// DscConvertTests
+BOOST_AUTO_TEST_SUITE_END()	// EngineSuite


### PR DESCRIPTION
The old output:
```SQL
select cast(345.12e-2 as varchar(30)) from rdb$database;

CAST                           
============================== 
3.45  

```
The new one:
```SQL
SQL> SELECT CAST(345.12e-2 as VARCHAR(10)) from RDB$DATABASE;

CAST       
========== 
3.4512000 
```