### PR TITLE
Added SHA3 support for the built-in function CRYPT_HASH()

### DIFF
--- a/doc/sql.extensions/README.builtin_functions.txt
+++ b/doc/sql.extensions/README.builtin_functions.txt
@@ -371,7 +371,7 @@ Function:
 Format:
     CRYPT_HASH( <any value> USING <algorithm> )
 
-    algorithm ::= { MD5 | SHA1 | SHA256 | SHA512 }
+    algorithm ::= { MD5 | SHA1 | SHA256 | SHA512 | SHA3_224 | SHA3_256 | SHA3_384 | SHA3_512 }
 
 Important:
     - This function returns VARCHAR strings with OCTETS charset with length depended on algorithm.

--- a/extern/libtomcrypt/src/headers/tomcrypt_custom.h
+++ b/extern/libtomcrypt/src/headers/tomcrypt_custom.h
@@ -31,6 +31,7 @@
 #define LTC_NO_HASHES
 #define LTC_MD5
 #define LTC_SHA1
+#define LTC_SHA3
 #define LTC_SHA256
 #define LTC_SHA512
 #define LTC_HASH_HELPERS

--- a/src/common/classes/Hash.h
+++ b/src/common/classes/Hash.h
@@ -401,6 +401,30 @@ namespace Firebird
 		Sha1HashContext(MemoryPool& pool);
 	};
 
+	class Sha3_512_HashContext final : public LibTomCryptHashContext
+	{
+	public:
+		Sha3_512_HashContext(MemoryPool& pool);
+	};
+
+	class Sha3_384_HashContext final : public LibTomCryptHashContext
+	{
+	public:
+		Sha3_384_HashContext(MemoryPool& pool);
+	};
+
+	class Sha3_256_HashContext final : public LibTomCryptHashContext
+	{
+	public:
+		Sha3_256_HashContext(MemoryPool& pool);
+	};
+
+	class Sha3_224_HashContext final : public LibTomCryptHashContext
+	{
+	public:
+		Sha3_224_HashContext(MemoryPool& pool);
+	};
+
 	class Sha256HashContext final : public LibTomCryptHashContext
 	{
 	public:

--- a/src/common/classes/TomCryptHash.cpp
+++ b/src/common/classes/TomCryptHash.cpp
@@ -87,6 +87,33 @@ Sha1HashContext::Sha1HashContext(MemoryPool& pool)
 {
 }
 
+static LibTomCryptHashContext::Descriptor sha3_512_Descriptor{&sha3_512_desc};
+
+Sha3_512_HashContext::Sha3_512_HashContext(MemoryPool& pool)
+	: LibTomCryptHashContext(pool, &sha3_512_Descriptor)
+{
+}
+
+static LibTomCryptHashContext::Descriptor sha3_384_Descriptor{&sha3_384_desc};
+
+Sha3_384_HashContext::Sha3_384_HashContext(MemoryPool& pool)
+	: LibTomCryptHashContext(pool, &sha3_384_Descriptor)
+{
+}
+
+static LibTomCryptHashContext::Descriptor sha3_256_Descriptor{&sha3_256_desc};
+
+Sha3_256_HashContext::Sha3_256_HashContext(MemoryPool& pool)
+	: LibTomCryptHashContext(pool, &sha3_256_Descriptor)
+{
+}
+
+static LibTomCryptHashContext::Descriptor sha3_224_Descriptor{&sha3_224_desc};
+
+Sha3_224_HashContext::Sha3_224_HashContext(MemoryPool& pool)
+	: LibTomCryptHashContext(pool, &sha3_224_Descriptor)
+{
+}
 
 static LibTomCryptHashContext::Descriptor sha256Descriptor{&sha256_desc};
 

--- a/src/jrd/SysFunction.cpp
+++ b/src/jrd/SysFunction.cpp
@@ -163,6 +163,10 @@ static const HashAlgorithmDescriptor* cryptHashAlgorithmDescriptors[] = {
 	HashAlgorithmDescriptorFactory<Sha1HashContext>::getInstance("SHA1", 20),
 	HashAlgorithmDescriptorFactory<Sha256HashContext>::getInstance("SHA256", 32),
 	HashAlgorithmDescriptorFactory<Sha512HashContext>::getInstance("SHA512", 64),
+	HashAlgorithmDescriptorFactory<Sha3_512_HashContext>::getInstance("SHA3_512", 64),
+	HashAlgorithmDescriptorFactory<Sha3_384_HashContext>::getInstance("SHA3_384", 48),
+	HashAlgorithmDescriptorFactory<Sha3_256_HashContext>::getInstance("SHA3_256", 32),
+	HashAlgorithmDescriptorFactory<Sha3_224_HashContext>::getInstance("SHA3_224", 28),
 	nullptr
 };
 
@@ -2964,6 +2968,10 @@ public:
 
 		registerHash(md5_desc);
 		registerHash(sha1_desc);
+		registerHash(sha3_512_desc);
+		registerHash(sha3_384_desc);
+		registerHash(sha3_256_desc);
+		registerHash(sha3_224_desc);
 		registerHash(sha256_desc);
 		registerHash(sha512_desc);
 	}


### PR DESCRIPTION
Added support for SHA3_224, SHA3_256, SHA3_384, SHA3_512 for the built-in function CRYPT_HASH()

Example:
```sqlpl
SELECT CRYPT_HASH('qwerty' USING SHA3_256) FROM RDB$DATABASE;
``` 
Result:
```
F171CBB35DD1166A20F99B5AD226553E122F3C0F2FE981915FB9E4517AAC9038
``` 