### PR TITLE
Add backward compatibility option that disables joins transformation

### DIFF
--- a/src/common/config/config.h
+++ b/src/common/config/config.h
@@ -192,6 +192,7 @@ enum ConfigKey
 	KEY_PARALLEL_WORKERS,
 	KEY_MAX_PARALLEL_WORKERS,
 	KEY_OPTIMIZE_FOR_FIRST_ROWS,
+	KEY_OUTER_JOIN_CONVERSION,
 	MAX_CONFIG_KEY		// keep it last
 };
 
@@ -310,7 +311,8 @@ constexpr ConfigEntry entries[MAX_CONFIG_KEY] =
 	{TYPE_INTEGER,	"MaxStatementCacheSize",	false,	2 * 1048576},	// bytes
 	{TYPE_INTEGER,	"ParallelWorkers",			true,	1},
 	{TYPE_INTEGER,	"MaxParallelWorkers",		true,	1},
-	{TYPE_BOOLEAN,	"OptimizeForFirstRows",		false,	false}
+	{TYPE_BOOLEAN,	"OptimizeForFirstRows",		false,	false},
+	{TYPE_BOOLEAN,	"OuterJoinConversion",		false,	true}
 };
 
 
@@ -638,6 +640,8 @@ public:
 	CONFIG_GET_GLOBAL_INT(getMaxParallelWorkers, KEY_MAX_PARALLEL_WORKERS);
 
 	CONFIG_GET_PER_DB_BOOL(getOptimizeForFirstRows, KEY_OPTIMIZE_FOR_FIRST_ROWS);
+
+	CONFIG_GET_PER_DB_BOOL(getOuterJoinConversion, KEY_OUTER_JOIN_CONVERSION);
 };
 
 // Implementation of interface to access master configuration file

--- a/src/jrd/RecordSourceNodes.cpp
+++ b/src/jrd/RecordSourceNodes.cpp
@@ -2888,7 +2888,9 @@ RseNode* RseNode::pass1(thread_db* tdbb, CompilerScratch* csb)
 void RseNode::pass1Source(thread_db* tdbb, CompilerScratch* csb, RseNode* rse,
 	BoolExprNode** boolean, RecordSourceNodeStack& stack)
 {
-	if (rse_jointype != blr_inner)
+	const auto dbb = tdbb->getDatabase();
+
+	if (rse_jointype != blr_inner && dbb->dbb_config->getOuterJoinConversion())
 	{
 		// Check whether any of the upper level booleans (those belonging to the WHERE clause)
 		// is able to filter out rows from the "inner" streams. If this is the case,


### PR DESCRIPTION
Given a few tickets showing performance regressions after this improvement and feedback from users at the conference asking about some compatibility option to simplify migration in cases when LEFT JOINs were widely used intentionally just as optimizer hints -- here it is, a backward compatibility option is provided.