### PR TITLE
Allow to configure Firebird in posix using relative directories with options --with-fb*

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,9 +26,19 @@ dnl XE_CONF_DIR(param, help, variable, default)
 define([XE_CONF_DIR],[
 AC_ARG_WITH([$1],
 	[AS_HELP_STRING([--with-$1],[$2])],
-	[[$3]="$withval"
-	 CHANGE_PATH_SUPPORT=no
-	 AC_DEFINE_UNQUOTED([$3], "$[$3]", [$2])],
+	[
+		case "$withval" in
+			/*)
+				CHANGE_PATH_SUPPORT=no
+				[$3]="$withval"
+				;;
+			*)
+				[$3]='${fb_install_prefix}'/"${withval}"
+				;;
+		esac
+
+		AC_DEFINE_UNQUOTED([$3], "${withval}", [$2])
+	],
 	[[$3]='${fb_install_prefix}[$4]'
 	 AC_DEFINE_UNQUOTED([$3], [""], [$2])]
 )

--- a/src/common/TimeZoneUtil.cpp
+++ b/src/common/TimeZoneUtil.cpp
@@ -121,7 +121,9 @@ namespace
 			PathName temp;
 
 			// Could not call fb_utils::getPrefix here.
-			if (FB_TZDATADIR[0])
+			if (FB_TZDATADIR[0] && PathUtils::isRelative(FB_TZDATADIR))
+				PathUtils::concatPath(temp, Config::getRootDirectory(), FB_TZDATADIR);
+			else if (FB_TZDATADIR[0])
 				temp = FB_TZDATADIR;
 			else
 			{

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -1232,11 +1232,19 @@ Firebird::PathName getPrefix(unsigned int prefType, const char* name)
 	{
 		if (prefType != Firebird::IConfigManager::DIR_CONF &&
 			prefType != Firebird::IConfigManager::DIR_MSG &&
+			prefType != Firebird::IConfigManager::DIR_TZDATA &&
 			configDir[prefType][0])
 		{
 			// Value is set explicitly and is not environment overridable
 			PathUtils::concatPath(s, configDir[prefType], name);
-			return s;
+
+			if (PathUtils::isRelative(s))
+			{
+				gds__prefix(tmp, s.c_str());
+				return tmp;
+			}
+			else
+				return s;
 		}
 	}
 
@@ -1316,11 +1324,11 @@ Firebird::PathName getPrefix(unsigned int prefType, const char* name)
 	}
 
 	if (s.hasData() && name[0])
-	{
 		s += PathUtils::dir_sep;
-	}
+
 	s += name;
 	gds__prefix(tmp, s.c_str());
+
 	return tmp;
 #endif
 }

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -1243,8 +1243,8 @@ Firebird::PathName getPrefix(unsigned int prefType, const char* name)
 				gds__prefix(tmp, s.c_str());
 				return tmp;
 			}
-			else
-				return s;
+
+			return s;
 		}
 	}
 

--- a/src/yvalve/gds.cpp
+++ b/src/yvalve/gds.cpp
@@ -4146,7 +4146,10 @@ public:
 		Firebird::PathName msgPrefix;
 		if (!fb_utils::readenv(FB_MSG_ENV, msgPrefix))
 		{
-			msgPrefix = FB_MSGDIR[0] ? FB_MSGDIR : prefix;
+			if (FB_MSGDIR[0] && PathUtils::isRelative(FB_MSGDIR))
+				PathUtils::concatPath(msgPrefix, prefix, FB_MSGDIR);
+			else
+				msgPrefix = FB_MSGDIR[0] ? FB_MSGDIR : prefix;
 		}
 		msgPrefix.copyTo(fb_prefix_msg_val, sizeof(fb_prefix_msg_val));
 		fb_prefix_msg = fb_prefix_msg_val;


### PR DESCRIPTION
Relative directories will be interpreted based in the runtime root prefix.