### PR TITLE
Added the ability to change deterministic option

### DIFF
--- a/doc/sql.extensions/README.ddl.txt
+++ b/doc/sql.extensions/README.ddl.txt
@@ -603,3 +603,8 @@ ALTER TABLE <name> ... [ {ENABLE | DISABLE} PUBLICATION ]
 
 Defines whether replication is enabled for the specified table.
 If not specified in the CREATE TABLE statement, the database-level default behaviour is applied.
+
+24) Added the ability to change deterministic option without specifying the entire body of the function.
+(Alexander Zhdanov)
+
+ALTER FUNCTION <name> {DETERMINISTIC | NOT DETERMINISTIC}

--- a/src/dsql/DdlNodes.epp
+++ b/src/dsql/DdlNodes.epp
@@ -1726,7 +1726,7 @@ void CreateAlterFunctionNode::execute(thread_db* tdbb, DsqlCompilerScratch* dsql
 	AutoSavePoint savePoint(tdbb, transaction);
 	bool altered = false;
 
-	bool alterIndividualParameters = !(body || external);
+	const bool alterIndividualParameters = !(body || external);
 
 	// first pass
 	if (alter)
@@ -1738,19 +1738,16 @@ void CreateAlterFunctionNode::execute(thread_db* tdbb, DsqlCompilerScratch* dsql
 			else
 				status_exception::raise(Arg::Gds(isc_dyn_func_not_found) << Arg::Str(name));
 		}
+		else if (executeAlter(tdbb, dsqlScratch, transaction, false, true))
+		{
+			altered = true;
+		}
 		else
 		{
-			if (executeAlter(tdbb, dsqlScratch, transaction, false, true))
-			{
-				altered = true;
-			}
+			if (create)	// create or alter
+				executeCreate(tdbb, dsqlScratch, transaction);
 			else
-			{
-				if (create)	// create or alter
-					executeCreate(tdbb, dsqlScratch, transaction);
-				else
-					status_exception::raise(Arg::Gds(isc_dyn_func_not_found) << Arg::Str(name));
-			}
+				status_exception::raise(Arg::Gds(isc_dyn_func_not_found) << Arg::Str(name));
 		}
 	}
 	else

--- a/src/dsql/DdlNodes.epp
+++ b/src/dsql/DdlNodes.epp
@@ -1726,19 +1726,31 @@ void CreateAlterFunctionNode::execute(thread_db* tdbb, DsqlCompilerScratch* dsql
 	AutoSavePoint savePoint(tdbb, transaction);
 	bool altered = false;
 
+	bool alterIndividualParameters = !(body || external);
+
 	// first pass
 	if (alter)
 	{
-		if (executeAlter(tdbb, dsqlScratch, transaction, false, true))
+		if (alterIndividualParameters)
 		{
-			altered = true;
+			if (executeAlterIndividualParameters(tdbb, dsqlScratch, transaction, false, true))
+				altered = true;
+			else
+				status_exception::raise(Arg::Gds(isc_dyn_func_not_found) << Arg::Str(name));
 		}
 		else
 		{
-			if (create)	// create or alter
-				executeCreate(tdbb, dsqlScratch, transaction);
+			if (executeAlter(tdbb, dsqlScratch, transaction, false, true))
+			{
+				altered = true;
+			}
 			else
-				status_exception::raise(Arg::Gds(isc_dyn_func_not_found) << Arg::Str(name));
+			{
+				if (create)	// create or alter
+					executeCreate(tdbb, dsqlScratch, transaction);
+				else
+					status_exception::raise(Arg::Gds(isc_dyn_func_not_found) << Arg::Str(name));
+			}
 		}
 	}
 	else
@@ -1746,7 +1758,12 @@ void CreateAlterFunctionNode::execute(thread_db* tdbb, DsqlCompilerScratch* dsql
 
 	compile(tdbb, dsqlScratch);
 
-	executeAlter(tdbb, dsqlScratch, transaction, true, false);	// second pass
+	// second pass
+	if (alterIndividualParameters)
+		executeAlterIndividualParameters(tdbb, dsqlScratch, transaction, true, false);
+	else
+		executeAlter(tdbb, dsqlScratch, transaction, true, false);
+
 
 	if (package.isEmpty())
 	{
@@ -2060,6 +2077,43 @@ bool CreateAlterFunctionNode::executeAlter(thread_db* tdbb, DsqlCompilerScratch*
 	}
 
 	return modified;
+}
+
+bool CreateAlterFunctionNode::executeAlterIndividualParameters(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, jrd_tra* transaction, bool secondPass, bool runTriggers)
+{
+	Attachment* const attachment = transaction->getAttachment();
+
+	bool modifed = false;
+
+	AutoCacheRequest requestHandle(tdbb, drq_m_prm_funcs2, DYN_REQUESTS);
+
+	FOR (REQUEST_HANDLE requestHandle TRANSACTION_HANDLE transaction)
+		FUN IN RDB$FUNCTIONS
+		WITH FUN.RDB$FUNCTION_NAME EQ name.c_str() AND
+			 FUN.RDB$PACKAGE_NAME EQUIV NULLIF(package.c_str(), '')
+	{
+		if (FUN.RDB$SYSTEM_FLAG)
+		{
+			status_exception::raise(
+				Arg::Gds(isc_dyn_cannot_mod_sysfunc) << MetaName(FUN.RDB$FUNCTION_NAME));
+		}
+
+		if (!secondPass && runTriggers && package.isEmpty())
+		{
+			executeDdlTrigger(tdbb, dsqlScratch, transaction, DTW_BEFORE,
+				DDL_TRIGGER_ALTER_FUNCTION, name, NULL);
+		}
+
+		MODIFY FUN
+			FUN.RDB$DETERMINISTIC_FLAG.NULL = FALSE;
+			FUN.RDB$DETERMINISTIC_FLAG = deterministic ? TRUE : FALSE;
+
+			modifed = true;
+		END_MODIFY
+	}
+	END_FOR
+
+	return modifed;
 }
 
 void CreateAlterFunctionNode::storeArgument(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch,

--- a/src/dsql/DdlNodes.h
+++ b/src/dsql/DdlNodes.h
@@ -455,6 +455,8 @@ private:
 	void executeCreate(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, jrd_tra* transaction);
 	bool executeAlter(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, jrd_tra* transaction,
 		bool secondPass, bool runTriggers);
+	bool executeAlterIndividualParameters(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, jrd_tra* transaction,
+		bool secondPass, bool runTriggers);
 
 	void storeArgument(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, jrd_tra* transaction,
 		unsigned pos, bool returnArg, ParameterClause* parameter,

--- a/src/jrd/drq.h
+++ b/src/jrd/drq.h
@@ -176,6 +176,7 @@ enum drq_type_t
 	drq_s_funcs2,			// store functions (CreateAlterFunctionNode)
 	drq_s_func_args2,		// store function arguments (CreateAlterFunctionNode)
 	drq_m_funcs2,			// modify functions (CreateAlterFunctionNode)
+	drq_m_prm_funcs2,		// modify individual function parameters (CreateAlterFunctionNode)
 	drq_e_func_args2,		// erase function arguments (CreateAlterFunctionNode)
 	drq_s_prcs2,
 	drq_s_prms4,


### PR DESCRIPTION
Added the ability to change deterministic opt without specifiying the entire body of the function. Extended "ALTER FUNCTION" syntax:
```
ALTER FUNCTION name DETERMINISTIC;
ALTER FUNCTION name NOT DETERMINISTIC;
```