### PR TITLE
[FB5, GBAK] Correct handling of NULLs in RDB$RETURN_ARGUMENT and RDB$ARGUMENT_POSITION

### DIFF
--- a/src/burp/backup.epp
+++ b/src/burp/backup.epp
@@ -2821,7 +2821,10 @@ void write_functions()
 			BURP_verbose (147, temp);
 			// msg 147 writing function %.*s
 			put_source_blob (att_function_description2, att_function_description, X.RDB$DESCRIPTION);
-			put_int32 (att_function_return_arg, X.RDB$RETURN_ARGUMENT);
+
+			if (!X.RDB$RETURN_ARGUMENT.NULL)
+				put_int32 (att_function_return_arg, X.RDB$RETURN_ARGUMENT);
+
 			put_int32 (att_function_type, X.RDB$FUNCTION_TYPE);
 			PUT_TEXT (att_function_query_name, X.RDB$QUERY_NAME);
 
@@ -2875,7 +2878,10 @@ void write_functions()
 			put_source_blob (att_function_description2, att_function_description, X.RDB$DESCRIPTION);
 			PUT_TEXT (att_function_module_name, X.RDB$MODULE_NAME);
 			PUT_TEXT (att_function_entrypoint, X.RDB$ENTRYPOINT);
-			put_int32 (att_function_return_arg, X.RDB$RETURN_ARGUMENT);
+
+			if (!X.RDB$RETURN_ARGUMENT.NULL)
+				put_int32 (att_function_return_arg, X.RDB$RETURN_ARGUMENT);
+
 			put_int32 (att_function_type, X.RDB$FUNCTION_TYPE);
 			PUT_TEXT (att_function_query_name, X.RDB$QUERY_NAME);
 			put(tdgbl, att_end);
@@ -2937,7 +2943,9 @@ void write_function_args(const GDS_NAME package, GDS_NAME funcptr)
 			BURP_verbose (141, temp);
 			// msg 141 writing argument for function %s
 
-			put_int32 (att_functionarg_position, X.RDB$ARGUMENT_POSITION);
+			if (!X.RDB$ARGUMENT_POSITION.NULL)
+				put_int32 (att_functionarg_position, X.RDB$ARGUMENT_POSITION);
+
 			put_int32 (att_functionarg_passing_mechanism, X.RDB$MECHANISM);
 			put_int32 (att_functionarg_field_type, X.RDB$FIELD_TYPE);
 			put_int32 (att_functionarg_field_scale, X.RDB$FIELD_SCALE);
@@ -2988,7 +2996,10 @@ void write_function_args(const GDS_NAME package, GDS_NAME funcptr)
 			MISC_terminate (X.RDB$FUNCTION_NAME, temp, l, sizeof(temp));
 			BURP_verbose (141, temp);
 			// msg 141 writing argument for function %s
-			put_int32 (att_functionarg_position, X.RDB$ARGUMENT_POSITION);
+
+			if (!X.RDB$ARGUMENT_POSITION.NULL)
+				put_int32 (att_functionarg_position, X.RDB$ARGUMENT_POSITION);
+
 			put_int32 (att_functionarg_passing_mechanism, X.RDB$MECHANISM);
 			put_int32 (att_functionarg_field_type, X.RDB$FIELD_TYPE);
 			put_int32 (att_functionarg_field_scale, X.RDB$FIELD_SCALE);
@@ -3016,7 +3027,10 @@ void write_function_args(const GDS_NAME package, GDS_NAME funcptr)
 			MISC_terminate (X.RDB$FUNCTION_NAME, temp, l, sizeof(temp));
 			BURP_verbose (141, temp);
 			// msg 141 writing argument for function %s
-			put_int32 (att_functionarg_position, X.RDB$ARGUMENT_POSITION);
+
+			if (!X.RDB$ARGUMENT_POSITION.NULL)
+				put_int32 (att_functionarg_position, X.RDB$ARGUMENT_POSITION);
+
 			put_int32 (att_functionarg_passing_mechanism, X.RDB$MECHANISM);
 			put_int32 (att_functionarg_field_type, X.RDB$FIELD_TYPE);
 			put_int32 (att_functionarg_field_scale, X.RDB$FIELD_SCALE);

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -4353,6 +4353,7 @@ bool get_function(BurpGlobals* tdgbl)
 			X.RDB$OWNER_NAME.NULL = TRUE;
 			X.RDB$MODULE_NAME.NULL = TRUE;
 			X.RDB$ENTRYPOINT.NULL = TRUE;
+			X.RDB$RETURN_ARGUMENT.NULL = TRUE;
 
 			X.RDB$SYSTEM_FLAG.NULL = FALSE;
 			X.RDB$SYSTEM_FLAG = 0;
@@ -4409,6 +4410,7 @@ bool get_function(BurpGlobals* tdgbl)
 					break;
 
 				case att_function_return_arg:
+					X.RDB$RETURN_ARGUMENT.NULL = FALSE;
 					X.RDB$RETURN_ARGUMENT = (USHORT) get_int32(tdgbl);
 					break;
 
@@ -4568,6 +4570,7 @@ bool get_function(BurpGlobals* tdgbl)
 		STORE (TRANSACTION_HANDLE local_trans
 				REQUEST_HANDLE tdgbl->handles_get_function_req_handle1)
 			X IN RDB$FUNCTIONS
+			X.RDB$RETURN_ARGUMENT.NULL = TRUE;
 			X.RDB$SYSTEM_FLAG = 0;
 			X.RDB$SYSTEM_FLAG.NULL = FALSE;
 			X.RDB$DESCRIPTION.NULL = TRUE;
@@ -4603,6 +4606,7 @@ bool get_function(BurpGlobals* tdgbl)
 					break;
 
 				case att_function_return_arg:
+					X.RDB$RETURN_ARGUMENT.NULL = FALSE;
 					X.RDB$RETURN_ARGUMENT = (USHORT) get_int32(tdgbl);
 					break;
 
@@ -4820,6 +4824,7 @@ void get_function_arg(BurpGlobals* tdgbl, bool skip_arguments)
 		STORE (TRANSACTION_HANDLE local_trans
 				REQUEST_HANDLE tdgbl->handles_get_function_arg_req_handle1)
 			X IN RDB$FUNCTION_ARGUMENTS
+			X.RDB$ARGUMENT_POSITION.NULL = TRUE;
 			X.RDB$FIELD_SUB_TYPE.NULL = TRUE;
 			X.RDB$CHARACTER_SET_ID.NULL = TRUE;
 			X.RDB$FIELD_PRECISION.NULL = TRUE;
@@ -4863,6 +4868,7 @@ void get_function_arg(BurpGlobals* tdgbl, bool skip_arguments)
 					break;
 
 				case att_functionarg_position:
+					X.RDB$ARGUMENT_POSITION.NULL = FALSE;
 					X.RDB$ARGUMENT_POSITION = (USHORT) get_int32(tdgbl);
 					break;
 
@@ -5030,6 +5036,7 @@ void get_function_arg(BurpGlobals* tdgbl, bool skip_arguments)
 		STORE (TRANSACTION_HANDLE local_trans
 				REQUEST_HANDLE tdgbl->handles_get_function_arg_req_handle1)
 			X IN RDB$FUNCTION_ARGUMENTS
+			X.RDB$ARGUMENT_POSITION.NULL = TRUE;
 			X.RDB$FIELD_SUB_TYPE.NULL = TRUE;
 			X.RDB$CHARACTER_SET_ID.NULL = TRUE;
 			X.RDB$FIELD_PRECISION.NULL  = TRUE;
@@ -5047,6 +5054,7 @@ void get_function_arg(BurpGlobals* tdgbl, bool skip_arguments)
 					break;
 
 				case att_functionarg_position:
+					X.RDB$ARGUMENT_POSITION.NULL = FALSE;
 					X.RDB$ARGUMENT_POSITION = (USHORT) get_int32(tdgbl);
 					break;
 
@@ -5144,6 +5152,7 @@ void get_function_arg(BurpGlobals* tdgbl, bool skip_arguments)
 		STORE (TRANSACTION_HANDLE local_trans
 				REQUEST_HANDLE tdgbl->handles_get_function_arg_req_handle1)
 			X IN RDB$FUNCTION_ARGUMENTS
+			X.RDB$ARGUMENT_POSITION.NULL = TRUE;
 			X.RDB$FIELD_SUB_TYPE.NULL = TRUE;
 			X.RDB$CHARACTER_SET_ID.NULL = TRUE;
 
@@ -5160,6 +5169,7 @@ void get_function_arg(BurpGlobals* tdgbl, bool skip_arguments)
 					break;
 
 				case att_functionarg_position:
+					X.RDB$ARGUMENT_POSITION.NULL = FALSE;
 					X.RDB$ARGUMENT_POSITION = (USHORT) get_int32(tdgbl);
 					break;
 


### PR DESCRIPTION
It is a fix for issue #7869

See also #7870