### PR TITLE
Add LoongArch64 support

### DIFF
--- a/builds/posix/prefix.linux_loongarch64
+++ b/builds/posix/prefix.linux_loongarch64
@@ -1,0 +1,20 @@
+# The contents of this file are subject to the Interbase Public
+# License Version 1.0 (the "License"); you may not use this file
+# except in compliance with the License. You may obtain a copy
+# of the License at http://www.Inprise.com/IPL.html
+#
+# Software distributed under the License is distributed on an
+# "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express
+# or implied. See the License for the specific language governing
+# rights and limitations under the License.
+#
+# The Original Code was created by Inprise Corporation
+# and its predecessors. Portions created by Inprise Corporation are
+# Copyright (C) Inprise Corporation.
+#
+# All Rights Reserved.
+# Contributor(s): ______________________________________.
+# Start of file prefix.linux:  $(VERSION)  $(PLATFORM)
+
+PROD_FLAGS=-O3 -DLINUX -DLOONGARCH64 -pipe -p -MMD -fPIC -fsigned-char -fmessage-length=0 -std=gnu++03 -fno-delete-null-pointer-checks
+DEV_FLAGS=-ggdb -DLINUX -DLOONGARCH64 -pipe -p -MMD -fPIC -Werror=delete-incomplete -Wall -fsigned-char -fmessage-length=0 -Wno-non-virtual-dtor

--- a/configure.ac
+++ b/configure.ac
@@ -317,6 +317,18 @@ dnl CPU_TYPE=ppc64
     libdir=/usr/lib64
     ;;
 
+  loongarch64*-*-linux*)
+    MAKEFILE_PREFIX=linux_loongarch64
+    INSTALL_PREFIX=linux
+    PLATFORM=LINUX
+    AC_DEFINE(LINUX, 1, [Define this if OS is Linux])
+    EDITLINE_FLG=Y
+    SHRLIB_EXT=so
+    STD_EDITLINE=true
+    STD_ICU=true
+    libdir=/usr/lib64
+    ;;
+
   powerpc64le-*-linux*)
     MAKEFILE_PREFIX=linux_powerpc64el
     INSTALL_PREFIX=linux

--- a/extern/libcds/cds/compiler/gcc/compiler_macro.h
+++ b/extern/libcds/cds/compiler/gcc/compiler_macro.h
@@ -127,6 +127,11 @@
 #   else
 #       define CDS_BUILD_BITS        32
 #   endif
+#elif defined(__loongarch64)
+#    define CDS_PROCESSOR_ARCH    CDS_PROCESSOR_LOONGARCH64
+#    define CDS_BUILD_BITS        64
+#    define CDS_PROCESSOR__NAME   "loongarch64"
+#    define CDS_PROCESSOR__NICK   "loongarch64"
 #else
 #   if defined(CDS_USE_LIBCDS_ATOMIC)
 #       error "Libcds does not support atomic implementation for the processor architecture. Try to use C++11-compatible compiler and remove CDS_USE_LIBCDS_ATOMIC flag from compiler command line"

--- a/src/common/classes/DbImplementation.cpp
+++ b/src/common/classes/DbImplementation.cpp
@@ -51,6 +51,7 @@ static const UCHAR CpuPowerPc64el = 16;
 static const UCHAR CpuM68k = 17;
 static const UCHAR CpuRiscV64 = 18;
 static const UCHAR CpuMips64el = 19;
+static const UCHAR CpuLoongArch64 = 20;
 
 static const UCHAR OsWindows = 0;
 static const UCHAR OsLinux = 1;
@@ -93,7 +94,8 @@ const char* hardware[] = {
 	"PowerPC64el",
 	"M68k",
 	"RiscV64",
-	"MIPS64EL"
+	"MIPS64EL",
+	"LoongArch64"
 };
 
 const char* operatingSystem[] = {
@@ -120,23 +122,23 @@ const char* compiler[] = {
 // This table lists pre-fb3 implementation codes
 const UCHAR backwardTable[FB_NELEM(hardware) * FB_NELEM(operatingSystem)] =
 {
-//				Intel	AMD		Sparc	PPC		PPC64	MIPSEL	MIPS	ARM		IA64	s390	s390x	SH		SHEB	HPPA	Alpha	ARM64	PPC64el	M68k	RiscV64 MIPS64EL
-/* Windows */	50,		68,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
-/* Linux */		60,		66,		65,		69,		86,		71,		72,		75, 	76,		79, 	78,		80,		81,		82,		83,		84,		85,		87,		88,		90,
-/* Darwin */	70,		73,		0,		63,		77,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
-/* Solaris */	0,		0,		30,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
-/* HPUX */		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		31,		0,		0,		0,		0,		0,		0,
-/* AIX */		0,		0,		0,		35,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
-/* MVS */		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
-/* FreeBSD */	61,		67,		0,		92,		91,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		89,		0,		0,		0,
-/* NetBSD */	62,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0
+//				Intel	AMD		Sparc	PPC		PPC64	MIPSEL	MIPS	ARM		IA64	s390	s390x	SH		SHEB	HPPA	Alpha	ARM64	PPC64el	M68k	RiscV64 MIPS64EL LoongArch64
+/* Windows */	50,		68,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
+/* Linux */		60,		66,		65,		69,		86,		71,		72,		75, 	76,		79, 	78,		80,		81,		82,		83,		84,		85,		87,		88,		90,		93,
+/* Darwin */	70,		73,		0,		63,		77,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
+/* Solaris */	0,		0,		30,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
+/* HPUX */		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		31,		0,		0,		0,		0,		0,		0,		0,
+/* AIX */		0,		0,		0,		35,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
+/* MVS */		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
+/* FreeBSD */	61,		67,		0,		92,		91,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		89,		0,		0,		0,		0,
+/* NetBSD */	62,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0
 };
 
 
 const UCHAR backEndianess[FB_NELEM(hardware)] =
 {
-//	Intel	AMD		Sparc	PPC		PPC64	MIPSEL	MIPS	ARM		IA64	s390	s390x	SH		SHEB	HPPA	Alpha	ARM64	PPC64el	M68k	RiscV64 MIPS64EL
-	0,		0,		1,		1,		1,		0,		1,		0,		0,		1,		1,		0,		1,		1,		0,		0,		0,		1,		0,		0,
+//	Intel	AMD		Sparc	PPC		PPC64	MIPSEL	MIPS	ARM		IA64	s390	s390x	SH		SHEB	HPPA	Alpha	ARM64	PPC64el	M68k	RiscV64 MIPS64EL LoongArch64
+	0,		0,		1,		1,		1,		0,		1,		0,		0,		1,		1,		0,		1,		1,		0,		0,		0,		1,		0,		0,		0,
 };
 
 } // anonymous namespace

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -214,6 +214,10 @@
 #define FB_CPU CpuM68k
 #endif /* M68K */
 
+#ifdef LOONGARCH64
+#define FB_CPU CpuLoongArch64
+#endif /* loongarch64 */
+
 #endif /* LINUX */
 
 

--- a/src/include/firebird/impl/inf_pub.h
+++ b/src/include/firebird/impl/inf_pub.h
@@ -307,6 +307,8 @@ enum  info_db_implementations
 	isc_info_db_impl_freebsd_ppc64 = 91,
 	isc_info_db_impl_freebsd_ppc = 92,
 
+        isc_info_db_impl_linux_loongarch64 = 93,
+
 	isc_info_db_impl_last_value   // Leave this LAST!
 };
 


### PR DESCRIPTION
Hi, There are many errors when compiling on the LoongArch64 architecture, so I submitted this pr to add LoongArch64 port.

About LoongArch:
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.
Documentations:https://loongson.github.io/LoongArch-Documentation/README-EN.html

thanks.