### PR TITLE
Fix crash on assert or memory corruption when too long a username is …

### DIFF
--- a/src/auth/SecureRemotePassword/server/SrpServer.cpp
+++ b/src/auth/SecureRemotePassword/server/SrpServer.cpp
@@ -288,7 +288,7 @@ int SrpServer::authenticate(CheckStatusWrapper* status, IServerBlock* sb, IWrite
 
 			account = sb->getLogin();
 
-			const size_t len = strlen(account.c_str());
+			const size_t len = account.length();
 			if (len > SZ_LOGIN)
 				status_exception::raise(Arg::Gds(isc_long_login) << Arg::Num(len) << Arg::Num(SZ_LOGIN));
 

--- a/src/auth/SecureRemotePassword/server/SrpServer.cpp
+++ b/src/auth/SecureRemotePassword/server/SrpServer.cpp
@@ -288,6 +288,10 @@ int SrpServer::authenticate(CheckStatusWrapper* status, IServerBlock* sb, IWrite
 
 			account = sb->getLogin();
 
+			const size_t len = strlen(account.c_str());
+			if (len > SZ_LOGIN)
+				status_exception::raise(Arg::Gds(isc_long_login) << Arg::Num(len) << Arg::Num(SZ_LOGIN));
+
 			unsigned int length;
 			const unsigned char* val = sb->getData(&length);
 			clientPubKey.assign(val, length);


### PR DESCRIPTION
…used for authentication