### PR TITLE
Fixed bug #7713

### DIFF
--- a/src/dsql/ExprNodes.cpp
+++ b/src/dsql/ExprNodes.cpp
@@ -9463,6 +9463,12 @@ DmlNode* SubQueryNode::parse(thread_db* tdbb, MemoryPool& pool, CompilerScratch*
 
 		if (csb->csb_currentDMLNode)
 			node->ownSavepoint = false;
+
+		if (!csb->csb_currentForNode && !csb->csb_currentDMLNode &&
+			(csb->csb_g_flags & csb_computed_field))
+		{
+			node->ownSavepoint = false;
+		}
 	}
 
 	return node;

--- a/src/jrd/exe.h
+++ b/src/jrd/exe.h
@@ -611,6 +611,7 @@ const int csb_validation		= 64;	// we're in a validation expression (RDB hack)
 const int csb_reuse_context		= 128;	// allow context reusage
 const int csb_subroutine		= 256;	// sub routine
 const int csb_reload			= 512;	// request's BLR should be loaded and parsed again
+const int csb_computed_field	= 1024;	// computed field expression
 
 // CompilerScratch.csb_rpt[].csb_flags's values.
 const int csb_active		= 1;		// stream is active

--- a/src/jrd/met.epp
+++ b/src/jrd/met.epp
@@ -4012,8 +4012,8 @@ void MET_scan_relation(thread_db* tdbb, jrd_rel* relation)
 
 					DmlNode* nod = dependencies ?
 						MET_get_dependencies(tdbb, relation, p, length, csb, NULL, NULL, NULL,
-							field->fld_name, obj_computed, 0, depTrans) :
-						PAR_blr(tdbb, relation, p, length, csb, NULL, NULL, false, 0);
+							field->fld_name, obj_computed, csb_computed_field, depTrans) :
+						PAR_blr(tdbb, relation, p, length, csb, NULL, NULL, false, csb_computed_field);
 
 					field->fld_computation = static_cast<ValueExprNode*>(nod);
 				}


### PR DESCRIPTION
Stability of implicit cursor could be broken, if cursor's select expression is based
on view with sub-query in select list, or
on table with sub-query in computed field.
