### PR TITLE
Fix cases where the precedence relationship between a record page and a blob page is not set

### DIFF
--- a/src/jrd/blb.cpp
+++ b/src/jrd/blb.cpp
@@ -448,6 +448,7 @@ void BLB_garbage_collect(thread_db* tdbb,
  **************************************/
 	SET_TDBB(tdbb);
 
+	fb_assert(prior_page > 0);
 	RecordBitmap bmGoing;
 	ULONG cntGoing = 0;
 


### PR DESCRIPTION
The precedence is not set when:
1. A blob is deleted during the intermediate garbage collection (FB4+).
2. A blob is created for a modified record.

Both cases can lead to a situation where a record points to a blob that doesn't exist or that belongs to another record, which is quite dangerous.