### PR TITLE
Fix performance issues in prepare_update()

### DIFF
--- a/src/jrd/vio.cpp
+++ b/src/jrd/vio.cpp
@@ -574,8 +574,6 @@ namespace
 	{
 		if (rpb->rpb_flags & rpb_not_packed)
 		{
-			rpb->rpb_flags &= ~rpb_not_packed;
-
 			const auto length = MIN(rpb->rpb_length, outLength);
 
 			memcpy(output, rpb->rpb_address, length);

--- a/src/jrd/vio.cpp
+++ b/src/jrd/vio.cpp
@@ -1831,6 +1831,8 @@ void VIO_data(thread_db* tdbb, record_param* rpb, MemoryPool* pool)
 		const ULONG back_page  = rpb->rpb_b_page;
 		const USHORT back_line = rpb->rpb_b_line;
 		const USHORT save_flags = rpb->rpb_flags;
+		const ULONG save_f_page = rpb->rpb_f_page;
+		const USHORT save_f_line = rpb->rpb_f_line;
 
 		while (rpb->rpb_flags & rpb_incomplete)
 		{
@@ -1842,6 +1844,8 @@ void VIO_data(thread_db* tdbb, record_param* rpb, MemoryPool* pool)
 		rpb->rpb_b_page = back_page;
 		rpb->rpb_b_line = back_line;
 		rpb->rpb_flags = save_flags;
+		rpb->rpb_f_page = save_f_page;
+		rpb->rpb_f_line = save_f_line;
 	}
 
 	CCH_RELEASE(tdbb, &rpb->getWindow(tdbb));


### PR DESCRIPTION
Commits in the PR fix similar cases where the temporary record is inserted twice in prepare_update().