### PR TITLE
Fix invalid conversion in src/common/unicode_util.cpp

### DIFF
--- a/src/common/unicode_util.cpp
+++ b/src/common/unicode_util.cpp
@@ -1373,7 +1373,7 @@ UnicodeUtil::Utf16Collation* UnicodeUtil::Utf16Collation::create(
 
 			for (int prefixLen = 1; prefixLen < len; ++prefixLen)
 			{
-				const Array<USHORT> str(strChars, prefixLen);
+				const Array<USHORT> str(reinterpret_cast<USHORT*>(strChars), prefixLen);
 				SortKeyArray* keySet = obj->contractionsPrefix.get(str);
 
 				if (!keySet)


### PR DESCRIPTION
I found this error when I built Firebird as part of LibreOffice.

[...]
> workdir/UnpackedTarball/firebird/src/common/unicode_util.cpp:1381:48:
> error: invalid conversion from 'UChar* {aka char16_t*}' to
> 'const short unsigned int*' [-fpermissive]
>      const Array<USHORT> str(strChars, prefixLen);
>                                                 ^
[...]

Use the reinterpret_cast operator to avoid this error.