### PR TITLE
Optimize creation of expression and partial indices

### DIFF
--- a/src/jrd/btr.h
+++ b/src/jrd/btr.h
@@ -362,9 +362,19 @@ private:
 class IndexKey
 {
 public:
-	IndexKey(thread_db* tdbb, jrd_rel* relation, index_desc* idx);
+	IndexKey(thread_db* tdbb, jrd_rel* relation, index_desc* idx)
+		: m_tdbb(tdbb), m_relation(relation), m_index(idx),
+		  m_keyType((idx->idx_flags & idx_unique) ? INTL_KEY_UNIQUE : INTL_KEY_SORT),
+		  m_segments(idx->idx_count), m_expression(tdbb, idx)
+	{}
+
 	IndexKey(thread_db* tdbb, jrd_rel* relation, index_desc* idx,
-			 USHORT type, USHORT segments);
+			 USHORT keyType, USHORT segments)
+		: m_tdbb(tdbb), m_relation(relation), m_index(idx),
+		  m_keyType(keyType), m_segments(segments), m_expression(tdbb, idx)
+	{
+		fb_assert(m_segments && m_segments <= idx->idx_count);
+	}
 
 	idx_e compose(Record* record);
 
@@ -414,10 +424,10 @@ private:
 	thread_db* const m_tdbb;
 	jrd_rel* const m_relation;
 	index_desc* const m_index;
-	const USHORT m_type;
+	const USHORT m_keyType;
 	const USHORT m_segments;
 	temporary_key m_key;
-	Firebird::AutoPtr<IndexExpression> m_expression;
+	IndexExpression m_expression;
 };
 
 } //namespace Jrd

--- a/src/jrd/btr.h
+++ b/src/jrd/btr.h
@@ -349,11 +349,10 @@ public:
 	IndexExpression(thread_db* tdbb, index_desc* idx);
 	~IndexExpression();
 
-	dsc* evaluate(Record* record, bool& notNull) const;
+	dsc* evaluate(Record* record) const;
 
 private:
 	thread_db* const m_tdbb;
-	dsc* m_desc = nullptr;
 	ValueExprNode* m_expression = nullptr;
 	Request* m_request = nullptr;
 };

--- a/src/jrd/btr.h
+++ b/src/jrd/btr.h
@@ -327,6 +327,36 @@ private:
 	bool isLocationDefined;
 };
 
+// Helper classes to allow efficient evaluation of index conditions/expressions
+
+class IndexCondition
+{
+public:
+	IndexCondition(thread_db* tdbb, index_desc* idx);
+	~IndexCondition();
+
+	bool evaluate(Record* record) const;
+
+private:
+	thread_db* const m_tdbb;
+	BoolExprNode* m_condition = nullptr;
+	Request* m_request = nullptr;
+};
+
+class IndexExpression
+{
+public:
+	IndexExpression(thread_db* tdbb, index_desc* idx);
+	~IndexExpression();
+
+	dsc* evaluate(Record* record, bool& notNull) const;
+
+private:
+	thread_db* const m_tdbb;
+	dsc* m_desc = nullptr;
+	ValueExprNode* m_expression = nullptr;
+	Request* m_request = nullptr;
+};
 
 } //namespace Jrd
 

--- a/src/jrd/btr_proto.h
+++ b/src/jrd/btr_proto.h
@@ -35,7 +35,7 @@ void	BTR_create(Jrd::thread_db*, Jrd::IndexCreation&, Jrd::SelectivityList&);
 bool	BTR_delete_index(Jrd::thread_db*, Jrd::win*, USHORT);
 bool	BTR_description(Jrd::thread_db*, Jrd::jrd_rel*, Ods::index_root_page*, Jrd::index_desc*, USHORT);
 bool	BTR_check_condition(Jrd::thread_db*, Jrd::index_desc*, Jrd::Record*);
-DSC*	BTR_eval_expression(Jrd::thread_db*, Jrd::index_desc*, Jrd::Record*, bool&);
+dsc*	BTR_eval_expression(Jrd::thread_db*, Jrd::index_desc*, Jrd::Record*, bool&);
 void	BTR_evaluate(Jrd::thread_db*, const Jrd::IndexRetrieval*, Jrd::RecordBitmap**, Jrd::RecordBitmap*);
 UCHAR*	BTR_find_leaf(Ods::btree_page*, Jrd::temporary_key*, UCHAR*, USHORT*, bool, int);
 Ods::btree_page*	BTR_find_page(Jrd::thread_db*, const Jrd::IndexRetrieval*, Jrd::win*, Jrd::index_desc*,

--- a/src/jrd/btr_proto.h
+++ b/src/jrd/btr_proto.h
@@ -35,7 +35,7 @@ void	BTR_create(Jrd::thread_db*, Jrd::IndexCreation&, Jrd::SelectivityList&);
 bool	BTR_delete_index(Jrd::thread_db*, Jrd::win*, USHORT);
 bool	BTR_description(Jrd::thread_db*, Jrd::jrd_rel*, Ods::index_root_page*, Jrd::index_desc*, USHORT);
 bool	BTR_check_condition(Jrd::thread_db*, Jrd::index_desc*, Jrd::Record*);
-dsc*	BTR_eval_expression(Jrd::thread_db*, Jrd::index_desc*, Jrd::Record*, bool&);
+dsc*	BTR_eval_expression(Jrd::thread_db*, Jrd::index_desc*, Jrd::Record*);
 void	BTR_evaluate(Jrd::thread_db*, const Jrd::IndexRetrieval*, Jrd::RecordBitmap**, Jrd::RecordBitmap*);
 UCHAR*	BTR_find_leaf(Ods::btree_page*, Jrd::temporary_key*, UCHAR*, USHORT*, bool, int);
 Ods::btree_page*	BTR_find_page(Jrd::thread_db*, const Jrd::IndexRetrieval*, Jrd::win*, Jrd::index_desc*,

--- a/src/jrd/btr_proto.h
+++ b/src/jrd/btr_proto.h
@@ -41,8 +41,6 @@ UCHAR*	BTR_find_leaf(Ods::btree_page*, Jrd::temporary_key*, UCHAR*, USHORT*, boo
 Ods::btree_page*	BTR_find_page(Jrd::thread_db*, const Jrd::IndexRetrieval*, Jrd::win*, Jrd::index_desc*,
 								 Jrd::temporary_key*, Jrd::temporary_key*, bool = true);
 void	BTR_insert(Jrd::thread_db*, Jrd::win*, Jrd::index_insertion*);
-Jrd::idx_e	BTR_key(Jrd::thread_db*, Jrd::jrd_rel*, Jrd::Record*, Jrd::index_desc*, Jrd::temporary_key*,
-					const USHORT, USHORT = 0);
 USHORT	BTR_key_length(Jrd::thread_db*, Jrd::jrd_rel*, Jrd::index_desc*);
 Ods::btree_page*	BTR_left_handoff(Jrd::thread_db*, Jrd::win*, Ods::btree_page*, SSHORT);
 bool	BTR_lookup(Jrd::thread_db*, Jrd::jrd_rel*, USHORT, Jrd::index_desc*, Jrd::RelationPages*);

--- a/src/jrd/idx.cpp
+++ b/src/jrd/idx.cpp
@@ -464,7 +464,6 @@ bool IndexCreateTask::handler(WorkItem& _item)
 	jrd_tra* transaction = item->m_tra ? item->m_tra : m_creation->transaction;
 	Sort* scb = item->m_sort;
 
-	idx_e result = idx_e_ok;
 	RecordStack stack;
 	record_param primary, secondary;
 	secondary.rpb_relation = relation;
@@ -815,8 +814,6 @@ void IDX_create_index(thread_db* tdbb,
  *	Create and populate index.
  *
  **************************************/
-	idx_e result = idx_e_ok;
-
 	SET_TDBB(tdbb);
 	Database* dbb = tdbb->getDatabase();
 	Jrd::Attachment* attachment = tdbb->getAttachment();
@@ -1797,8 +1794,6 @@ static idx_e check_partner_index(thread_db* tdbb,
  **************************************/
 	SET_TDBB(tdbb);
 
-	idx_e result = idx_e_ok;
-
 	// get the index root page for the partner relation
 
 	WIN window(get_root_page(tdbb, partner_relation));
@@ -1855,7 +1850,7 @@ static idx_e check_partner_index(thread_db* tdbb,
 		(tmpIndex.idx_flags & idx_unique) ? INTL_KEY_UNIQUE : INTL_KEY_SORT;
 
 	IndexKey key(tdbb, relation, &tmpIndex, keyType, segment);
-	result = key.compose(record);
+	auto result = key.compose(record);
 
 	CCH_RELEASE(tdbb, &window);
 

--- a/src/jrd/met.epp
+++ b/src/jrd/met.epp
@@ -2685,7 +2685,7 @@ void MET_lookup_index_expression(thread_db* tdbb, jrd_rel* relation, index_desc*
 	{
 		idx->idx_expression = index_block->idb_expression;
 		idx->idx_expression_statement = index_block->idb_expression_statement;
-		memcpy(&idx->idx_expression_desc, &index_block->idb_expression_desc, sizeof(struct dsc));
+		idx->idx_expression_desc = index_block->idb_expression_desc;
 		return;
 	}
 
@@ -2705,7 +2705,7 @@ void MET_lookup_index_expression(thread_db* tdbb, jrd_rel* relation, index_desc*
 		if (idx->idx_expression_statement)
 		{
 			idx->idx_expression_statement->release(tdbb);
-			idx->idx_expression_statement = NULL;
+			idx->idx_expression_statement = nullptr;
 		}
 
 		// parse the blr, making sure to create the resulting expression

--- a/src/jrd/replication/Applier.cpp
+++ b/src/jrd/replication/Applier.cpp
@@ -1079,16 +1079,14 @@ bool Applier::lookupRecord(thread_db* tdbb,
 
 	if (lookupKey(tdbb, relation, idx))
 	{
-		temporary_key key;
-		const auto result = BTR_key(tdbb, relation, record, &idx, &key,
-			(idx.idx_flags & idx_unique) ? INTL_KEY_UNIQUE : INTL_KEY_SORT);
-		if (result != idx_e_ok)
+		IndexKey key(tdbb, relation, &idx);
+		if (const auto result = key.compose(record))
 		{
 			IndexErrorContext context(relation, &idx);
 			context.raise(tdbb, result, record);
 		}
 
-		IndexRetrieval retrieval(relation, &idx, idx.idx_count, &key);
+		IndexRetrieval retrieval(relation, &idx, idx.idx_count, key);
 		retrieval.irb_generic = irb_equality | (idx.idx_flags & idx_descending ? irb_descending : 0);
 
 		BTR_evaluate(tdbb, &retrieval, &m_bitmap, NULL);

--- a/src/jrd/validation.cpp
+++ b/src/jrd/validation.cpp
@@ -1080,7 +1080,10 @@ void Validation::cleanup()
 	vdr_idx_records = NULL;
 
 	for (auto& item : vdr_cond_idx)
+	{
 		delete item.m_recs;
+		delete item.m_condition;
+	}
 
 	vdr_cond_idx.clear();
 }
@@ -1893,7 +1896,10 @@ Validation::RTN Validation::walk_data_page(jrd_rel* relation, ULONG page_number,
 				{
 					if (getInfo.m_desc.idx_flags & idx_condition)
 					{
-						if (BTR_check_condition(vdr_tdbb, &getInfo.m_desc, rpb.rpb_record))
+						if (!getInfo.m_condition)
+							getInfo.m_condition = FB_NEW_POOL(*pool) IndexCondition(vdr_tdbb, &getInfo.m_desc);
+
+						if (getInfo.m_condition->evaluate(rpb.rpb_record))
 							RBM_SET(pool, &getInfo.m_recs, recno);
 					}
 				}
@@ -3076,7 +3082,10 @@ Validation::RTN Validation::walk_relation(jrd_rel* relation)
 	// walking relation. System relations have no conditional indices.
 
 	for (auto& item : vdr_cond_idx)
+	{
 		delete item.m_recs;
+		delete item.m_condition;
+	}
 
 	vdr_cond_idx.clear();
 

--- a/src/jrd/validation.h
+++ b/src/jrd/validation.h
@@ -82,11 +82,11 @@ private:
 	struct IdxInfo
 	{
 		IdxInfo()
-		  : m_recs(nullptr)
 		{}
 
 		index_desc m_desc;
-		RecordBitmap* m_recs;
+		RecordBitmap* m_recs = nullptr;
+		IndexCondition* m_condition = nullptr;
 	};
 
 	enum VAL_ERRORS


### PR DESCRIPTION
The idea is to share an expression/condition request between multiple processed records in cases when it's possible (index creation, garbage collection, validation).

Test case:

```
recreate table t (id int) ;
insert into t select row_number() over() from rdb$types, rdb$types, rdb$types;
commit;

set stat on;

create index it0 on t (id);
create index it1 on t (id) where id is not null;
create index it2 on t computed (id+0);
create index it3 on t computed (id+0) where id is not null;

-- v5

SQL> create index it0 on t (id);
Elapsed time = 9.331 sec

SQL> create index it1 on t (id) where id is not null;
Elapsed time = 69.126 sec

SQL> create index it2 on t computed (id+0);
Elapsed time = 72.234 sec

SQL> create index it3 on t computed (id+0) where id is not null;
Elapsed time = 129.571 sec

-- v5 with patch

SQL> create index it0 on t (id);
Elapsed time = 9.369 sec

SQL> create index it1 on t (id) where id is not null;
Elapsed time = 10.920 sec

SQL> create index it2 on t computed (id+0);
Elapsed time = 12.464 sec

SQL> create index it3 on t computed (id+0) where id is not null;
Elapsed time = 14.466 sec

```