### PR TITLE
Additional fixes for #7810 (Improve SKIP LOCKED implementation)

### DIFF
--- a/doc/sql.extensions/README.skip_locked.md
+++ b/doc/sql.extensions/README.skip_locked.md
@@ -46,9 +46,9 @@ DELETE FROM <sometable>
 
 ## Notes
 
-As it happens with subclauses `FIRST`/`SKIP`/`ROWS`/`OFFSET`/`FETCH` record lock
-(and "skip locked" check) is done in between of skip (`SKIP`/`ROWS`/`OFFSET`/`FETCH`) and
-limit (`FIRST`/`ROWS`/`OFFSET`/`FETCH`) checks.
+If statement have both `SKIP LOCKED` and `SKIP`/`ROWS` subclauses, some locked rows 
+could be skipped before `SKIP`/`ROWS` subclause would account it, thus skipping more 
+rows than specified in `SKIP`/`ROWS`.
 
 ## Examples
 

--- a/src/dsql/StmtNodes.cpp
+++ b/src/dsql/StmtNodes.cpp
@@ -178,11 +178,11 @@ namespace
 			m_savepoint.rollback();
 		}
 
-	private:
 		// Prohibit unwanted creation/copying
 		CondSavepointAndMarker(const CondSavepointAndMarker&) = delete;
 		CondSavepointAndMarker& operator=(const CondSavepointAndMarker&) = delete;
 
+	private:
 		AutoSavePoint m_savepoint;
 		Savepoint::ChangeMarker m_marker;
 	};

--- a/src/dsql/StmtNodes.h
+++ b/src/dsql/StmtNodes.h
@@ -552,6 +552,7 @@ public:
 	dsql_ctx* dsqlContext = nullptr;
 	NestConst<StmtNode> statement;
 	NestConst<StmtNode> subStatement;
+	NestConst<StmtNode> returningStatement;
 	NestConst<ForNode> forNode;			// parent implicit cursor, if present
 	StreamType stream = 0;
 	unsigned marks = 0;					// see StmtNode::IUD_MARK_xxx

--- a/src/include/firebird/impl/blr.h
+++ b/src/include/firebird/impl/blr.h
@@ -309,8 +309,7 @@
 #define blr_agg_list		(unsigned char)170
 #define blr_agg_list_distinct	(unsigned char)171
 #define blr_modify2			(unsigned char)172
-
-// unused codes: 173
+#define blr_erase2			(unsigned char)173
 
 /* FB 1.0 specific BLR */
 

--- a/src/jrd/blp.h
+++ b/src/jrd/blp.h
@@ -199,7 +199,7 @@ static const struct
 	{"agg_list", two}, // 170
 	{"agg_list_distinct", two},
 	{"modify2", modify2},
-	{NULL, NULL},
+	{"erase2", erase2},
 	// New BLR in FB1
 	{"current_role", zero},
 	{"skip", one},

--- a/src/yvalve/gds.cpp
+++ b/src/yvalve/gds.cpp
@@ -414,6 +414,7 @@ static const UCHAR
 	store3[] = { op_line, op_byte, op_line, op_verb, op_verb, op_verb, 0},
 	marks[] = { op_byte, op_literal, op_line, op_verb, 0},
 	erase[] = { op_erase, 0},
+	erase2[] = { op_erase, op_verb, 0},
 	local_table[] = { op_word, op_byte, op_literal, op_byte, op_line, 0},
 	outer_map[] = { op_outer_map, 0 },
 	in_list[] = { op_verb, op_line, op_word, op_line, op_args, 0},


### PR DESCRIPTION
Fixed DELETE RETURNING handling, update documentation for SKIP LOCKED.
Revert the old way of BLR generation for DELETE RETURNING when SKIP LOCKED is not specified.