### PR TITLE
Firebird.conf DefaultDbCachePages better description

### DIFF
--- a/builds/install/misc/firebird.conf
+++ b/builds/install/misc/firebird.conf
@@ -253,7 +253,7 @@
 # Priority of setings is: direcly in database, databases.conf, firebird.conf.
 # The SuperServer default value is 2048 pages for each database and the classic
 # value is 256 pages per client connection per database.
-# As this value means maximum number of pages cached, at start server use minimal cache.
+# As this value means maximum number of pages cached, at start server use minimal RAM.
 # Cache is filled over time as server access different pages by issuing any command e.g. SELECT.
 #
 # Per-database configurable.

--- a/builds/install/misc/firebird.conf
+++ b/builds/install/misc/firebird.conf
@@ -244,13 +244,13 @@
 # ----------------------------
 # Number of cached database pages
 #
-# This setings is used to cache in memory database pages. 
-# It specify maximum number of pages which can be cached.
+# This seting is used to cache in memory database pages. 
+# It specifies maximum number of pages which can be cached.
 # In SuperServer it is per database, in Classic per client connection.
 # Per-database configurable. This value can be overrided by databases.conf or 
 # directly in database file by issuing command:
 # gfix -b[uffers] BUFFERS
-# Priority of setings is: direcly in database, databases.conf, firebird.conf.
+# Priority of settings is: directly in database, databases.conf, firebird.conf.
 # The SuperServer default value is 2048 pages for each database and the classic
 # value is 256 pages per client connection per database.
 # As this value means maximum number of pages cached, at start server use minimal RAM.

--- a/builds/install/misc/firebird.conf
+++ b/builds/install/misc/firebird.conf
@@ -244,7 +244,7 @@
 # ----------------------------
 # Number of cached database pages
 #
-# This seting is used to cache in memory database pages. 
+# This setting is used to cache in memory database pages. 
 # It specifies maximum number of pages which can be cached.
 # In SuperServer it is per database, in Classic per client connection.
 # Per-database configurable. This value can be overrided by databases.conf or 

--- a/builds/install/misc/firebird.conf
+++ b/builds/install/misc/firebird.conf
@@ -244,11 +244,17 @@
 # ----------------------------
 # Number of cached database pages
 #
-# This sets the number of pages from any one database that can be held
-# in cache at once. If you increase this value, the engine will
-# allocate more pages to the cache for every database. By default, the
-# SuperServer allocates 2048 pages for each database and the classic
-# allocates 256 pages per client connection per database.
+# This setings is used to cache in memory database pages. 
+# It specify maximum number of pages which can be cached.
+# In SuperServer it is per database, in Classic per client connection.
+# Per-database configurable. This value can be overrided by databases.conf or 
+# directly in database file by issuing command:
+# gfix -b[uffers] BUFFERS
+# Priority of setings is: direcly in database, databases.conf, firebird.conf.
+# The SuperServer default value is 2048 pages for each database and the classic
+# value is 256 pages per client connection per database.
+# As this value means maximum number of pages cached, at start server use minimal cache.
+# Cache is filled over time as server access different pages by issuing any command e.g. SELECT.
 #
 # Per-database configurable.
 #


### PR DESCRIPTION
Hi. As many times on Firebird group is question about DefaultDbCachePages, i have written probably better description. Users ask why my server use so low memory even if i setup big value in config. They do not know how this cache work and that firebird.conf setting can be overrided by different one.

Please fill free to fix it as i am not native English