### PR TITLE
Make async replication reliable on Linux CS (replica side)

### DIFF
--- a/src/jrd/replication/Config.cpp
+++ b/src/jrd/replication/Config.cpp
@@ -426,3 +426,26 @@ void Config::enumerate(Firebird::Array<Config*>& replicas)
 		logReplicaStatus(dbName, &localStatus);
 	}
 }
+
+bool Config::hasReplicas()
+{
+	try
+	{
+		const PathName filename =
+			fb_utils::getPrefix(IConfigManager::DIR_CONF, REPLICATION_CFGFILE);
+
+		ConfigFile cfgFile(filename, ConfigFile::HAS_SUB_CONF |
+									 ConfigFile::NATIVE_ORDER |
+									 ConfigFile::CUSTOM_MACROS);
+
+		for (const auto& section : cfgFile.getParameters())
+		{
+			if (section.name == "database" && section.value.hasData())
+				return true;
+		}
+	}
+	catch (const Exception&)
+	{} // no-op
+
+	return false;
+}

--- a/src/jrd/replication/Config.cpp
+++ b/src/jrd/replication/Config.cpp
@@ -438,11 +438,28 @@ bool Config::hasReplicas()
 									 ConfigFile::NATIVE_ORDER |
 									 ConfigFile::CUSTOM_MACROS);
 
+		bool hasDbs = false, hasSource = false;
+
 		for (const auto& section : cfgFile.getParameters())
 		{
 			if (section.name == "database" && section.value.hasData())
-				return true;
+				hasDbs = true;
+
+			if (!section.sub)
+				continue;
+
+			for (const auto& el : section.sub->getParameters())
+			{
+				if (el.name == "journal_source_directory" && el.value.hasData())
+				{
+					hasSource = true;
+					break;
+				}
+			}
 		}
+
+		if (hasDbs && hasSource)
+			return true;
 	}
 	catch (const Exception&)
 	{} // no-op

--- a/src/jrd/replication/Config.h
+++ b/src/jrd/replication/Config.h
@@ -38,6 +38,7 @@ namespace Replication
 
 		static Config* get(const Firebird::PathName& dbName);
 		static void enumerate(Firebird::Array<Config*>& replicas);
+		static bool hasReplicas();
 
 		Firebird::PathName dbName;
 		ULONG bufferSize;

--- a/src/remote/server/ReplServer.h
+++ b/src/remote/server/ReplServer.h
@@ -23,6 +23,6 @@
 #ifndef UTIL_REPL_SERVER_H
 #define UTIL_REPL_SERVER_H
 
-bool REPL_server(Firebird::CheckStatusWrapper*, bool, bool*);
+bool REPL_server(Firebird::CheckStatusWrapper*, bool);
 
 #endif // UTIL_REPL_SERVER_H

--- a/src/remote/server/os/win32/srvr_w32.cpp
+++ b/src/remote/server/os/win32/srvr_w32.cpp
@@ -595,7 +595,7 @@ static THREAD_ENTRY_DECLARE start_connections_thread(THREAD_ENTRY_PARAM)
 	}
 
 	FbLocalStatus localStatus;
-	if (!REPL_server(&localStatus, false, &server_shutdown))
+	if (!REPL_server(&localStatus, false))
 	{
 		const char* errorMsg = "Replication server initialization error";
 		iscLogStatus(errorMsg, localStatus->getErrors());


### PR DESCRIPTION
The initial implementation was buggy as it allowed to replicate journals by worker processes which appear/disappear sporadically. Replication should rather be performed by a dedicated process. This fixes #7387.