### PR TITLE
Fix wrong assert throw on validation

### DIFF
--- a/src/jrd/cch.cpp
+++ b/src/jrd/cch.cpp
@@ -1026,7 +1026,10 @@ void CCH_fetch_page(thread_db* tdbb, WIN* window, const bool read_shadow)
 			}
 		}
 		fb_assert(bdb->bdb_page == window->win_page);
-		fb_assert(bdb->bdb_buffer->pag_pageno == window->win_page.getPageNum());
+		fb_assert(bdb->bdb_buffer->pag_pageno == window->win_page.getPageNum() ||
+			bdb->bdb_buffer->pag_type == pag_undefined &&
+			bdb->bdb_buffer->pag_generation == 0 &&
+			bdb->bdb_buffer->pag_scn == 0);
 	}
 	else
 	{


### PR DESCRIPTION
It can be thrown by lastUsedPage(), when it trying to fetch incorrect page number of PIP.

I wrote @hvlad about this and gave him a sql script that can reproduce this assert throw. He gave an example of how it can be fixed, and i think it works correctly now.