### PR TITLE
Free memory issued for isql command list but has never been freed on output file write

### DIFF
--- a/src/isql/InputDevices.h
+++ b/src/isql/InputDevices.h
@@ -133,8 +133,6 @@ inline InputDevices::~InputDevices()
 	for (unsigned n = 0; n < commands.getCount(); ++n)
 		delete commands[n];
 
-	commands.clear();
-
 	clear();
 }
 

--- a/src/isql/InputDevices.h
+++ b/src/isql/InputDevices.h
@@ -130,6 +130,11 @@ inline InputDevices::InputDevices(Firebird::MemoryPool& p)
 
 inline InputDevices::~InputDevices()
 {
+	for (unsigned n = 0; n < commands.getCount(); ++n)
+		delete commands[n];
+
+	commands.clear();
+
 	clear();
 }
 


### PR DESCRIPTION
Such kind of a leak is not a big concern (memory will be freed on isql exit anyway), but it interferes with isql.memdebug.log memory leaks log.