### PR TITLE
Cleanup RelaxedAliasChecking configuration setting

### DIFF
--- a/builds/install/misc/firebird.conf
+++ b/builds/install/misc/firebird.conf
@@ -677,32 +677,6 @@
 
 
 # ----------------------------
-# Relaxing relation alias checking rules in SQL
-#
-# Since Firebird 2.0, strict alias checking rules were implemented in the SQL
-# parser to accord with the SQL standard requirements. This setting allows
-# these rules to be relaxed in order to allow legacy applications to run on
-# Firebird 2.0.
-# A setting of 1 (true) allows the parser to resolve a qualified column reference
-# using the relation name, where an alias has been specified for that relation.
-#
-# For example, it allows a query such as:
-#       SELECT TABLE.X FROM TABLE A
-#
-# It is not recommended to enable this setting. It should be regarded as an
-# interim workaround for porting untidy legacy code, until it is possible to
-# revise such code.
-#
-# CAUTION!
-# There is no guarantee that this setting will be available in future Firebird
-# versions.
-#
-# Type: boolean
-#
-#RelaxedAliasChecking = 0
-
-
-# ----------------------------
 # The engine currently provides statement-level read consistency in READ COMMITTED
 # mode by default. In this mode, rec_version/no_rec_version transaction flags have
 # no effect. Setting this parameter to 0 effectively reverts the engine to legacy

--- a/src/common/classes/MetaString.h
+++ b/src/common/classes/MetaString.h
@@ -70,6 +70,7 @@ public:
 
 	MetaString& assign(const char* s, FB_SIZE_T l);
 	MetaString& assign(const char* s) { return assign(s, s ? fb_strlen(s) : 0); }
+	MetaString& clear() { return assign(nullptr, 0); }
 	MetaString& operator=(const char* s) { return assign(s); }
 	MetaString& operator=(const AbstractString& s) { return assign(s.c_str(), s.length()); }
 	MetaString& operator=(const MetaString& m) { return set(m); }

--- a/src/common/config/config.h
+++ b/src/common/config/config.h
@@ -153,7 +153,6 @@ enum ConfigKey
 	KEY_REDIRECTION,
 	KEY_DATABASE_GROWTH_INCREMENT,
 	KEY_FILESYSTEM_CACHE_THRESHOLD,
-	KEY_RELAXED_ALIAS_CHECKING,
 	KEY_TRACE_CONFIG,
 	KEY_MAX_TRACELOG_SIZE,
 	KEY_FILESYSTEM_CACHE_SIZE,
@@ -258,7 +257,6 @@ constexpr ConfigEntry entries[MAX_CONFIG_KEY] =
 	{TYPE_BOOLEAN,	"Redirection",				true,	false},
 	{TYPE_INTEGER,	"DatabaseGrowthIncrement",	false,	128 * 1048576},	// bytes
 	{TYPE_INTEGER,	"FileSystemCacheThreshold",	false,	65536},		// page buffers
-	{TYPE_BOOLEAN,	"RelaxedAliasChecking",		true,	false},		// if true relax strict alias checking rules in DSQL a bit
 	{TYPE_STRING,	"AuditTraceConfigFile",		true,	""},		// location of audit trace configuration file
 	{TYPE_INTEGER,	"MaxUserTraceLogSize",		true,	10},		// maximum size of user session trace log
 	{TYPE_INTEGER,	"FileSystemCacheSize",		true,	0},			// percent
@@ -577,8 +575,6 @@ public:
 	CONFIG_GET_PER_DB_INT(getFileSystemCacheThreshold, KEY_FILESYSTEM_CACHE_THRESHOLD);
 
 	CONFIG_GET_GLOBAL_KEY(FB_UINT64, getFileSystemCacheSize, KEY_FILESYSTEM_CACHE_SIZE, getInt);
-
-	CONFIG_GET_GLOBAL_BOOL(getRelaxedAliasChecking, KEY_RELAXED_ALIAS_CHECKING);
 
 	CONFIG_GET_GLOBAL_STR(getAuditTraceConfigFile, KEY_TRACE_CONFIG);
 

--- a/src/dsql/ExprNodes.h
+++ b/src/dsql/ExprNodes.h
@@ -829,7 +829,7 @@ public:
 
 private:
 	static dsql_fld* resolveContext(DsqlCompilerScratch* dsqlScratch,
-		const MetaName& qualifier, dsql_ctx* context, bool resolveByAlias);
+		const MetaName& qualifier, dsql_ctx* context);
 
 public:
 	MetaName dsqlQualifier;


### PR DESCRIPTION
This backward compatibility option was added after the v2.0 release, I believe 15 years was enough for migration and now it's a good time to wipe the thing out.