### PR TITLE
Better processing and optimization if IN <list> predicates

### DIFF
--- a/src/dsql/BoolNodes.cpp
+++ b/src/dsql/BoolNodes.cpp
@@ -41,6 +41,7 @@
 #include "../dsql/gen_proto.h"
 #include "../dsql/make_proto.h"
 #include "../dsql/pass1_proto.h"
+#include "../dsql/DSqlDataTypeUtil.h"
 
 using namespace Firebird;
 using namespace Jrd;
@@ -49,8 +50,8 @@ namespace Jrd {
 
 
 // Maximum members in "IN" list. For eg. SELECT * FROM T WHERE F IN (1, 2, 3, ...)
-// Bug 10061, bsriram - 19-Apr-1999
-static const int MAX_MEMBER_LIST = 1500;
+// Switching beyond the 16-bit number would mean an incompatible BLR change.
+static const unsigned MAX_MEMBER_LIST = MAX_USHORT;
 
 
 //--------------------
@@ -306,7 +307,20 @@ ComparativeBoolNode::ComparativeBoolNode(MemoryPool& pool, UCHAR aBlrOp,
 	  arg1(aArg1),
 	  arg2(aArg2),
 	  arg3(aArg3),
-	  dsqlSpecialArg(NULL)
+	  dsqlSpecialArg(nullptr)
+{
+}
+
+ComparativeBoolNode::ComparativeBoolNode(MemoryPool& pool, UCHAR aBlrOp,
+			ValueExprNode* aArg1, DsqlFlag aDsqlFlag, ExprNode* aSpecialArg)
+	: TypedNode<BoolExprNode, ExprNode::TYPE_COMPARATIVE_BOOL>(pool),
+	  blrOp(aBlrOp),
+	  dsqlCheckBoolean(false),
+	  dsqlFlag(aDsqlFlag),
+	  arg1(aArg1),
+	  arg2(nullptr),
+	  arg3(nullptr),
+	  dsqlSpecialArg(aSpecialArg)
 {
 }
 
@@ -355,34 +369,35 @@ BoolExprNode* ComparativeBoolNode::dsqlPass(DsqlCompilerScratch* dsqlScratch)
 
 	if (dsqlSpecialArg)
 	{
-		ValueListNode* listNode = nodeAs<ValueListNode>(dsqlSpecialArg);
-		if (listNode)
+		if (const auto listNode = nodeAs<ValueListNode>(dsqlSpecialArg))
 		{
-			int listItemCount = 0;
-			BoolExprNode* resultNode = NULL;
-			NestConst<ValueExprNode>* ptr = listNode->items.begin();
-
-			for (const NestConst<ValueExprNode>* const end = listNode->items.end();
-				 ptr != end;
-				 ++listItemCount, ++ptr)
+			if (listNode->items.getCount() > MAX_MEMBER_LIST)
 			{
-				if (listItemCount >= MAX_MEMBER_LIST)
-				{
-					ERRD_post(Arg::Gds(isc_sqlerr) << Arg::Num(-901) <<
-							  Arg::Gds(isc_imp_exc) <<
-							  Arg::Gds(isc_dsql_too_many_values) << Arg::Num(MAX_MEMBER_LIST));
-				}
-
-				ComparativeBoolNode* temp = FB_NEW_POOL(dsqlScratch->getPool()) ComparativeBoolNode(
-					dsqlScratch->getPool(), blrOp, procArg1, *ptr);
-				resultNode = PASS1_compose(resultNode, temp, blr_or);
+				ERRD_post(Arg::Gds(isc_sqlerr) << Arg::Num(-901) <<
+					Arg::Gds(isc_imp_exc) <<
+					Arg::Gds(isc_dsql_too_many_values) << Arg::Num(MAX_MEMBER_LIST));
 			}
+
+			if (listNode->items.getCount() == 1)
+			{
+				// Convert A IN (B) into A = B
+
+				ComparativeBoolNode* const resultNode = FB_NEW_POOL(dsqlScratch->getPool())
+					ComparativeBoolNode(dsqlScratch->getPool(),
+						blr_eql, arg1, listNode->items.front());
+
+				return resultNode->dsqlPass(dsqlScratch);
+			}
+
+			// Generate the IN LIST boolean
+
+			InListBoolNode* const resultNode = FB_NEW_POOL(dsqlScratch->getPool())
+				InListBoolNode(dsqlScratch->getPool(), procArg1, listNode);
 
 			return resultNode->dsqlPass(dsqlScratch);
 		}
 
-		SelectExprNode* selNode = nodeAs<SelectExprNode>(dsqlSpecialArg);
-		if (selNode)
+		if (const auto selNode = nodeAs<SelectExprNode>(dsqlSpecialArg))
 		{
 			fb_assert(!(selNode->dsqlFlags & RecordSourceNode::DFLAG_SINGLETON));
 			UCHAR newBlrOp = blr_any;
@@ -1137,6 +1152,271 @@ BoolExprNode* ComparativeBoolNode::createRseNode(DsqlCompilerScratch* dsqlScratc
 	dsqlScratch->context->clear(base);
 
 	return rseBoolNode;
+}
+
+
+//--------------------
+
+
+static RegisterBoolNode<InListBoolNode> regInListBoolNode({blr_in_list});
+
+InListBoolNode::InListBoolNode(MemoryPool& pool, ValueExprNode* aArg, ValueListNode* aList)
+	: TypedNode<BoolExprNode, ExprNode::TYPE_IN_LIST_BOOL>(pool),
+	  arg(aArg),
+	  list(aList)
+{
+}
+
+DmlNode* InListBoolNode::parse(thread_db* tdbb, MemoryPool& pool, CompilerScratch* csb, const UCHAR blrOp)
+{
+	const auto arg = PAR_parse_value(tdbb, csb);
+
+	const auto count = csb->csb_blr_reader.getWord();
+	const auto list = PAR_args(tdbb, csb, count, count);
+
+	return FB_NEW_POOL(pool) InListBoolNode(pool, arg, list);
+}
+
+string InListBoolNode::internalPrint(NodePrinter& printer) const
+{
+	BoolExprNode::internalPrint(printer);
+
+	NODE_PRINT(printer, blrOp);
+	NODE_PRINT(printer, arg);
+	NODE_PRINT(printer, list);
+
+	return "InListBoolNode";
+}
+
+BoolExprNode* InListBoolNode::dsqlPass(DsqlCompilerScratch* dsqlScratch)
+{
+	const auto procArg = doDsqlPass(dsqlScratch, arg);
+	const auto procList = doDsqlPass(dsqlScratch, list);
+
+	const auto node = FB_NEW_POOL(dsqlScratch->getPool())
+		InListBoolNode(dsqlScratch->getPool(), procArg, procList);
+
+	dsc argDesc;
+	DsqlDescMaker::fromNode(dsqlScratch, &argDesc, procArg);
+
+	dsc listDesc;
+	DsqlDescMaker::fromList(dsqlScratch, &listDesc, procList, "IN LIST");
+
+	if (argDesc.isText() && listDesc.isText())
+	{
+		const dsc* descs[] = {&argDesc, &listDesc};
+		dsc commonDesc;
+		DSqlDataTypeUtil(dsqlScratch).makeFromList(&commonDesc, "IN LIST",
+			FB_NELEM(descs), descs);
+
+		if (IS_INTL_DATA(&argDesc) || IS_INTL_DATA(&listDesc))
+		{
+			const auto charset1 = argDesc.getCharSet();
+			const auto charset2 = listDesc.getCharSet();
+
+			if ((charset1 != CS_BINARY) && (charset2 != CS_BINARY) &&
+				((charset1 != CS_ASCII) || (charset2 != CS_ASCII)) &&
+				((charset1 != CS_NONE) || (charset2 != CS_NONE)))
+			{
+				const auto ttype = MAX(argDesc.getTextType(), listDesc.getTextType());
+				commonDesc.setTextType(ttype);
+			}
+		}
+
+		listDesc = commonDesc;
+	}
+
+	for (auto& item : procList->items)
+	{
+		const auto desc = item->getDsqlDesc();
+
+		if (!DSC_EQUIV(&listDesc, &desc, true))
+		{
+			auto field = FB_NEW_POOL(dsqlScratch->getPool())
+				dsql_fld(dsqlScratch->getPool());
+
+			field->dtype = listDesc.dsc_dtype;
+			field->scale = listDesc.dsc_scale;
+			field->subType = listDesc.dsc_sub_type;
+			field->length = listDesc.dsc_length;
+			field->flags = (listDesc.dsc_flags & DSC_nullable) ? FLD_nullable : 0;
+			field->textType = listDesc.getTextType();
+			field->charSetId = listDesc.getCharSet();
+			field->collationId = listDesc.getCollation();
+
+			const auto castNode = FB_NEW_POOL(dsqlScratch->getPool())
+				CastNode(dsqlScratch->getPool(), item, field);
+			item = castNode->dsqlPass(dsqlScratch);
+		}
+	}
+
+	// Try to force arg to be same type as list eg: ? = (FIELD, ...) case
+	for (auto item : procList->items)
+		PASS1_set_parameter_type(dsqlScratch, node->arg, item, false);
+
+	// Try to force list to be same type as arg eg: FIELD = (?, ...) case
+	for (auto item : procList->items)
+		PASS1_set_parameter_type(dsqlScratch, item, node->arg, false);
+
+	return node;
+}
+
+void InListBoolNode::genBlr(DsqlCompilerScratch* dsqlScratch)
+{
+	dsqlScratch->appendUChar(blrOp);
+
+	GEN_expr(dsqlScratch, arg);
+
+	fb_assert(list->items.getCount() <= MAX_USHORT);
+	dsqlScratch->appendUShort(list->items.getCount());
+
+	for (auto item : list->items)
+		GEN_expr(dsqlScratch, item);
+}
+
+bool InListBoolNode::dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const
+{
+	if (!BoolExprNode::dsqlMatch(dsqlScratch, other, ignoreMapCast))
+		return false;
+
+	return nodeIs<InListBoolNode>(other);
+}
+
+bool InListBoolNode::sameAs(const ExprNode* other, bool ignoreStreams) const
+{
+	const auto otherNode = nodeAs<InListBoolNode>(other);
+
+	if (!otherNode)
+		return false;
+
+	return (arg->sameAs(otherNode->arg, ignoreStreams) &&
+		list->sameAs(otherNode->list, ignoreStreams));
+}
+
+BoolExprNode* InListBoolNode::copy(thread_db* tdbb, NodeCopier& copier) const
+{
+	const auto newArg = copier.copy(tdbb, arg);
+	const auto newList = copier.copy(tdbb, list);
+
+	const auto node = FB_NEW_POOL(*tdbb->getDefaultPool())
+		InListBoolNode(*tdbb->getDefaultPool(), newArg, newList);
+	node->nodFlags = nodFlags;
+
+	return node;
+}
+
+BoolExprNode* InListBoolNode::pass1(thread_db* tdbb, CompilerScratch* csb)
+{
+	doPass1(tdbb, csb, arg.getAddress());
+
+//	nodFlags |= FLAG_INVARIANT;
+	csb->csb_current_nodes.push(this);
+
+	doPass1(tdbb, csb, list.getAddress());
+
+	csb->csb_current_nodes.pop();
+
+	if (nodFlags & FLAG_INVARIANT)
+	{
+		for (auto item : list->items)
+		{
+			while (auto castNode = nodeAs<CastNode>(item))
+				item = castNode->source;
+
+			if (!nodeIs<LiteralNode>(item) &&
+				!nodeIs<ParameterNode>(item) &&
+				!nodeIs<VariableNode>(item))
+			{
+				nodFlags &= ~FLAG_INVARIANT;
+				break;
+			}
+		}
+	}
+
+	return this;
+}
+
+void InListBoolNode::pass2Boolean1(thread_db* /*tdbb*/, CompilerScratch* csb)
+{
+	if (nodFlags & FLAG_INVARIANT)
+		csb->csb_invariants.push(&impureOffset);
+}
+
+void InListBoolNode::pass2Boolean2(thread_db* tdbb, CompilerScratch* csb)
+{
+	if (const auto keyNode = nodeAs<RecordKeyNode>(arg))
+	{
+		if (keyNode->aggregate)
+			ERR_post(Arg::Gds(isc_bad_dbkey));
+	}
+
+	dsc descriptor_a, descriptor_b;
+	arg->getDesc(tdbb, csb, &descriptor_a);
+	list->getDesc(tdbb, csb, &descriptor_b);
+
+	if (DTYPE_IS_DATE(descriptor_a.dsc_dtype))
+		arg->nodFlags |= FLAG_DATE;
+	else if (DTYPE_IS_DATE(descriptor_b.dsc_dtype))
+	{
+		for (auto item : list->items)
+			item->nodFlags |= FLAG_DATE;
+	}
+
+	if (nodFlags & FLAG_INVARIANT)
+		impureOffset = csb->allocImpure<impure_value>();
+}
+
+bool InListBoolNode::execute(thread_db* tdbb, Request* request) const
+{
+	if (const auto argDesc = EVL_expr(tdbb, request, arg))
+	{
+		if (nodFlags & FLAG_INVARIANT)
+		{
+			const auto impure = request->getImpure<impure_value>(impureOffset);
+			auto sortedList = impure->vlu_misc.vlu_sortedList;
+
+			if (!(impure->vlu_flags & VLU_computed))
+			{
+				delete impure->vlu_misc.vlu_sortedList;
+
+				sortedList = impure->vlu_misc.vlu_sortedList =
+					FB_NEW_POOL(*tdbb->getDefaultPool())
+						SortedValueList(*tdbb->getDefaultPool(), list->items.getCount());
+
+				sortedList->setSortMode(FB_ARRAY_SORT_MANUAL);
+
+				for (const auto value : list->items)
+				{
+					if (const auto valueDesc = EVL_expr(tdbb, request, value))
+						sortedList->add(SortValueItem(value, valueDesc));
+				}
+
+				sortedList->sort();
+
+				impure->vlu_flags |= VLU_computed;
+			}
+
+			if (sortedList->isEmpty())
+			{
+				fb_assert(list->items.hasData());
+				request->req_flags |= req_null;
+				return false;
+			}
+
+			return sortedList->exist(SortValueItem(arg, argDesc));
+		}
+
+		for (const auto value : list->items)
+		{
+			if (const auto valueDesc = EVL_expr(tdbb, request, value))
+			{
+				if (!MOV_compare(tdbb, argDesc, valueDesc))
+					return true;
+			}
+		}
+	}
+
+	return false;
 }
 
 

--- a/src/dsql/BoolNodes.h
+++ b/src/dsql/BoolNodes.h
@@ -166,13 +166,13 @@ public:
 	virtual bool dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const;
 	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
 	virtual BoolExprNode* pass1(thread_db* tdbb, CompilerScratch* csb);
-	virtual void pass2Boolean1(thread_db* tdbb, CompilerScratch* csb);
-	virtual void pass2Boolean2(thread_db* tdbb, CompilerScratch* csb);
+	void pass2Boolean(thread_db* tdbb, CompilerScratch* csb, std::function<void ()> process);
 	virtual bool execute(thread_db* tdbb, Request* request) const;
 
 public:
 	NestConst<ValueExprNode> arg;
 	NestConst<ValueListNode> list;
+	NestConst<LookupValueList> lookup;
 };
 
 

--- a/src/dsql/BoolNodes.h
+++ b/src/dsql/BoolNodes.h
@@ -150,7 +150,7 @@ public:
 
 	static DmlNode* parse(thread_db* tdbb, MemoryPool& pool, CompilerScratch* csb, const UCHAR blrOp);
 
-	virtual void getChildren(NodeRefsHolder& holder, bool dsql) const
+	void getChildren(NodeRefsHolder& holder, bool dsql) const override
 	{
 		BoolExprNode::getChildren(holder, dsql);
 
@@ -158,16 +158,16 @@ public:
 		holder.add(list);
 	}
 
-	virtual Firebird::string internalPrint(NodePrinter& printer) const;
-	virtual BoolExprNode* dsqlPass(DsqlCompilerScratch* dsqlScratch);
-	virtual void genBlr(DsqlCompilerScratch* dsqlScratch);
+	Firebird::string internalPrint(NodePrinter& printer) const override;
+	BoolExprNode* dsqlPass(DsqlCompilerScratch* dsqlScratch) override;
+	void genBlr(DsqlCompilerScratch* dsqlScratch) override;
 
-	virtual BoolExprNode* copy(thread_db* tdbb, NodeCopier& copier) const;
-	virtual bool dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const;
-	virtual bool sameAs(const ExprNode* other, bool ignoreStreams) const;
-	virtual BoolExprNode* pass1(thread_db* tdbb, CompilerScratch* csb);
+	BoolExprNode* copy(thread_db* tdbb, NodeCopier& copier) const override;
+	bool dsqlMatch(DsqlCompilerScratch* dsqlScratch, const ExprNode* other, bool ignoreMapCast) const override;
+	bool sameAs(const ExprNode* other, bool ignoreStreams) const override;
+	BoolExprNode* pass1(thread_db* tdbb, CompilerScratch* csb) override;
 	void pass2Boolean(thread_db* tdbb, CompilerScratch* csb, std::function<void ()> process);
-	virtual bool execute(thread_db* tdbb, Request* request) const;
+	bool execute(thread_db* tdbb, Request* request) const override;
 
 public:
 	NestConst<ValueExprNode> arg;

--- a/src/dsql/DdlNodes.epp
+++ b/src/dsql/DdlNodes.epp
@@ -4316,9 +4316,7 @@ void CreateDomainNode::execute(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch
 
 	type->resolve(dsqlScratch);
 
-	dsqlScratch->domainValue.dsc_dtype = type->dtype;
-	dsqlScratch->domainValue.dsc_length = type->length;
-	dsqlScratch->domainValue.dsc_scale = type->scale;
+	DsqlDescMaker::fromField(&dsqlScratch->domainValue, type);
 
 	// run all statements under savepoint control
 	AutoSavePoint savePoint(tdbb, transaction);
@@ -5003,9 +5001,7 @@ void AlterDomainNode::execute(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch,
 						Arg::Gds(isc_dsql_domain_not_found) << name);
 				}
 
-				dsqlScratch->domainValue.dsc_dtype = localField.dtype;
-				dsqlScratch->domainValue.dsc_length = localField.length;
-				dsqlScratch->domainValue.dsc_scale = localField.scale;
+				DsqlDescMaker::fromField(&dsqlScratch->domainValue, &localField);
 
 				FLD.RDB$VALIDATION_SOURCE.NULL = FALSE;
 				attachment->storeMetaDataBlob(tdbb, transaction, &FLD.RDB$VALIDATION_SOURCE,

--- a/src/dsql/ExprNodes.cpp
+++ b/src/dsql/ExprNodes.cpp
@@ -197,11 +197,11 @@ int SortValueItem::compare(const dsc* desc1, const dsc* desc2)
 	return MOV_compare(JRD_get_thread_data(), desc1, desc2);
 }
 
-LookupValueList::LookupValueList(MemoryPool& pool, const ValueListNode* values, ULONG impure)
+LookupValueList::LookupValueList(MemoryPool& pool, ValueListNode* values, ULONG impure)
 	: m_values(pool, values->items.getCount()), m_impureOffset(impure)
 {
-	for (const auto item : values->items)
-		m_values.add(const_cast<ValueExprNode*>(item.getObject()));
+	for (auto& item : values->items)
+		m_values.add(item);
 }
 
 TriState LookupValueList::find(thread_db* tdbb, Request* request, const ValueExprNode* value, const dsc* desc) const
@@ -212,6 +212,7 @@ TriState LookupValueList::find(thread_db* tdbb, Request* request, const ValueExp
 	if (!(impure->vlu_flags & VLU_computed))
 	{
 		delete impure->vlu_misc.vlu_sortedList;
+		impure->vlu_misc.vlu_sortedList = nullptr;
 
 		sortedList = impure->vlu_misc.vlu_sortedList =
 			FB_NEW_POOL(*tdbb->getDefaultPool())
@@ -4813,9 +4814,7 @@ void DecodeNode::genBlr(DsqlCompilerScratch* dsqlScratch)
 	dsqlScratch->appendUChar(conditions->items.getCount());
 
 	for (auto& condition : conditions->items)
-	{
 		condition->genBlr(dsqlScratch);
-	}
 
 	dsqlScratch->appendUChar(values->items.getCount());
 

--- a/src/dsql/Nodes.h
+++ b/src/dsql/Nodes.h
@@ -510,6 +510,7 @@ public:
 		TYPE_MISSING_BOOL,
 		TYPE_NOT_BOOL,
 		TYPE_RSE_BOOL,
+		TYPE_IN_LIST_BOOL,
 
 		// RecordSource types
 		TYPE_AGGREGATE_SOURCE,
@@ -1297,6 +1298,7 @@ public:
 	}
 
 	virtual Firebird::string internalPrint(NodePrinter& printer) const;
+	virtual void getDesc(thread_db* tdbb, CompilerScratch* csb, dsc* desc);
 
 	virtual ValueListNode* dsqlPass(DsqlCompilerScratch* dsqlScratch)
 	{

--- a/src/dsql/parse.y
+++ b/src/dsql/parse.y
@@ -7028,12 +7028,7 @@ comparison_operator
 %type <boolExprNode> quantified_predicate
 quantified_predicate
 	: value comparison_operator quantified_flag '(' column_select ')'
-		{
-			ComparativeBoolNode* node = newNode<ComparativeBoolNode>($2, $1);
-			node->dsqlFlag = $3;
-			node->dsqlSpecialArg = $5;
-			$$ = node;
-		}
+		{ $$ = newNode<ComparativeBoolNode>($2, $1, $3, $5); }
 	;
 
 %type <cmpBoolFlag> quantified_flag
@@ -7124,16 +7119,13 @@ ternary_pattern_predicate
 in_predicate
 	: value IN in_predicate_value
 		{
-			ComparativeBoolNode* node = newNode<ComparativeBoolNode>(blr_eql, $1);
-			node->dsqlFlag = ComparativeBoolNode::DFLAG_ANSI_ANY;
-			node->dsqlSpecialArg = $3;
-			$$ = node;
+			$$ = newNode<ComparativeBoolNode>(blr_eql, $1,
+				ComparativeBoolNode::DFLAG_ANSI_ANY, $3);
 		}
 	| value NOT IN in_predicate_value
 		{
-			ComparativeBoolNode* node = newNode<ComparativeBoolNode>(blr_eql, $1);
-			node->dsqlFlag = ComparativeBoolNode::DFLAG_ANSI_ANY;
-			node->dsqlSpecialArg = $4;
+			const auto node = newNode<ComparativeBoolNode>(blr_eql, $1,
+				ComparativeBoolNode::DFLAG_ANSI_ANY, $4);
 			$$ = newNode<NotBoolNode>(node);
 		}
 	;

--- a/src/include/firebird/impl/blr.h
+++ b/src/include/firebird/impl/blr.h
@@ -168,8 +168,9 @@
 #define blr_missing		(unsigned char)61
 #define blr_unique		(unsigned char)62
 #define blr_like		(unsigned char)63
+#define blr_in_list		(unsigned char)64
 
-// unused codes: 64..66
+// unused codes: 65..66
 
 #define blr_rse			(unsigned char)67
 #define blr_first		(unsigned char)68

--- a/src/jrd/RecordSourceNodes.cpp
+++ b/src/jrd/RecordSourceNodes.cpp
@@ -3710,6 +3710,7 @@ static void genDeliverUnmapped(CompilerScratch* csb,
 
 		const auto cmpNode = nodeAs<ComparativeBoolNode>(boolean);
 		const auto missingNode = nodeAs<MissingBoolNode>(boolean);
+		const auto listNode = nodeAs<InListBoolNode>(boolean);
 		HalfStaticArray<ValueExprNode*, 2> children;
 
 		if (cmpNode &&
@@ -3721,6 +3722,8 @@ static void genDeliverUnmapped(CompilerScratch* csb,
 			children.add(cmpNode->arg1);
 			children.add(cmpNode->arg2);
 		}
+		else if (listNode)
+			children.add(listNode->arg);
 		else if (missingNode)
 			children.add(missingNode->arg);
 		else
@@ -3755,6 +3758,18 @@ static void genDeliverUnmapped(CompilerScratch* csb,
 			newChildren.add(newCmpNode->arg2.getAddress());
 
 			deliverNode = newCmpNode;
+		}
+		else if (listNode)
+		{
+			const auto newListNode = FB_NEW_POOL(pool) InListBoolNode(pool);
+			const auto count = listNode->list->items.getCount();
+			newListNode->list = FB_NEW_POOL(pool) ValueListNode(pool, count);
+
+			newChildren.add(newListNode->arg.getAddress());
+			for (auto item : newListNode->list->items)
+				newChildren.add(item.getAddress());
+
+			deliverNode = newListNode;
 		}
 		else if (missingNode)
 		{

--- a/src/jrd/blp.h
+++ b/src/jrd/blp.h
@@ -89,7 +89,7 @@ static const struct
 	{"missing", one},
 	{"unique", one},
 	{"like", two},
-	{NULL, NULL},
+	{"in_list", in_list},
 	{NULL, NULL},
 	{NULL, NULL},
 	{"rse", rse},

--- a/src/jrd/btr.cpp
+++ b/src/jrd/btr.cpp
@@ -713,18 +713,18 @@ IndexScanListIterator::IndexScanListIterator(thread_db* tdbb, const IndexRetriev
 	auto values = m_retrieval->irb_value;
 	m_lowerValues.assign(values, m_retrieval->irb_lower_count);
 	fb_assert(!m_lowerValues[m_segno]);
-	m_lowerValues[m_segno] = const_cast<ValueExprNode*>(*m_iterator);
+	m_lowerValues[m_segno] = *m_iterator;
 
 	values += m_retrieval->irb_desc.idx_count;
 	m_upperValues.assign(values, m_retrieval->irb_upper_count);
 	fb_assert(!m_upperValues[m_segno]);
-	m_upperValues[m_segno] = const_cast<ValueExprNode*>(*m_iterator);
+	m_upperValues[m_segno] = *m_iterator;
 }
 
 void IndexScanListIterator::makeKeys(temporary_key* lower, temporary_key* upper)
 {
-	m_lowerValues[m_segno] = const_cast<ValueExprNode*>(*m_iterator);
-	m_upperValues[m_segno] = const_cast<ValueExprNode*>(*m_iterator);
+	m_lowerValues[m_segno] = *m_iterator;
+	m_upperValues[m_segno] = *m_iterator;
 
 	const auto keyType =
 		(m_retrieval->irb_desc.idx_flags & idx_unique) ? INTL_KEY_UNIQUE : INTL_KEY_SORT;

--- a/src/jrd/btr.h
+++ b/src/jrd/btr.h
@@ -478,7 +478,7 @@ public:
 
 	bool getNext()
 	{
-		if (++m_iterator < m_values.end())
+		if (++m_iterator < m_listValues.end())
 		{
 			makeKeys();
 			return true;
@@ -488,14 +488,36 @@ public:
 		return false;
 	}
 
-	temporary_key* getLower()
+	temporary_key* getLowerKey()
 	{
 		return &m_lower;
 	}
 
-	temporary_key* getUpper()
+	temporary_key* getUpperKey()
 	{
 		return &m_upper;
+	}
+
+	ValueExprNode** getLowerValues()
+	{
+		const auto values = m_retrieval->irb_value;
+		m_keyValues.assign(values, m_retrieval->irb_lower_count);
+
+		fb_assert(!m_keyValues[m_segno]);
+		m_keyValues[m_segno] = const_cast<ValueExprNode*>(*m_iterator);
+
+		return m_keyValues.begin();
+	}
+
+	ValueExprNode** getUpperValues()
+	{
+		const auto values = m_retrieval->irb_value + m_retrieval->irb_desc.idx_count;
+		m_keyValues.assign(values, m_retrieval->irb_upper_count);
+
+		fb_assert(!m_keyValues[m_segno]);
+		m_keyValues[m_segno] = const_cast<ValueExprNode*>(*m_iterator);
+
+		return m_keyValues.begin();
 	}
 
 private:
@@ -503,7 +525,8 @@ private:
 
 	thread_db* const m_tdbb;
 	const IndexRetrieval* const m_retrieval;
-	Firebird::HalfStaticArray<ValueExprNode*, 4> m_values;
+	Firebird::HalfStaticArray<ValueExprNode*, 4> m_listValues;
+	Firebird::HalfStaticArray<ValueExprNode*, 4> m_keyValues;
 	const ValueExprNode* const* m_iterator;
 	temporary_key m_lower, m_upper;
 	USHORT m_segno = MAX_USHORT;

--- a/src/jrd/btr_proto.h
+++ b/src/jrd/btr_proto.h
@@ -39,13 +39,15 @@ dsc*	BTR_eval_expression(Jrd::thread_db*, Jrd::index_desc*, Jrd::Record*);
 void	BTR_evaluate(Jrd::thread_db*, const Jrd::IndexRetrieval*, Jrd::RecordBitmap**, Jrd::RecordBitmap*);
 UCHAR*	BTR_find_leaf(Ods::btree_page*, Jrd::temporary_key*, UCHAR*, USHORT*, bool, int);
 Ods::btree_page*	BTR_find_page(Jrd::thread_db*, const Jrd::IndexRetrieval*, Jrd::win*, Jrd::index_desc*,
-								 Jrd::temporary_key*, Jrd::temporary_key*, bool = true);
+	Jrd::temporary_key*, Jrd::temporary_key*);
 void	BTR_insert(Jrd::thread_db*, Jrd::win*, Jrd::index_insertion*);
 USHORT	BTR_key_length(Jrd::thread_db*, Jrd::jrd_rel*, Jrd::index_desc*);
 Ods::btree_page*	BTR_left_handoff(Jrd::thread_db*, Jrd::win*, Ods::btree_page*, SSHORT);
 bool	BTR_lookup(Jrd::thread_db*, Jrd::jrd_rel*, USHORT, Jrd::index_desc*, Jrd::RelationPages*);
+void	BTR_make_bounds(Jrd::thread_db*, const Jrd::IndexRetrieval*, Jrd::IndexScanListIterator*,
+	Jrd::temporary_key*, Jrd::temporary_key*);
 Jrd::idx_e	BTR_make_key(Jrd::thread_db*, USHORT, const Jrd::ValueExprNode* const*, const Jrd::index_desc*,
-						 Jrd::temporary_key*, USHORT);
+	Jrd::temporary_key*, USHORT);
 void	BTR_make_null_key(Jrd::thread_db*, const Jrd::index_desc*, Jrd::temporary_key*);
 bool	BTR_next_index(Jrd::thread_db*, Jrd::jrd_rel*, Jrd::jrd_tra*, Jrd::index_desc*, Jrd::win*);
 void	BTR_remove(Jrd::thread_db*, Jrd::win*, Jrd::index_insertion*);

--- a/src/jrd/optimizer/Optimizer.h
+++ b/src/jrd/optimizer/Optimizer.h
@@ -511,7 +511,8 @@ enum segmentScanType {
 	segmentScanEqual,
 	segmentScanEquivalent,
 	segmentScanMissing,
-	segmentScanStarting
+	segmentScanStarting,
+	segmentScanList
 };
 
 typedef Firebird::HalfStaticArray<BoolExprNode*, OPT_STATIC_ITEMS> MatchedBooleanList;
@@ -525,6 +526,7 @@ struct IndexScratchSegment
 	explicit IndexScratchSegment(MemoryPool& p, const IndexScratchSegment& other)
 		: lowerValue(other.lowerValue),
 		  upperValue(other.upperValue),
+		  matchValues(other.matchValues),
 		  excludeLower(other.excludeLower),
 		  excludeUpper(other.excludeUpper),
 		  scope(other.scope),
@@ -534,6 +536,7 @@ struct IndexScratchSegment
 
 	ValueExprNode* lowerValue = nullptr;		// lower bound on index value
 	ValueExprNode* upperValue = nullptr;		// upper bound on index value
+	ValueListNode* matchValues = nullptr;		// values to match
 	bool excludeLower = false;					// exclude lower bound value from scan
 	bool excludeUpper = false;					// exclude upper bound value from scan
 	unsigned scope = 0;							// highest scope level

--- a/src/jrd/optimizer/Optimizer.h
+++ b/src/jrd/optimizer/Optimizer.h
@@ -566,6 +566,7 @@ struct IndexScratch
 	unsigned nonFullMatchedSegments = 0;
 	bool usePartialKey = false;				// Use INTL_KEY_PARTIAL
 	bool useMultiStartingKeys = false;		// Use INTL_KEY_MULTI_STARTING
+	bool useRootListScan = false;
 
 	Firebird::ObjectsArray<IndexScratchSegment> segments;
 	MatchedBooleanList matches;					// matched booleans (partial indices only)

--- a/src/jrd/optimizer/Optimizer.h
+++ b/src/jrd/optimizer/Optimizer.h
@@ -526,7 +526,7 @@ struct IndexScratchSegment
 	explicit IndexScratchSegment(MemoryPool& p, const IndexScratchSegment& other)
 		: lowerValue(other.lowerValue),
 		  upperValue(other.upperValue),
-		  matchValues(other.matchValues),
+		  valueList(other.valueList),
 		  excludeLower(other.excludeLower),
 		  excludeUpper(other.excludeUpper),
 		  scope(other.scope),
@@ -536,7 +536,7 @@ struct IndexScratchSegment
 
 	ValueExprNode* lowerValue = nullptr;		// lower bound on index value
 	ValueExprNode* upperValue = nullptr;		// upper bound on index value
-	ValueListNode* matchValues = nullptr;		// values to match
+	LookupValueList* valueList = nullptr;		// values to match
 	bool excludeLower = false;					// exclude lower bound value from scan
 	bool excludeUpper = false;					// exclude upper bound value from scan
 	unsigned scope = 0;							// highest scope level

--- a/src/jrd/optimizer/Optimizer.h
+++ b/src/jrd/optimizer/Optimizer.h
@@ -372,6 +372,12 @@ public:
 				break;
 			}
 		}
+		else if (const auto listNode = nodeAs<InListBoolNode>(node))
+		{
+			const auto selectivity = REDUCE_SELECTIVITY_FACTOR_EQUALITY *
+				listNode->list->items.getCount();
+			return MIN(selectivity, MAXIMUM_SELECTIVITY);
+		}
 		else if (nodeIs<MissingBoolNode>(node))
 		{
 			return REDUCE_SELECTIVITY_FACTOR_EQUALITY;

--- a/src/jrd/optimizer/Retrieval.cpp
+++ b/src/jrd/optimizer/Retrieval.cpp
@@ -1901,17 +1901,19 @@ bool Retrieval::matchBoolean(IndexScratch* indexScratch,
 			if (!((segment->scanType == segmentScanEqual) ||
 				(segment->scanType == segmentScanEquivalent)))
 			{
-				auto lookup = listNode->lookup;
-				for (auto& item : *lookup)
+				if (auto lookup = listNode->lookup)
 				{
-					cast = nullptr; // create new cast node for every value
-					item = injectCast(csb, item, cast, matchDesc);
+					for (auto& item : *lookup)
+					{
+						cast = nullptr; // create new cast node for every value
+						item = injectCast(csb, item, cast, matchDesc);
+					}
+					segment->lowerValue = segment->upperValue = nullptr;
+					segment->valueList = lookup;
+					segment->scanType = segmentScanList;
+					segment->excludeLower = false;
+					segment->excludeUpper = false;
 				}
-				segment->lowerValue = segment->upperValue = nullptr;
-				segment->valueList = lookup;
-				segment->scanType = segmentScanList;
-				segment->excludeLower = false;
-				segment->excludeUpper = false;
 			}
 		}
 		else if (missingNode)

--- a/src/jrd/recsrc/IndexTableScan.cpp
+++ b/src/jrd/recsrc/IndexTableScan.cpp
@@ -253,8 +253,8 @@ bool IndexTableScan::internalGetRecord(thread_db* tdbb) const
 			{
 				if (impure->irsb_iterator && impure->irsb_iterator->getNext())
 				{
-					const auto nextLower = impure->irsb_iterator->getLower();
-					const auto nextUpper = impure->irsb_iterator->getUpper();
+					const auto nextLower = impure->irsb_iterator->getLowerKey();
+					const auto nextUpper = impure->irsb_iterator->getUpperKey();
 
 					// If END_BUCKET is reached BTR_find_leaf will return NULL
 					while (!(nextPointer = BTR_find_leaf(page, nextLower, nullptr, nullptr,
@@ -616,7 +616,10 @@ UCHAR* IndexTableScan::openStream(thread_db* tdbb, Impure* impure, win* window) 
 	const IndexRetrieval* const retrieval = m_index->retrieval;
 	index_desc* const idx = (index_desc*) ((SCHAR*) impure + m_offset);
 
-	Ods::btree_page* page = BTR_find_page(tdbb, retrieval, window, idx, lower, upper, firstKeys);
+	if (firstKeys)
+		BTR_make_bounds(tdbb, retrieval, impure->irsb_iterator, lower, upper);
+
+	Ods::btree_page* page = BTR_find_page(tdbb, retrieval, window, idx, lower, upper);
 	setPage(tdbb, impure, window);
 
 	// find the upper limit for the search

--- a/src/jrd/recsrc/RecordSource.cpp
+++ b/src/jrd/recsrc/RecordSource.cpp
@@ -161,6 +161,7 @@ void RecordSource::printInversion(thread_db* tdbb, const InversionNode* inversio
 
 				const bool fullscan = (maxSegs == 0);
 				const bool unique = uniqueIdx && equality && (minSegs == segCount);
+				const bool list = (retrieval->irb_list != nullptr);
 
 				string bounds;
 				if (!unique && !fullscan)
@@ -194,7 +195,7 @@ void RecordSource::printInversion(thread_db* tdbb, const InversionNode* inversio
 				}
 
 				plan += "Index " + printName(tdbb, indexName.c_str()) +
-					(fullscan ? " Full" : unique ? " Unique" : " Range") + " Scan" + bounds;
+					(fullscan ? " Full" : unique ? " Unique" : list ? " List" : " Range") + " Scan" + bounds;
 			}
 			else
 			{

--- a/src/jrd/recsrc/RecordSource.cpp
+++ b/src/jrd/recsrc/RecordSource.cpp
@@ -160,8 +160,8 @@ void RecordSource::printInversion(thread_db* tdbb, const InversionNode* inversio
 				const bool partial = (retrieval->irb_generic & irb_partial);
 
 				const bool fullscan = (maxSegs == 0);
-				const bool unique = uniqueIdx && equality && (minSegs == segCount);
 				const bool list = (retrieval->irb_list != nullptr);
+				const bool unique = !list && uniqueIdx && equality && (minSegs == segCount);
 
 				string bounds;
 				if (!unique && !fullscan)

--- a/src/jrd/recsrc/RecordSource.h
+++ b/src/jrd/recsrc/RecordSource.h
@@ -249,6 +249,7 @@ namespace Jrd
 			temporary_key* irsb_nav_upper;				// upper (possible multiple) key
 			temporary_key* irsb_nav_current_lower;		// current lower key
 			temporary_key* irsb_nav_current_upper;		// current upper key
+			IndexScanListIterator* irsb_iterator;		// key list iterator
 			USHORT irsb_nav_offset;						// page offset of current index node
 			USHORT irsb_nav_upper_length;				// length of upper key value
 			USHORT irsb_nav_length;						// length of expanded key

--- a/src/jrd/val.h
+++ b/src/jrd/val.h
@@ -57,6 +57,26 @@ class ArrayField;
 class blb;
 class Request;
 class jrd_tra;
+class ValueExprNode;
+
+struct SortValueItem
+{
+	SortValueItem(const ValueExprNode* val, const dsc* d)
+		: value(val), desc(d)
+	{}
+
+	static int compare(const dsc* desc1, const dsc* desc2);
+
+	bool operator>(const SortValueItem& other) const
+	{
+		return (compare(desc, other.desc) > 0);
+	}
+
+	const ValueExprNode* value;
+	const dsc* desc;
+};
+
+typedef Firebird::SortedArray<SortValueItem> SortedValueList;
 
 // Various structures in the impure area
 
@@ -109,6 +129,7 @@ struct impure_value
 		// Pre-compiled invariant object for pattern matcher functions
 		Jrd::PatternMatcher* vlu_invariant;
 		PatternMatcherCache* vlu_patternMatcherCache;
+		SortedValueList* vlu_sortedList;
 	} vlu_misc;
 
 	void make_long(const SLONG val, const signed char scale = 0);

--- a/src/jrd/val.h
+++ b/src/jrd/val.h
@@ -31,6 +31,7 @@
 
 #include "../include/fb_blk.h"
 #include "../common/classes/array.h"
+#include "../common/classes/Nullable.h"
 #include "../jrd/intl_classes.h"
 #include "../jrd/MetaName.h"
 #include "../jrd/QualifiedName.h"
@@ -56,8 +57,11 @@ namespace Jrd {
 class ArrayField;
 class blb;
 class Request;
+class jrd_req;
 class jrd_tra;
+class thread_db;
 class ValueExprNode;
+class ValueListNode;
 
 struct SortValueItem
 {
@@ -77,6 +81,23 @@ struct SortValueItem
 };
 
 typedef Firebird::SortedArray<SortValueItem> SortedValueList;
+
+class LookupValueList
+{
+public:
+	LookupValueList(MemoryPool& pool, const ValueListNode* values, ULONG impure);
+
+	ULONG getCount() const { return m_values.getCount(); }
+	ValueExprNode** begin() { return m_values.begin(); }
+	ValueExprNode** end() { return m_values.end(); }
+
+	TriState find(thread_db* tdbb, Request* request,
+				  const ValueExprNode* value, const dsc* desc) const;
+
+private:
+	Firebird::HalfStaticArray<ValueExprNode*, 4> m_values;
+	const ULONG m_impureOffset;
+};
 
 // Various structures in the impure area
 

--- a/src/jrd/val.h
+++ b/src/jrd/val.h
@@ -85,7 +85,7 @@ typedef Firebird::SortedArray<SortValueItem> SortedValueList;
 class LookupValueList
 {
 public:
-	LookupValueList(MemoryPool& pool, const ValueListNode* values, ULONG impure);
+	LookupValueList(MemoryPool& pool, ValueListNode* values, ULONG impure);
 
 	ULONG getCount() const { return m_values.getCount(); }
 	ValueExprNode** begin() { return m_values.begin(); }

--- a/src/yvalve/gds.cpp
+++ b/src/yvalve/gds.cpp
@@ -412,7 +412,8 @@ static const UCHAR
 	marks[] = { op_byte, op_literal, op_line, op_verb, 0},
 	erase[] = { op_erase, 0},
 	local_table[] = { op_word, op_byte, op_literal, op_byte, op_line, 0},
-	outer_map[] = { op_outer_map, 0 };
+	outer_map[] = { op_outer_map, 0 },
+	in_list[] = { op_verb, op_line, op_word, op_line, op_args, 0};
 
 
 #include "../jrd/blp.h"


### PR DESCRIPTION
This PR implements native IN <list> processing rather than converting it into a binary tree of ORed predicates. Details are described below.

1) Processing is now linear rather than recursive, thus no runtime stack limitations. The artificial limit of 1500 items is gone. The current implementation has a hard-limit of 64K items just because BLR needs some limit and because this value looks OK from the sanity POV.

2) Lists that are known to be constant are pre-evaluated as invariants and cached as a binary search tree, thus making comparisons faster if condition needs to be checked for many rows or if the value list is long enough.

3) If the list is very long or if the IN predicate is not selective, the index scan supports searching groups using the sibling pointer (i.e. horizontally) rather than searching every group from root (i.e. vertically). This corresponds to #4915.

Performance results in TPC-R queries containing IN <list> predicates:

Q12: ~ 2x improvement (list scan is used instead of full-scan with bitmap)
Q16: no difference (the plan is the same)
Q19: ~ 10x improvement (list scan is used instead of many range scans)
Q22: ~ 2x improvement (the plan is the same, but expression evaluation is more optimal)

The patch (in its original incarnation, based on v3 and v4 codebases) was tested by our customer in production since 2022 and looked stable, although they didn't see such a noticeable performance boost. But they needed longish lists (> 1500 items) more than a better performance ;-) When porting this into master I improved some things I didn't like originally.