### PR TITLE
[FB4] The functional description of CVT_get_int128 was corrected

### DIFF
--- a/src/common/cvt.cpp
+++ b/src/common/cvt.cpp
@@ -3132,7 +3132,7 @@ Int128 CVT_get_int128(const dsc* desc, SSHORT scale, DecimalStatus decSt, ErrorF
  *      of given scale.
  *
  **************************************/
-	VaryStr<1024> buffer;			// represents unreasonably long decfloat literal in ASCII
+	VaryStr<1024> buffer;			// represents unreasonably INT128 literal in ASCII
 	Int128 int128;
 	Decimal128 tmp;
 	double d, eps;

--- a/src/common/cvt.cpp
+++ b/src/common/cvt.cpp
@@ -3123,12 +3123,13 @@ Int128 CVT_get_int128(const dsc* desc, SSHORT scale, DecimalStatus decSt, ErrorF
 {
 /**************************************
  *
- *      C V T _ g e t _ d e c 1 2 8
+ *      C V T _ g e t _ i n t 1 2 8
  *
  **************************************
  *
  * Functional description
- *      Convert something arbitrary to a DecFloat(34) / (128 bit).
+ *      Convert something arbitrary to an INT128 (128 bit integer)
+ *      of given scale.
  *
  **************************************/
 	VaryStr<1024> buffer;			// represents unreasonably long decfloat literal in ASCII


### PR DESCRIPTION
An old description was copyed from CVT_get_dec128 function.

I hope that a new description is ok now :)