### PR TITLE
Extend SYSTEM context of RDB$GET_CONTEXT with allocated, free and used pages

### DIFF
--- a/doc/sql.extensions/README.context_variables2
+++ b/doc/sql.extensions/README.context_variables2
@@ -142,6 +142,12 @@ Usage:
                                 |
    DECFLOAT_TRAPS               | Exceptional conditions in operations with DECFLOAT
                                 | values that cause a trap.
+                                |
+   PAGES_ALLOCATED              | Current value of allocated pages in the database.
+                                |
+   PAGES_USED                   | Current value of allocated pages in the database.
+                                |
+   PAGES_FREE                   | Current value of free pages in the database.
 
 Notes:
    To prevent DoS attacks against Firebird Server you are not allowed to have

--- a/src/jrd/SysFunction.cpp
+++ b/src/jrd/SysFunction.cpp
@@ -432,6 +432,12 @@ static const char
 	FALSE_VALUE[] = "FALSE",
 	TRUE_VALUE[] = "TRUE";
 
+// Get pages
+const char
+    PAGES_ALLOCATED[] = "PAGES_ALLOCATED",
+    PAGES_USED[] = "PAGES_USED",
+    PAGES_FREE[] = "PAGES_FREE";
+
 
 double fbcot(double value) noexcept
 {
@@ -4583,6 +4589,18 @@ dsc* evlGetContext(thread_db* tdbb, const SysFunction*, const NestValueArray& ar
 			GuidToString(guidBuffer, &dbb->dbb_guid);
 			resultStr = string(guidBuffer);
 		}
+        else if (nameStr == PAGES_ALLOCATED)
+        {
+            resultStr.printf("%" ULONGFORMAT, PageSpace::actAlloc(dbb));
+        }
+        else if (nameStr == PAGES_USED)
+        {
+            resultStr.printf("%" ULONGFORMAT, PageSpace::usedPages(dbb));
+        }
+        else if (nameStr == PAGES_FREE)
+        {
+            resultStr.printf("%" ULONGFORMAT, PageSpace::maxAlloc(dbb) - PageSpace::usedPages(dbb));
+        }
 		else if (nameStr == DATABASE_FILE_ID)
 		{
 			resultStr = dbb->getUniqueFileId();


### PR DESCRIPTION
number of pages in use, and the number of free pages via the GET_CONTEXT.