### PR TITLE
Suggested fix for #7514: Segfault when detaching after deleting shadow on Classic

### DIFF
--- a/src/jrd/sdw.cpp
+++ b/src/jrd/sdw.cpp
@@ -581,7 +581,11 @@ void SDW_get_shadows(thread_db* tdbb)
 	// to prevent missing any new ones later on, although it does not
 	// matter for the purposes of the current page being written
 
-	MET_get_shadow_files(tdbb, false);
+	// no use even trying to get shadow files in a case when we invoked from
+	// JRD_shutdown_database, i.e. there are no attachments to database
+
+	if (tdbb->getAttachment())
+		MET_get_shadow_files(tdbb, false);
 }
 
 


### PR DESCRIPTION
The reason is as obvious as bug is hard to reproduce. 
When process A deletes shadow it sends appropriate AST to others. Each time before dealing with shadows list appropriate flag is checked which normally causes reload of shadows info. But when database is closing (JRD_shutdown_database) no attachments are left and that does not prevent receiving shadow's AST, i.e. it may be needed to reload shadows info when writing transaction counters to header.

The only visible solution is to skip shadows reload at this moment.