### PR TITLE
Add missing release of broken trace plugin

### DIFF
--- a/src/jrd/trace/TraceManager.cpp
+++ b/src/jrd/trace/TraceManager.cpp
@@ -458,6 +458,7 @@ void TraceManager::event_dsql_restart(Attachment* att, jrd_tra* transaction,
 			i++; /* Move to next plugin */ \
 		} \
 		else { \
+			plug_info->plugin->release(); \
 			trace_sessions.remove(i); /* Remove broken plugin from the list */ \
 		} \
 	}


### PR DESCRIPTION
Broken trace plugins do not release. As the result, the TracePluginImpl destructor is never called and the logWriter keeps the log file descriptor.