### PR TITLE
[FB4][GBAK, Restore] The skip of att_functionarg_field_precision is corrected

### DIFF
--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -5387,7 +5387,10 @@ void get_function_arg(BurpGlobals* tdgbl, bool skip_arguments)
 				break;
 
 			case att_functionarg_field_precision:
-				get_int32(tdgbl);
+				if (tdgbl->RESTORE_format >= 6)
+					get_int32(tdgbl);
+				else
+					bad_attribute(scan_next_attr, attribute, 90);
 				break;
 
 			case att_functionarg_package_name:


### PR DESCRIPTION
This commit fixes the issue #7851.