### PR TITLE
Some enhancements for the file open modes (FS cache usage and forced writes)

### DIFF
--- a/src/jrd/Database.cpp
+++ b/src/jrd/Database.cpp
@@ -51,13 +51,16 @@ namespace Jrd
 {
 	bool Database::onRawDevice() const
 	{
-		const PageSpace* const pageSpace = dbb_page_manager.findPageSpace(DB_PAGE_SPACE);
+		const auto pageSpace = dbb_page_manager.findPageSpace(DB_PAGE_SPACE);
 		return pageSpace->onRawDevice();
 	}
 
 	ULONG Database::getIOBlockSize() const
 	{
-		if ((dbb_flags & DBB_no_fs_cache) || onRawDevice())
+		const auto pageSpace = dbb_page_manager.findPageSpace(DB_PAGE_SPACE);
+		fb_assert(pageSpace && pageSpace->file);
+
+		if ((pageSpace->file->fil_flags & FIL_no_fs_cache) || pageSpace->onRawDevice())
 			return DIRECT_IO_BLOCK_SIZE;
 
 		return PAGE_ALIGNMENT;

--- a/src/jrd/Database.h
+++ b/src/jrd/Database.h
@@ -227,11 +227,9 @@ const ULONG DBB_suspend_bgio			= 0x4000L;		// Suspend I/O by background threads
 const ULONG DBB_new						= 0x8000L;		// Database object is just created
 const ULONG DBB_gc_cooperative			= 0x10000L;		// cooperative garbage collection
 const ULONG DBB_gc_background			= 0x20000L;		// background garbage collection by gc_thread
-const ULONG DBB_no_fs_cache				= 0x40000L;		// Not using file system cache
-const ULONG DBB_sweep_starting			= 0x80000L;		// Auto-sweep is starting
-const ULONG DBB_creating				= 0x100000L;	// Database creation is in progress
-const ULONG DBB_shared					= 0x200000L;	// Database object is shared among connections
-//const ULONG DBB_closing					= 0x400000L;	// Database closing, special backgroud threads should exit
+const ULONG DBB_sweep_starting			= 0x40000L;		// Auto-sweep is starting
+const ULONG DBB_creating				= 0x80000L;	// Database creation is in progress
+const ULONG DBB_shared					= 0x100000L;	// Database object is shared among connections
 
 //
 // dbb_ast_flags

--- a/src/jrd/jrd.cpp
+++ b/src/jrd/jrd.cpp
@@ -1790,7 +1790,19 @@ JAttachment* JProvider::internalAttach(CheckStatusWrapper* user_status, const ch
 				else
 					dbb->dbb_database_name = expanded_name;
 
-				PageSpace* pageSpace = dbb->dbb_page_manager.findPageSpace(DB_PAGE_SPACE);
+				// We don't know the database FW mode before the header page is read.
+				// However, given that the default behaviour is FW = ON, it makes sense
+				// to assume this unless the opposite is explicitly specified in DPB.
+				// The actual FW mode (if different) will be fixed afterwards by PIO_header_init().
+
+				const TriState newForceWrite = options.dpb_set_force_write ?
+					TriState(options.dpb_force_write) : TriState();
+
+				// Set the FW flag inside the database block to be considered by PIO routines
+				if (newForceWrite.valueOr(true))
+					dbb->dbb_flags |= DBB_force_write;
+
+				const auto pageSpace = dbb->dbb_page_manager.findPageSpace(DB_PAGE_SPACE);
 				pageSpace->file = PIO_open(tdbb, expanded_name, org_filename);
 
 				// Initialize the global objects
@@ -1828,7 +1840,7 @@ JAttachment* JProvider::internalAttach(CheckStatusWrapper* user_status, const ch
 				dbb->dbb_monitoring_data = FB_NEW_POOL(*dbb->dbb_permanent) MonitoringData(dbb);
 
 				PAG_init2(tdbb, 0);
-				PAG_header(tdbb, false);
+				PAG_header(tdbb, false, newForceWrite);
 				dbb->dbb_page_manager.initTempPageSpace(tdbb);
 				dbb->dbb_crypto_manager->attach(tdbb, attachment);
 
@@ -3002,6 +3014,13 @@ JAttachment* JProvider::createDatabase(CheckStatusWrapper* user_status, const ch
 
 			TRA_init(attachment);
 
+			// By default, we create a database with FW = ON (unless explicitly specified in DPB)
+			const bool forceWrite = options.dpb_set_force_write ? options.dpb_force_write : true;
+
+			// Set the FW flag inside the database block to be considered by PIO routines
+			if (forceWrite)
+				dbb->dbb_flags |= DBB_force_write;
+
 			PageSpace* pageSpace = dbb->dbb_page_manager.findPageSpace(DB_PAGE_SPACE);
 			try
 			{
@@ -3146,9 +3165,6 @@ JAttachment* JProvider::createDatabase(CheckStatusWrapper* user_status, const ch
 				dbb->dbb_sweep_interval = options.dpb_sweep_interval;
 			}
 
-			if (options.dpb_set_force_write)
-				PAG_set_force_write(tdbb, options.dpb_force_write);
-
 			// initialize shadowing semaphore as soon as the database is ready for it
 			// but before any real work is done
 
@@ -3204,9 +3220,6 @@ JAttachment* JProvider::createDatabase(CheckStatusWrapper* user_status, const ch
 			}
 
 			CCH_flush(tdbb, FLUSH_FINI, 0);
-
-			if (!options.dpb_set_force_write)
-				PAG_set_force_write(tdbb, true);
 
 			dbb->dbb_crypto_manager->attach(tdbb, attachment);
 			dbb->dbb_backup_manager->dbCreating = false;

--- a/src/jrd/nbak.cpp
+++ b/src/jrd/nbak.cpp
@@ -227,11 +227,8 @@ void BackupManager::openDelta(thread_db* tdbb)
 	fb_assert(!diff_file);
 	diff_file = PIO_open(tdbb, diff_name, diff_name);
 
-	if (database->dbb_flags & (DBB_force_write | DBB_no_fs_cache))
-	{
-		setForcedWrites(database->dbb_flags & DBB_force_write,
-						database->dbb_flags & DBB_no_fs_cache);
-	}
+	if (database->dbb_flags & DBB_force_write)
+		setForcedWrites(true);
 }
 
 void BackupManager::closeDelta(thread_db* tdbb)
@@ -295,11 +292,8 @@ void BackupManager::beginBackup(thread_db* tdbb)
 	}
 
 	{ // logical scope
-		if (database->dbb_flags & (DBB_force_write | DBB_no_fs_cache))
-		{
-			setForcedWrites(database->dbb_flags & DBB_force_write,
-							database->dbb_flags & DBB_no_fs_cache);
-		}
+		if (database->dbb_flags & DBB_force_write)
+			setForcedWrites(true);
 
 #ifdef UNIX
 		// adjust difference file access rights to make it match main DB ones
@@ -891,10 +885,10 @@ void BackupManager::flushDifference(thread_db* tdbb)
 	PIO_flush(tdbb, diff_file);
 }
 
-void BackupManager::setForcedWrites(const bool forceWrite, const bool notUseFSCache)
+void BackupManager::setForcedWrites(const bool forceWrite)
 {
 	if (diff_file)
-		PIO_force_write(diff_file, forceWrite, notUseFSCache);
+		PIO_force_write(diff_file, forceWrite);
 }
 
 BackupManager::BackupManager(thread_db* tdbb, Database* _database, int ini_state) :

--- a/src/jrd/nbak.cpp
+++ b/src/jrd/nbak.cpp
@@ -226,9 +226,6 @@ void BackupManager::openDelta(thread_db* tdbb)
 {
 	fb_assert(!diff_file);
 	diff_file = PIO_open(tdbb, diff_name, diff_name);
-
-	if (database->dbb_flags & DBB_force_write)
-		setForcedWrites(true);
 }
 
 void BackupManager::closeDelta(thread_db* tdbb)
@@ -292,9 +289,6 @@ void BackupManager::beginBackup(thread_db* tdbb)
 	}
 
 	{ // logical scope
-		if (database->dbb_flags & DBB_force_write)
-			setForcedWrites(true);
-
 #ifdef UNIX
 		// adjust difference file access rights to make it match main DB ones
 		if (diff_file && geteuid() == 0)

--- a/src/jrd/nbak.h
+++ b/src/jrd/nbak.h
@@ -454,7 +454,7 @@ public:
 	bool writeDifference(thread_db* tdbb, FbStatusVector* status, ULONG diff_page, Ods::pag* page);
 	bool readDifference(thread_db* tdbb, ULONG diff_page, Ods::pag* page);
 	void flushDifference(thread_db* tdbb);
-	void setForcedWrites(const bool forceWrite, const bool notUseFSCache);
+	void setForcedWrites(const bool forceWrite);
 
 	void shutdown(thread_db* tdbb);
 

--- a/src/jrd/os/pio_proto.h
+++ b/src/jrd/os/pio_proto.h
@@ -43,7 +43,7 @@ Jrd::jrd_file*	PIO_create(Jrd::thread_db*, const Firebird::PathName&,
 bool	PIO_expand(const TEXT*, USHORT, TEXT*, FB_SIZE_T);
 void	PIO_extend(Jrd::thread_db*, Jrd::jrd_file*, const ULONG, const USHORT);
 void	PIO_flush(Jrd::thread_db*, Jrd::jrd_file*);
-void	PIO_force_write(Jrd::jrd_file*, const bool, const bool);
+void	PIO_force_write(Jrd::jrd_file*, const bool);
 ULONG	PIO_get_number_of_pages(const Jrd::jrd_file*, const USHORT);
 void	PIO_header(Jrd::thread_db*, UCHAR*, int);
 USHORT	PIO_init_data(Jrd::thread_db*, Jrd::jrd_file*, Jrd::FbStatusVector*, ULONG, USHORT);

--- a/src/jrd/os/posix/unix.cpp
+++ b/src/jrd/os/posix/unix.cpp
@@ -1000,7 +1000,7 @@ static jrd_file* setup_file(Database* dbb, const PathName& file_name, int desc, 
 		file = FB_NEW_RPT(*dbb->dbb_permanent, file_name.length() + 1) jrd_file();
 		file->fil_desc = desc;
 		file->fil_max_page = MAX_ULONG;
-		file->fil_flags |= flags;
+		file->fil_flags = flags;
 		strcpy(file->fil_string, file_name.c_str());
 	}
 	catch (const Exception&)

--- a/src/jrd/os/posix/unix.cpp
+++ b/src/jrd/os/posix/unix.cpp
@@ -226,17 +226,20 @@ jrd_file* PIO_create(thread_db* tdbb, const PathName& file_name,
 	const int flag = SYNC | O_RDWR | O_CREAT | (overwrite ? O_TRUNC : O_EXCL) | O_BINARY;
 #else
 	int flag = O_RDWR | O_BINARY;
+
 #ifdef SUPPORT_RAW_DEVICES
 	if (PIO_on_raw_device(file_name))
 		onRawDevice = true;
-	else
-		flag |= O_CREAT;
 #endif
+
 	flag |= overwrite ? O_TRUNC : O_EXCL;
+
 	if (forceWrite)
 		flag |= SYNC;
 	if (notUseFSCache)
 		flag |= O_DIRECT;
+	if (!onRawDevice)
+		flag |= O_CREAT;
 #endif
 
 	int desc = os_utils::open(file_name.c_str(), flag, 0666);

--- a/src/jrd/os/win32/winnt.cpp
+++ b/src/jrd/os/win32/winnt.cpp
@@ -878,7 +878,7 @@ static jrd_file* setup_file(Database* dbb,
 			file->fil_flags |= FIL_readonly;
 		if (shareMode)
 			file->fil_flags |= FIL_sh_write;
-		if (forceWrites)
+		if (forceWrite)
 			file->fil_flags |= FIL_force_write;
 		if (notUseFSCache)
 			file->fil_flags |= FIL_no_fs_cache;

--- a/src/jrd/pag.cpp
+++ b/src/jrd/pag.cpp
@@ -408,9 +408,6 @@ USHORT PAG_add_file(thread_db* tdbb, const TEXT* file_name, SLONG start)
 
 	jrd_file* next = file->fil_next;
 
-	if (dbb->dbb_flags & DBB_force_write)
-		PIO_force_write(next, true);
-
 	WIN window(DB_PAGE_SPACE, next->fil_min_page);
 	header_page* header = (header_page*) CCH_fake(tdbb, &window, 1);
 	header->hdr_header.pag_type = pag_header;
@@ -924,6 +921,9 @@ void PAG_format_header(thread_db* tdbb)
 	if (dbb->dbb_flags & DBB_DB_SQL_dialect_3)
 		header->hdr_flags |= hdr_SQL_dialect_3;
 
+	if (dbb->dbb_flags & DBB_force_write)
+		header->hdr_flags |= hdr_force_write;
+
 	dbb->dbb_ods_version = header->hdr_ods_version & ~ODS_FIREBIRD_FLAG;
 	dbb->dbb_minor_version = header->hdr_ods_minor;
 
@@ -1035,7 +1035,7 @@ bool PAG_get_clump(thread_db* tdbb, USHORT type, USHORT* inout_len, UCHAR* entry
 }
 
 
-void PAG_header(thread_db* tdbb, bool info)
+void PAG_header(thread_db* tdbb, bool info, const TriState newForceWrite)
 {
 /**************************************
  *
@@ -1122,17 +1122,24 @@ void PAG_header(thread_db* tdbb, bool info)
 										  Arg::Str(attachment->att_filename));
 	}
 
-	if (header->hdr_flags & hdr_force_write)
-	{
+	// Determine the actual FW mode to be used. Use the setting stored on the header page
+	// unless something different is explicitly specified in DPB.
+	const bool currentForceWrite = (header->hdr_flags & hdr_force_write) != 0;
+	const bool forceWrite = newForceWrite.valueOr(currentForceWrite);
+
+	// Adjust the flag inside the database block
+	if (forceWrite)
 		dbb->dbb_flags |= DBB_force_write;
+	else
+		dbb->dbb_flags &= ~DBB_force_write;
 
-		PageSpace* const pageSpace = dbb->dbb_page_manager.findPageSpace(DB_PAGE_SPACE);
-		for (jrd_file* file = pageSpace->file; file; file = file->fil_next)
-			PIO_force_write(file, !readOnly);
+	// Ensure the file-level FW mode matches the actual FW mode in the database
+	const auto pageSpace = dbb->dbb_page_manager.findPageSpace(DB_PAGE_SPACE);
+	for (jrd_file* file = pageSpace->file; file; file = file->fil_next)
+		PIO_force_write(file, forceWrite && !readOnly);
 
-		if (dbb->dbb_backup_manager->getState() != Ods::hdr_nbak_normal)
-			dbb->dbb_backup_manager->setForcedWrites(true);
-	}
+	if (dbb->dbb_backup_manager->getState() != Ods::hdr_nbak_normal)
+		dbb->dbb_backup_manager->setForcedWrites(forceWrite);
 
 	if (header->hdr_flags & hdr_no_reserve)
 		dbb->dbb_flags |= DBB_no_reserve;
@@ -1419,9 +1426,6 @@ void PAG_init2(thread_db* tdbb, USHORT shadow_number)
 		file->fil_max_page = last_page;
 		file = file->fil_next;
 
-		if (dbb->dbb_flags & DBB_force_write)
-			PIO_force_write(file, true);
-
 		file->fil_min_page = last_page + 1;
 		file->fil_sequence = sequence++;
 	}
@@ -1619,6 +1623,9 @@ void PAG_set_force_write(thread_db* tdbb, bool flag)
 		for (jrd_file* file = shadow->sdw_file; file; file = file->fil_next)
 			PIO_force_write(file, flag);
 	}
+
+	if (dbb->dbb_backup_manager->getState() != Ods::hdr_nbak_normal)
+		dbb->dbb_backup_manager->setForcedWrites(flag);
 }
 
 

--- a/src/jrd/pag_proto.h
+++ b/src/jrd/pag_proto.h
@@ -46,7 +46,7 @@ bool	PAG_delete_clump_entry(Jrd::thread_db* tdbb, USHORT);
 void	PAG_format_header(Jrd::thread_db*);
 void	PAG_format_pip(Jrd::thread_db*, Jrd::PageSpace& pageSpace);
 bool	PAG_get_clump(Jrd::thread_db*, USHORT, USHORT*, UCHAR*);
-void	PAG_header(Jrd::thread_db*, bool);
+void	PAG_header(Jrd::thread_db*, bool, const Firebird::TriState newForceWrite = Firebird::TriState());
 void	PAG_header_init(Jrd::thread_db*);
 void	PAG_init(Jrd::thread_db*);
 void	PAG_init2(Jrd::thread_db*, USHORT);

--- a/src/jrd/sdw.cpp
+++ b/src/jrd/sdw.cpp
@@ -92,11 +92,8 @@ void SDW_add(thread_db* tdbb, const TEXT* file_name, USHORT shadow_number, USHOR
 
 	jrd_file* shadow_file = PIO_create(tdbb, file_name, false, false);
 
-	if (dbb->dbb_flags & (DBB_force_write | DBB_no_fs_cache))
-	{
-		PIO_force_write(shadow_file, dbb->dbb_flags & DBB_force_write,
-			dbb->dbb_flags & DBB_no_fs_cache);
-	}
+	if (dbb->dbb_flags & DBB_force_write)
+		PIO_force_write(shadow_file, true);
 
 	SyncLockGuard guard(&dbb->dbb_shadow_sync, SYNC_EXCLUSIVE, "SDW_add");
 
@@ -174,10 +171,8 @@ int SDW_add_file(thread_db* tdbb, const TEXT* file_name, SLONG start, USHORT sha
 
 	jrd_file* next = file->fil_next;
 
-	if (dbb->dbb_flags & (DBB_force_write | DBB_no_fs_cache))
-	{
-		PIO_force_write(next, dbb->dbb_flags & DBB_force_write, dbb->dbb_flags & DBB_no_fs_cache);
-	}
+	if (dbb->dbb_flags & DBB_force_write)
+		PIO_force_write(next, true);
 
 	// Always write the header page, even for a conditional
 	// shadow that hasn't been activated.
@@ -995,11 +990,8 @@ void SDW_start(thread_db* tdbb, const TEXT* file_name,
 
 	shadow_file = PIO_open(tdbb, expanded_name, file_name);
 
-	if (dbb->dbb_flags & (DBB_force_write | DBB_no_fs_cache))
-	{
-		PIO_force_write(shadow_file, dbb->dbb_flags & DBB_force_write,
-			dbb->dbb_flags & DBB_no_fs_cache);
-	}
+	if (dbb->dbb_flags & DBB_force_write)
+		PIO_force_write(shadow_file, true);
 
 	if (!(file_flags & FILE_conditional))
 	{

--- a/src/jrd/sdw.cpp
+++ b/src/jrd/sdw.cpp
@@ -92,9 +92,6 @@ void SDW_add(thread_db* tdbb, const TEXT* file_name, USHORT shadow_number, USHOR
 
 	jrd_file* shadow_file = PIO_create(tdbb, file_name, false, false);
 
-	if (dbb->dbb_flags & DBB_force_write)
-		PIO_force_write(shadow_file, true);
-
 	SyncLockGuard guard(&dbb->dbb_shadow_sync, SYNC_EXCLUSIVE, "SDW_add");
 
 	Shadow* shadow = allocate_shadow(shadow_file, shadow_number, file_flags);
@@ -170,9 +167,6 @@ int SDW_add_file(thread_db* tdbb, const TEXT* file_name, SLONG start, USHORT sha
 		return 0;
 
 	jrd_file* next = file->fil_next;
-
-	if (dbb->dbb_flags & DBB_force_write)
-		PIO_force_write(next, true);
 
 	// Always write the header page, even for a conditional
 	// shadow that hasn't been activated.
@@ -989,9 +983,6 @@ void SDW_start(thread_db* tdbb, const TEXT* file_name,
 	try {
 
 	shadow_file = PIO_open(tdbb, expanded_name, file_name);
-
-	if (dbb->dbb_flags & DBB_force_write)
-		PIO_force_write(shadow_file, true);
 
 	if (!(file_flags & FILE_conditional))
 	{


### PR DESCRIPTION
1. As now `UseFileSystemCache` remains the only rule whether filesystem cache should be used or not, it makes sense to consider it immediately when the database file is created/opened rather than adjusting it on demand (and reopen the file for that purpose).
2. The similar approach is also used for the FW mode - guess the likely mode before creating/opening the database file and adjust it later only if required.
3. Given point (1) above, it does not make sense to reopen the database file to change the FW mode on Linux anymore, `fcntl()` again becomes the minimalistic solution for that goal.
4. Some related cleanup.