### PR TITLE
Recursive plan output for queries involving selectable stored procedures

### DIFF
--- a/builds/install/misc/firebird.conf
+++ b/builds/install/misc/firebird.conf
@@ -750,6 +750,19 @@
 
 
 # ----------------------------
+# Define maximum recursion depth of the plan output.
+#
+# When set to non-zero, allows to recurse into selectable procedures and
+# include their nested plans into the plan of the outer query.
+#
+# Per-database configurable.
+#
+# Type: integer
+#
+#PlanRecursionLimit = 0
+
+
+# ----------------------------
 # The engine provides a number of new datatypes unknown to legacy clients.
 # To simplify use of old applications set this parameter to the Firebird version
 # matching the datatype compatibility you need. Currently two values are

--- a/src/common/config/config.h
+++ b/src/common/config/config.h
@@ -192,6 +192,7 @@ enum ConfigKey
 	KEY_MAX_STATEMENT_CACHE_SIZE,
 	KEY_PARALLEL_WORKERS,
 	KEY_MAX_PARALLEL_WORKERS,
+	KEY_PLAN_RECURSION_LIMIT,
 	MAX_CONFIG_KEY		// keep it last
 };
 
@@ -310,7 +311,8 @@ constexpr ConfigEntry entries[MAX_CONFIG_KEY] =
 	{TYPE_STRING,	"TempTableDirectory",		false,	""},
 	{TYPE_INTEGER,	"MaxStatementCacheSize",	false,	2 * 1048576},	// bytes
 	{TYPE_INTEGER,	"ParallelWorkers",			true,	1},
-	{TYPE_INTEGER,	"MaxParallelWorkers",		true,	1}
+	{TYPE_INTEGER,	"MaxParallelWorkers",		true,	1},
+	{TYPE_INTEGER,	"PlanRecursionLimit",		false,	0}
 };
 
 
@@ -638,6 +640,9 @@ public:
 	CONFIG_GET_GLOBAL_INT(getParallelWorkers, KEY_PARALLEL_WORKERS);
 
 	CONFIG_GET_GLOBAL_INT(getMaxParallelWorkers, KEY_MAX_PARALLEL_WORKERS);
+
+	CONFIG_GET_PER_DB_INT(getPlanRecursionLimit, KEY_PLAN_RECURSION_LIMIT);
+
 };
 
 // Implementation of interface to access master configuration file

--- a/src/jrd/ProfilerManager.cpp
+++ b/src/jrd/ProfilerManager.cpp
@@ -520,7 +520,9 @@ void ProfilerManager::prepareRecSource(thread_db* tdbb, Request* request, const 
 		const auto thisRsb = planItem.recordSource;
 
 		string& accessPath = planItem.accessPath;
-		thisRsb->print(tdbb, accessPath, true, 0, false);
+
+		PlanPrintContext context(tdbb->getDatabase(), accessPath, true, false);
+		thisRsb->print(tdbb, context, 0);
 
 		constexpr auto INDENT_MARKER = "\n    ";
 		constexpr unsigned INDENT_COUNT = 4;

--- a/src/jrd/recsrc/AggregatedStream.cpp
+++ b/src/jrd/recsrc/AggregatedStream.cpp
@@ -380,16 +380,16 @@ void AggregatedStream::getChildren(Array<const RecordSource*>& children) const
 	children.add(m_next);
 }
 
-void AggregatedStream::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void AggregatedStream::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + "Aggregate";
 		printOptInfo(plan);
 	}
 
-	if (recurse)
-		m_next->print(tdbb, plan, detailed, level, recurse);
+	if (plan.goDeeper())
+		m_next->print(tdbb, plan, level);
 }
 
 bool AggregatedStream::internalGetRecord(thread_db* tdbb) const

--- a/src/jrd/recsrc/BitmapTableScan.cpp
+++ b/src/jrd/recsrc/BitmapTableScan.cpp
@@ -126,10 +126,9 @@ void BitmapTableScan::getChildren(Array<const RecordSource*>& children) const
 {
 }
 
-void BitmapTableScan::print(thread_db* tdbb, string& plan,
-							bool detailed, unsigned level, bool recurse) const
+void BitmapTableScan::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + "Table " +
 			printName(tdbb, m_relation->rel_name.c_str(), m_alias) + " Access By ID";

--- a/src/jrd/recsrc/BufferedStream.cpp
+++ b/src/jrd/recsrc/BufferedStream.cpp
@@ -319,9 +319,9 @@ void BufferedStream::getChildren(Array<const RecordSource*>& children) const
 	children.add(m_next);
 }
 
-void BufferedStream::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void BufferedStream::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		string extras;
 		extras.printf(" (record length: %" ULONGFORMAT")", m_format->fmt_length);
@@ -330,8 +330,8 @@ void BufferedStream::print(thread_db* tdbb, string& plan, bool detailed, unsigne
 		printOptInfo(plan);
 	}
 
-	if (recurse)
-		m_next->print(tdbb, plan, detailed, level, recurse);
+	if (plan.goDeeper())
+		m_next->print(tdbb, plan, level);
 }
 
 void BufferedStream::markRecursive()

--- a/src/jrd/recsrc/ConditionalStream.cpp
+++ b/src/jrd/recsrc/ConditionalStream.cpp
@@ -120,17 +120,17 @@ void ConditionalStream::getChildren(Array<const RecordSource*>& children) const
 	children.add(m_second);
 }
 
-void ConditionalStream::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void ConditionalStream::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + "Condition";
 		printOptInfo(plan);
 
-		if (recurse)
+		if (plan.goDeeper())
 		{
-			m_first->print(tdbb, plan, true, level, recurse);
-			m_second->print(tdbb, plan, true, level, recurse);
+			m_first->print(tdbb, plan, level);
+			m_second->print(tdbb, plan, level);
 		}
 	}
 	else
@@ -138,11 +138,11 @@ void ConditionalStream::print(thread_db* tdbb, string& plan, bool detailed, unsi
 		if (!level)
 			plan += "(";
 
-		m_first->print(tdbb, plan, false, level + 1, recurse);
+		m_first->print(tdbb, plan, level + 1);
 
 		plan += ", ";
 
-		m_second->print(tdbb, plan, false, level + 1, recurse);
+		m_second->print(tdbb, plan, level + 1);
 
 		if (!level)
 			plan += ")";

--- a/src/jrd/recsrc/Cursor.cpp
+++ b/src/jrd/recsrc/Cursor.cpp
@@ -109,10 +109,10 @@ void Select::initializeInvariants(Request* request) const
 
 void Select::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	plan += level ? RecordSource::printIndent(level) : "\n";
-
 	if (plan.isDetailed())
 	{
+		plan += level ? RecordSource::printIndent(level) : "\n";
+
 		if (m_rse->isSubQuery())
 		{
 			plan += "Sub-query";
@@ -137,16 +137,16 @@ void Select::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) cons
 			plan += pos;
 		}
 	}
-	else
+	else if (!level)
 	{
-		if (!level && (m_line || m_column))
+		if (m_line || m_column)
 		{
 			string pos;
 			pos.printf("\n-- line %u, column %u", m_line, m_column);
 			plan += pos;
 		}
 
-		plan += "PLAN ";
+		plan += "\nPLAN ";
 	}
 
 	if (plan.goDeeper())

--- a/src/jrd/recsrc/Cursor.cpp
+++ b/src/jrd/recsrc/Cursor.cpp
@@ -107,26 +107,28 @@ void Select::initializeInvariants(Request* request) const
 	}
 }
 
-void Select::print(thread_db* tdbb, Firebird::string& plan, bool detailed, unsigned level, bool recurse) const
+void Select::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	plan += level ? RecordSource::printIndent(level) : "\n";
+
+	if (plan.isDetailed())
 	{
 		if (m_rse->isSubQuery())
 		{
-			plan += "\nSub-query";
+			plan += "Sub-query";
 
 			if (m_rse->isInvariant())
 				plan += " (invariant)";
 		}
 		else if (m_cursorName.hasData())
 		{
-			plan += "\nCursor \"" + string(m_cursorName) + "\"";
+			plan += "Cursor \"" + string(m_cursorName) + "\"";
 
 			if (m_rse->isScrollable())
 				plan += " (scrollable)";
 		}
 		else
-			plan += "\nSelect Expression";
+			plan += "Select Expression";
 
 		if (m_line || m_column)
 		{
@@ -137,18 +139,18 @@ void Select::print(thread_db* tdbb, Firebird::string& plan, bool detailed, unsig
 	}
 	else
 	{
-		if (m_line || m_column)
+		if (!level && (m_line || m_column))
 		{
 			string pos;
 			pos.printf("\n-- line %u, column %u", m_line, m_column);
 			plan += pos;
 		}
 
-		plan += "\nPLAN ";
+		plan += "PLAN ";
 	}
 
-	if (recurse)
-		m_root->print(tdbb, plan, detailed, level, true);
+	if (plan.goDeeper())
+		m_root->print(tdbb, plan, level);
 }
 
 // ---------------------

--- a/src/jrd/recsrc/Cursor.h
+++ b/src/jrd/recsrc/Cursor.h
@@ -25,12 +25,12 @@
 
 #include "../common/classes/array.h"
 #include "../jrd/MetaName.h"
+#include "../jrd/recsrc/RecordSource.h"
 
 namespace Jrd
 {
 	class thread_db;
 	class CompilerScratch;
-	class RecordSource;
 	class RseNode;
 
 	// Select class (common base for sub-queries and cursors)
@@ -70,11 +70,11 @@ namespace Jrd
 
 		void printPlan(thread_db* tdbb, Firebird::string& plan, bool detailed) const
 		{
-			print(tdbb, plan, detailed, 0, true);
+			PlanPrintContext context(tdbb->getDatabase(), plan, detailed, true);
+			print(tdbb, context, 0);
 		}
 
-		void print(thread_db* tdbb, Firebird::string& plan,
-			bool detailed, unsigned level, bool recurse) const override;
+		void print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const override;
 
 		void getChildren(Firebird::Array<const RecordSource*>& children) const override
 		{

--- a/src/jrd/recsrc/ExternalTableScan.cpp
+++ b/src/jrd/recsrc/ExternalTableScan.cpp
@@ -119,10 +119,9 @@ void ExternalTableScan::getChildren(Array<const RecordSource*>& children) const
 {
 }
 
-void ExternalTableScan::print(thread_db* tdbb, string& plan,
-							  bool detailed, unsigned level, bool recurse) const
+void ExternalTableScan::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + "Table " +
 			printName(tdbb, m_relation->rel_name.c_str(), m_alias) + " Full Scan";

--- a/src/jrd/recsrc/FilteredStream.cpp
+++ b/src/jrd/recsrc/FilteredStream.cpp
@@ -121,9 +121,9 @@ void FilteredStream::getChildren(Array<const RecordSource*>& children) const
 	children.add(m_next);
 }
 
-void FilteredStream::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void FilteredStream::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + "Filter";
 
@@ -133,8 +133,8 @@ void FilteredStream::print(thread_db* tdbb, string& plan, bool detailed, unsigne
 		printOptInfo(plan);
 	}
 
-	if (recurse)
-		m_next->print(tdbb, plan, detailed, level, recurse);
+	if (plan.goDeeper())
+		m_next->print(tdbb, plan, level);
 }
 
 void FilteredStream::markRecursive()

--- a/src/jrd/recsrc/FirstRowsStream.cpp
+++ b/src/jrd/recsrc/FirstRowsStream.cpp
@@ -125,16 +125,16 @@ void FirstRowsStream::getChildren(Array<const RecordSource*>& children) const
 	children.add(m_next);
 }
 
-void FirstRowsStream::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void FirstRowsStream::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + "First N Records";
 		printOptInfo(plan);
 	}
 
-	if (recurse)
-		m_next->print(tdbb, plan, detailed, level, recurse);
+	if (plan.goDeeper())
+		m_next->print(tdbb, plan, level);
 }
 
 void FirstRowsStream::markRecursive()

--- a/src/jrd/recsrc/FullOuterJoin.cpp
+++ b/src/jrd/recsrc/FullOuterJoin.cpp
@@ -118,25 +118,25 @@ void FullOuterJoin::getChildren(Array<const RecordSource*>& children) const
 	children.add(m_arg2);
 }
 
-void FullOuterJoin::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void FullOuterJoin::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + "Full Outer Join";
 
-		if (recurse)
+		if (plan.goDeeper())
 		{
-			m_arg1->print(tdbb, plan, true, level, recurse);
-			m_arg2->print(tdbb, plan, true, level, recurse);
+			m_arg1->print(tdbb, plan, level);
+			m_arg2->print(tdbb, plan, level);
 		}
 	}
 	else
 	{
 		level++;
 		plan += "JOIN (";
-		m_arg1->print(tdbb, plan, false, level, recurse);
+		m_arg1->print(tdbb, plan, level);
 		plan += ", ";
-		m_arg2->print(tdbb, plan, false, level, recurse);
+		m_arg2->print(tdbb, plan, level);
 		plan += ")";
 	}
 }

--- a/src/jrd/recsrc/FullTableScan.cpp
+++ b/src/jrd/recsrc/FullTableScan.cpp
@@ -166,9 +166,9 @@ void FullTableScan::getChildren(Array<const RecordSource*>& children) const
 {
 }
 
-void FullTableScan::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void FullTableScan::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		auto lowerBounds = 0, upperBounds = 0;
 		for (const auto range : m_dbkeyRanges)

--- a/src/jrd/recsrc/HashJoin.cpp
+++ b/src/jrd/recsrc/HashJoin.cpp
@@ -462,33 +462,33 @@ void HashJoin::getChildren(Array<const RecordSource*>& children) const
 		children.add(m_args[i].source);
 }
 
-void HashJoin::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void HashJoin::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + "Hash Join (inner)";
 		printOptInfo(plan);
 
-		if (recurse)
+		if (plan.goDeeper())
 		{
-			m_leader.source->print(tdbb, plan, true, level, recurse);
+			m_leader.source->print(tdbb, plan, level);
 
 			for (FB_SIZE_T i = 0; i < m_args.getCount(); i++)
-				m_args[i].source->print(tdbb, plan, true, level, recurse);
+				m_args[i].source->print(tdbb, plan, level);
 		}
 	}
 	else
 	{
 		level++;
 		plan += "HASH (";
-		m_leader.source->print(tdbb, plan, false, level, recurse);
+		m_leader.source->print(tdbb, plan, level);
 		plan += ", ";
 		for (FB_SIZE_T i = 0; i < m_args.getCount(); i++)
 		{
 			if (i)
 				plan += ", ";
 
-			m_args[i].source->print(tdbb, plan, false, level, recurse);
+			m_args[i].source->print(tdbb, plan, level);
 		}
 		plan += ")";
 	}

--- a/src/jrd/recsrc/IndexTableScan.cpp
+++ b/src/jrd/recsrc/IndexTableScan.cpp
@@ -304,9 +304,9 @@ void IndexTableScan::getChildren(Array<const RecordSource*>& children) const
 {
 }
 
-void IndexTableScan::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void IndexTableScan::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + "Table " +
 			printName(tdbb, m_relation->rel_name.c_str(), m_alias) + " Access By ID";

--- a/src/jrd/recsrc/LocalTableStream.cpp
+++ b/src/jrd/recsrc/LocalTableStream.cpp
@@ -113,11 +113,11 @@ WriteLockResult LocalTableStream::lockRecord(thread_db* tdbb, bool skipLocked) c
 	status_exception::raise(Arg::Gds(isc_record_lock_not_supp));
 }
 
-void LocalTableStream::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void LocalTableStream::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
 	//// TODO: Use Local Table name/alias.
 
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + "Local Table Full Scan";
 		printOptInfo(plan);

--- a/src/jrd/recsrc/LockedStream.cpp
+++ b/src/jrd/recsrc/LockedStream.cpp
@@ -116,16 +116,16 @@ void LockedStream::getChildren(Array<const RecordSource*>& children) const
 	children.add(m_next);
 }
 
-void LockedStream::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void LockedStream::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + "Write Lock";
 		printOptInfo(plan);
 	}
 
-	if (recurse)
-		m_next->print(tdbb, plan, detailed, level, recurse);
+	if (plan.goDeeper())
+		m_next->print(tdbb, plan, level);
 }
 
 void LockedStream::markRecursive()

--- a/src/jrd/recsrc/MergeJoin.cpp
+++ b/src/jrd/recsrc/MergeJoin.cpp
@@ -351,17 +351,17 @@ void MergeJoin::getChildren(Array<const RecordSource*>& children) const
 		children.add(m_args[i]);
 }
 
-void MergeJoin::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void MergeJoin::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + "Merge Join (inner)";
 		printOptInfo(plan);
 
-		if (recurse)
+		if (plan.goDeeper())
 		{
 			for (FB_SIZE_T i = 0; i < m_args.getCount(); i++)
-				m_args[i]->print(tdbb, plan, true, level, recurse);
+				m_args[i]->print(tdbb, plan, level);
 		}
 	}
 	else
@@ -373,7 +373,7 @@ void MergeJoin::print(thread_db* tdbb, string& plan, bool detailed, unsigned lev
 			if (i)
 				plan += ", ";
 
-			m_args[i]->print(tdbb, plan, false, level, recurse);
+			m_args[i]->print(tdbb, plan, level);
 		}
 		plan += ")";
 	}

--- a/src/jrd/recsrc/NestedLoopJoin.cpp
+++ b/src/jrd/recsrc/NestedLoopJoin.cpp
@@ -214,11 +214,11 @@ void NestedLoopJoin::getChildren(Array<const RecordSource*>& children) const
 		children.add(m_args[i]);
 }
 
-void NestedLoopJoin::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void NestedLoopJoin::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
 	if (m_args.hasData())
 	{
-		if (detailed)
+		if (plan.isDetailed())
 		{
 			plan += printIndent(++level) + "Nested Loop Join ";
 
@@ -246,10 +246,10 @@ void NestedLoopJoin::print(thread_db* tdbb, string& plan, bool detailed, unsigne
 
 			printOptInfo(plan);
 
-			if (recurse)
+			if (plan.goDeeper())
 			{
 				for (FB_SIZE_T i = 0; i < m_args.getCount(); i++)
-					m_args[i]->print(tdbb, plan, true, level, recurse);
+					m_args[i]->print(tdbb, plan, level);
 			}
 		}
 		else
@@ -261,7 +261,7 @@ void NestedLoopJoin::print(thread_db* tdbb, string& plan, bool detailed, unsigne
 				if (i)
 					plan += ", ";
 
-				m_args[i]->print(tdbb, plan, false, level, recurse);
+				m_args[i]->print(tdbb, plan, level);
 			}
 			plan += ")";
 		}

--- a/src/jrd/recsrc/RecursiveStream.cpp
+++ b/src/jrd/recsrc/RecursiveStream.cpp
@@ -244,17 +244,17 @@ void RecursiveStream::getChildren(Array<const RecordSource*>& children) const
 	children.add(m_inner);
 }
 
-void RecursiveStream::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void RecursiveStream::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + "Recursion";
 		printOptInfo(plan);
 
-		if (recurse)
+		if (plan.goDeeper())
 		{
-			m_root->print(tdbb, plan, true, level, recurse);
-			m_inner->print(tdbb, plan, true, level, recurse);
+			m_root->print(tdbb, plan, level);
+			m_inner->print(tdbb, plan, level);
 		}
 	}
 	else
@@ -262,11 +262,11 @@ void RecursiveStream::print(thread_db* tdbb, string& plan, bool detailed, unsign
 		if (!level)
 			plan += "(";
 
-		m_root->print(tdbb, plan, false, level + 1, recurse);
+		m_root->print(tdbb, plan, level + 1);
 
 		plan += ", ";
 
-		m_inner->print(tdbb, plan, false, level + 1, recurse);
+		m_inner->print(tdbb, plan, level + 1);
 
 		if (!level)
 			plan += ")";

--- a/src/jrd/recsrc/SingularStream.cpp
+++ b/src/jrd/recsrc/SingularStream.cpp
@@ -151,16 +151,16 @@ void SingularStream::getChildren(Array<const RecordSource*>& children) const
 	children.add(m_next);
 }
 
-void SingularStream::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void SingularStream::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + "Singularity Check";
 		printOptInfo(plan);
 	}
 
-	if (recurse)
-		m_next->print(tdbb, plan, detailed, level, recurse);
+	if (plan.goDeeper())
+		m_next->print(tdbb, plan, level);
 }
 
 void SingularStream::markRecursive()

--- a/src/jrd/recsrc/SkipRowsStream.cpp
+++ b/src/jrd/recsrc/SkipRowsStream.cpp
@@ -121,16 +121,16 @@ void SkipRowsStream::getChildren(Array<const RecordSource*>& children) const
 	children.add(m_next);
 }
 
-void SkipRowsStream::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void SkipRowsStream::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + "Skip N Records";
 		printOptInfo(plan);
 	}
 
-	if (recurse)
-		m_next->print(tdbb, plan, detailed, level, recurse);
+	if (plan.goDeeper())
+		m_next->print(tdbb, plan, level);
 }
 
 void SkipRowsStream::markRecursive()

--- a/src/jrd/recsrc/SortedStream.cpp
+++ b/src/jrd/recsrc/SortedStream.cpp
@@ -126,10 +126,9 @@ void SortedStream::getChildren(Array<const RecordSource*>& children) const
 	children.add(m_next);
 }
 
-void SortedStream::print(thread_db* tdbb, string& plan,
-						 bool detailed, unsigned level, bool recurse) const
+void SortedStream::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		string extras;
 		extras.printf(" (record length: %" ULONGFORMAT", key length: %" ULONGFORMAT")",
@@ -142,14 +141,14 @@ void SortedStream::print(thread_db* tdbb, string& plan,
 			((m_map->flags & FLAG_PROJECT) ? "Unique Sort" : "Sort") + extras;
 		printOptInfo(plan);
 
-		if (recurse)
-			m_next->print(tdbb, plan, true, level, recurse);
+		if (plan.goDeeper())
+			m_next->print(tdbb, plan, level);
 	}
 	else
 	{
 		level++;
 		plan += "SORT (";
-		m_next->print(tdbb, plan, false, level, recurse);
+		m_next->print(tdbb, plan, level);
 		plan += ")";
 	}
 }

--- a/src/jrd/recsrc/Union.cpp
+++ b/src/jrd/recsrc/Union.cpp
@@ -168,17 +168,17 @@ void Union::getChildren(Array<const RecordSource*>& children) const
 		children.add(m_args[i]);
 }
 
-void Union::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void Union::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + (m_args.getCount() == 1 ? "Materialize" : "Union");
 		printOptInfo(plan);
 
-		if (recurse)
+		if (plan.goDeeper())
 		{
 			for (FB_SIZE_T i = 0; i < m_args.getCount(); i++)
-				m_args[i]->print(tdbb, plan, true, level, recurse);
+				m_args[i]->print(tdbb, plan, level);
 		}
 	}
 	else
@@ -191,7 +191,7 @@ void Union::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, 
 			if (i)
 				plan += ", ";
 
-			m_args[i]->print(tdbb, plan, false, level + 1, recurse);
+			m_args[i]->print(tdbb, plan, level + 1);
 		}
 
 		if (!level)

--- a/src/jrd/recsrc/VirtualTableScan.cpp
+++ b/src/jrd/recsrc/VirtualTableScan.cpp
@@ -113,9 +113,9 @@ void VirtualTableScan::getChildren(Array<const RecordSource*>& children) const
 {
 }
 
-void VirtualTableScan::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void VirtualTableScan::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + "Table " +
 			printName(tdbb, m_relation->rel_name.c_str(), m_alias) + " Full Scan";

--- a/src/jrd/recsrc/WindowedStream.cpp
+++ b/src/jrd/recsrc/WindowedStream.cpp
@@ -61,7 +61,7 @@ namespace
 
 		void getChildren(Firebird::Array<const RecordSource*>& children) const override;
 
-		void print(thread_db* tdbb, Firebird::string& plan, bool detailed, unsigned level, bool recurse) const override;
+		void print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const override;
 
 		void markRecursive() override;
 		void invalidateRecords(Request* request) const override;
@@ -152,16 +152,16 @@ namespace
 		children.add(m_next);
 	}
 
-	void BufferedStreamWindow::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+	void BufferedStreamWindow::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 	{
-		if (detailed)
+		if (plan.isDetailed())
 		{
 			plan += printIndent(++level) + "Window Buffer";
 			printOptInfo(plan);
 		}
 
-		if (recurse)
-			m_next->print(tdbb, plan, detailed, level, recurse);
+		if (plan.goDeeper())
+			m_next->print(tdbb, plan, level);
 	}
 
 	void BufferedStreamWindow::markRecursive()
@@ -409,16 +409,16 @@ void WindowedStream::getChildren(Array<const RecordSource*>& children) const
 	children.add(m_joinedStream);
 }
 
-void WindowedStream::print(thread_db* tdbb, string& plan, bool detailed, unsigned level, bool recurse) const
+void WindowedStream::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + "Window";
 		printOptInfo(plan);
 	}
 
-	if (recurse)
-		m_joinedStream->print(tdbb, plan, detailed, level, recurse);
+	if (plan.goDeeper())
+		m_joinedStream->print(tdbb, plan, level);
 }
 
 void WindowedStream::markRecursive()
@@ -904,17 +904,16 @@ void WindowedStream::WindowStream::getChildren(Array<const RecordSource*>& child
 	children.add(m_next);
 }
 
-void WindowedStream::WindowStream::print(thread_db* tdbb, string& plan, bool detailed,
-	unsigned level, bool recurse) const
+void WindowedStream::WindowStream::print(thread_db* tdbb, PlanPrintContext& plan, unsigned level) const
 {
-	if (detailed)
+	if (plan.isDetailed())
 	{
 		plan += printIndent(++level) + "Window Partition";
 		printOptInfo(plan);
 	}
 
-	if (recurse)
-		m_next->print(tdbb, plan, detailed, level, recurse);
+	if (plan.goDeeper())
+		m_next->print(tdbb, plan, level);
 }
 
 void WindowedStream::WindowStream::findUsedStreams(StreamList& streams, bool expandAll) const


### PR DESCRIPTION
Related to issue #5322.

Prior to v3.0, if the query includes selectable procedures, their plans were embedded into the main query plan. This was changed in v3 due to refactoring and because such "mixed" plans were often hardly readable. But users kept complaining the feature was useful, at least to analyze plans for possible NATURAL scans inside. I'm still pessimistic about that, but the explained plan format allows to show embedded plans nicely indented, so why not. This PR re-allows embedding nested plans into the main one. It's controlled by the configuration parameter and disabled by default (thus compatible with v3 and v4).

Example:

```sql
set term ^;

create or alter procedure p1 returns (a int)
as
begin
  select null from rdb$database into :a;
  suspend;

  for select rdb$relation_id from rdb$relations into :a
  do suspend;
end^

create or alter procedure p2 returns (a int)
as
begin
  select null from rdb$database into :a;
  suspend;

  for select rdb$relation_id from rdb$relations into :a
  do suspend;

  for select a from p1 into :a
  do suspend;
end^

create or alter procedure p3 returns (a int)
as
begin
  select null from rdb$database into :a;
  suspend;

  for select rdb$relation_id from rdb$relations into :a
  do suspend;

  for select a from p3 into :a
  do suspend;
end^

set term ;^

SQL> select * from p1;

Select Expression
    -> Procedure "P1" Scan -- explain the P1 body below (for PlanRecursionLimit > 0)
        -> Select Expression (line 4, column 3)
            -> Singularity Check
                -> Table "RDB$DATABASE" Full Scan
        -> Select Expression (line 7, column 3)
            -> Table "RDB$RELATIONS" Full Scan

SQL> select * from p2;

Select Expression
    -> Procedure "P2" Scan -- explain the P2 body below (for PlanRecursionLimit > 0)
        -> Select Expression (line 4, column 3)
            -> Singularity Check
                -> Table "RDB$DATABASE" Full Scan
        -> Select Expression (line 7, column 3)
            -> Table "RDB$RELATIONS" Full Scan
        -> Select Expression (line 10, column 3)
            -> Procedure "P1" Scan -- explain the P1 body below (for PlanRecursionLimit > 1)
                -> Select Expression (line 4, column 3)
                    -> Singularity Check
                        -> Table "RDB$DATABASE" Full Scan
                -> Select Expression (line 7, column 3)
                    -> Table "RDB$RELATIONS" Full Scan

SQL> select * from p3;

Select Expression
    -> Procedure "P3" Scan -- explain the P3 body below (for PlanRecursionLimit > 0)
        -> Select Expression (line 4, column 3)
            -> Singularity Check
                -> Table "RDB$DATABASE" Full Scan
        -> Select Expression (line 7, column 3)
            -> Table "RDB$RELATIONS" Full Scan
        -> Select Expression (line 10, column 3)
            -> Procedure "P3" Scan -- recursion for P3 is detected, not going deeper

```

Questions:

- Is the `PlanRecursionLimit` parameter name OK or should it be better named `MaxPlanRecursion`?
- Should we also support per-connection parameter override (via DPB and/or session management statements)? IMO, this could be useful when analyzing things in special tools or dedicated ISQL sessions without a need to change the server configuration.