### PR TITLE
Fix an issue where the garbage collection in indexes and blobs is not performed in VIO_backout

### DIFF
--- a/src/jrd/Savepoint.cpp
+++ b/src/jrd/Savepoint.cpp
@@ -86,7 +86,7 @@ void VerbAction::garbageCollectIdxLite(thread_db* tdbb, jrd_tra* transaction, SI
 	rpb.rpb_transaction_nr = transaction->tra_number;
 
 	Record* next_ver;
-	AutoUndoRecord undo_next_ver(transaction->findNextUndo(this, vct_relation, recordNumber));
+	AutoTempRecord undo_next_ver(transaction->findNextUndo(this, vct_relation, recordNumber));
 	AutoPtr<Record> real_next_ver;
 
 	next_ver = undo_next_ver;
@@ -108,7 +108,7 @@ void VerbAction::garbageCollectIdxLite(thread_db* tdbb, jrd_tra* transaction, SI
 		BUGCHECK(185);	// msg 185 wrong record version
 
 	Record* prev_ver = NULL;
-	AutoUndoRecord undo_prev_ver;
+	AutoTempRecord undo_prev_ver;
 	AutoPtr<Record> real_prev_ver;
 
 	if (nextAction && nextAction->vct_undo && nextAction->vct_undo->locate(recordNumber))
@@ -197,7 +197,7 @@ void VerbAction::mergeTo(thread_db* tdbb, jrd_tra* transaction, VerbAction* next
 				// because going version for sure has all index entries successfully set up (in contrast with undo)
 				// we can use lightweigth version of garbage collection without collection of full staying list
 
-				AutoUndoRecord this_ver(item.setupRecord(transaction));
+				AutoTempRecord this_ver(item.setupRecord(transaction));
 
 				garbageCollectIdxLite(tdbb, transaction, recordNumber, nextAction, this_ver);
 
@@ -313,7 +313,7 @@ void VerbAction::undo(thread_db* tdbb, jrd_tra* transaction, bool preserveLocks,
 			}
 			else
 			{
-				AutoUndoRecord record(vct_undo->current().setupRecord(transaction));
+				AutoTempRecord record(vct_undo->current().setupRecord(transaction));
 
 				Record* const save_record = rpb.rpb_record;
 				record_param new_rpb = rpb;

--- a/src/jrd/idx.cpp
+++ b/src/jrd/idx.cpp
@@ -554,7 +554,7 @@ bool IndexCreateTask::handler(WorkItem& _item)
 
 	// Checkout a garbage collect record block for fetching data.
 
-	AutoGCRecord gc_record(VIO_gc_record(tdbb, relation));
+	AutoTempRecord gc_record(VIO_gc_record(tdbb, relation));
 
 	if (m_flags & IS_LARGE_SCAN)
 	{

--- a/src/jrd/tra.h
+++ b/src/jrd/tra.h
@@ -364,15 +364,16 @@ public:
 			Record* const record = *iter;
 			fb_assert(record);
 
-			if (!record->testFlags(REC_undo_active))
+			if (!record->isTempActive())
 			{
 				// initialize record for reuse
-				record->reset(format, REC_undo_active);
+				record->reset(format);
+				record->setTempActive();
 				return record;
 			}
 		}
 
-		Record* const record = FB_NEW_POOL(*tra_pool) Record(*tra_pool, format, REC_undo_active);
+		Record* const record = FB_NEW_POOL(*tra_pool) Record(*tra_pool, format, true);
 		tra_undo_records.add(record);
 
 		return record;

--- a/src/jrd/vio.cpp
+++ b/src/jrd/vio.cpp
@@ -775,7 +775,7 @@ inline void clearRecordStack(RecordStack& stack)
 	{
 		Record* r = stack.pop();
 		// records from undo log must not be deleted
-		if (!r->testFlags(REC_undo_active))
+		if (!r->isTempActive())
 			delete r;
 	}
 }
@@ -877,8 +877,8 @@ void VIO_backout(thread_db* tdbb, record_param* rpb, const jrd_tra* transaction)
 	Record* data = NULL;
 	Record* old_data = NULL;
 
-	AutoGCRecord gc_rec1;
-	AutoGCRecord gc_rec2;
+	AutoTempRecord gc_rec1;
+	AutoTempRecord gc_rec2;
 
 	bool samePage;
 	bool deleted;
@@ -2860,10 +2860,11 @@ Record* VIO_gc_record(thread_db* tdbb, jrd_rel* relation)
 		Record* const record = *iter;
 		fb_assert(record);
 
-		if (!record->testFlags(REC_gc_active))
+		if (!record->isTempActive())
 		{
 			// initialize record for reuse
-			record->reset(format, REC_gc_active);
+			record->reset(format);
+			record->setTempActive();
 			return record;
 		}
 	}
@@ -2871,7 +2872,7 @@ Record* VIO_gc_record(thread_db* tdbb, jrd_rel* relation)
 	// Allocate a garbage collect record block if all are active
 
 	Record* const record = FB_NEW_POOL(*relation->rel_pool)
-		Record(*relation->rel_pool, format, REC_gc_active);
+		Record(*relation->rel_pool, format, true);
 	relation->rel_gc_records.add(record);
 	return record;
 }
@@ -3274,7 +3275,7 @@ bool VIO_modify(thread_db* tdbb, record_param* org_rpb, record_param* new_rpb, j
 	if (org_rpb->rpb_runtime_flags & (RPB_refetch | RPB_undo_read))
 	{
 		const bool undo_read = (org_rpb->rpb_runtime_flags & RPB_undo_read);
-		AutoGCRecord old_record;
+		AutoTempRecord old_record;
 		if (undo_read)
 		{
 			old_record = VIO_gc_record(tdbb, relation);
@@ -5563,7 +5564,7 @@ static UndoDataRet get_undo_data(thread_db* tdbb, jrd_tra* transaction,
 		rpb->rpb_runtime_flags |= RPB_undo_data;
 		CCH_RELEASE(tdbb, &rpb->getWindow(tdbb));
 
-		AutoUndoRecord undoRecord(undo.setupRecord(transaction));
+		AutoTempRecord undoRecord(undo.setupRecord(transaction));
 
 		Record* const record = VIO_record(tdbb, rpb, undoRecord->getFormat(), pool);
 		record->copyFrom(undoRecord);
@@ -6458,7 +6459,7 @@ static void purge(thread_db* tdbb, record_param* rpb)
 	// the record.
 
 	record_param temp = *rpb;
-	AutoGCRecord gc_rec(VIO_gc_record(tdbb, relation));
+	AutoTempRecord gc_rec(VIO_gc_record(tdbb, relation));
 	Record* record = rpb->rpb_record = gc_rec;
 
 	VIO_data(tdbb, rpb, relation->rel_pool);
@@ -6807,7 +6808,7 @@ void VIO_update_in_place(thread_db* tdbb,
 	// becomes meaningless.  What we need to do is replace the old "delta" record
 	// with an old "complete" record, update in placement, then delete the old delta record
 
-	AutoGCRecord gc_rec;
+	AutoTempRecord gc_rec;
 
 	record_param temp2;
 	const Record* prior = org_rpb->rpb_prior;


### PR DESCRIPTION
Steps to reproduce the issue:
1. Create a database, insert a record, update it in a transaction with `no auto undo` and rollback.
```
create table t1_blob (id integer, str1 blob);
create index t1_blob_idx1 on t1_blob (id);
insert into t1_blob values (0, 'abc');
commit;

set transaction no auto undo;
update t1_blob set id = 1, str1 = '123' where id = 0;
rollback;
```
2. Close the connection. Execute `gstat -r` to see that we have 2 record versions (total records: 1, total versions: 1), 2 blobs (Blobs: 2) and 2 index nodes (nodes: 2).
3. Connect again and execute `select` to trigger the garbage collection:
```
select * from t1_blob;
```
4. Close the connection. Execute `gstat -r` again and see that the uncommitted record version is deleted (total versions: 0), but the amount of blobs and index nodes remained unchanged (Blobs: 2, nodes: 2).

The issue starts in `VIO_record`. There is a call `record->reset(format)` which clears the `REC_gc_active` flag by mistake. After that `VIO_gc_record` reuses the record which is already active.