### PR TITLE
Let optimizer automatically update empty index statistics for relatively small system tables

### DIFF
--- a/src/jrd/optimizer/Optimizer.cpp
+++ b/src/jrd/optimizer/Optimizer.cpp
@@ -1119,6 +1119,33 @@ void Optimizer::compileRelation(StreamType stream)
 		IndexDescList idxList;
 		BTR_all(tdbb, relation, idxList, relPages);
 
+		// if index stats is empty, update it for non-empty and not too big system relations
+
+		const bool updateStats = (relation->isSystem() && idxList.hasData() &&
+			!tdbb->getDatabase()->readOnly() &&
+			(relPages->rel_data_pages > 0) && (relPages->rel_data_pages < 100));
+
+		if (updateStats)
+		{
+			bool updated = false;
+			for (const index_desc& idx : idxList)
+			{
+				if (idx.idx_selectivity == 0.0f)
+				{
+					SelectivityList	selectivity;
+					BTR_selectivity(tdbb, relation, idx.idx_id, selectivity);
+					if (selectivity[0] != 0.0f)
+						updated = true;
+				}
+			}
+
+			if (updated)
+			{
+				idxList.clear();
+				BTR_all(tdbb, relation, idxList, relPages);
+			}
+		}
+
 		if (idxList.hasData())
 			tail->csb_idx = FB_NEW_POOL(getPool()) IndexDescList(getPool(), idxList);
 

--- a/src/jrd/optimizer/Optimizer.cpp
+++ b/src/jrd/optimizer/Optimizer.cpp
@@ -1111,6 +1111,9 @@ void Optimizer::compileRelation(StreamType stream)
 	const auto relation = tail->csb_relation;
 	fb_assert(relation);
 
+	const auto format = CMP_format(tdbb, csb, stream);
+	tail->csb_cardinality = getCardinality(tdbb, relation, format);
+
 	tail->csb_idx = nullptr;
 
 	if (needIndices && !relation->rel_file && !relation->isVirtual())
@@ -1152,9 +1155,6 @@ void Optimizer::compileRelation(StreamType stream)
 		if (tail->csb_plan)
 			markIndices(tail, relation->rel_id);
 	}
-
-	const auto format = CMP_format(tdbb, csb, stream);
-	tail->csb_cardinality = getCardinality(tdbb, relation, format);
 }
 
 

--- a/src/jrd/optimizer/Optimizer.cpp
+++ b/src/jrd/optimizer/Optimizer.cpp
@@ -1130,11 +1130,11 @@ void Optimizer::compileRelation(StreamType stream)
 			bool updated = false;
 			for (const index_desc& idx : idxList)
 			{
-				if (idx.idx_selectivity == 0.0f)
+				if (idx.idx_selectivity <= 0.0f)
 				{
 					SelectivityList	selectivity;
 					BTR_selectivity(tdbb, relation, idx.idx_id, selectivity);
-					if (selectivity[0] != 0.0f)
+					if (selectivity[0] > 0.0f)
 						updated = true;
 				}
 			}


### PR DESCRIPTION
This is experimental change. 
It should allow to get correct execution plan for system queries when index statistics is empty, for example at the restore.
Also, it fix the QA test for CORE-5602 (#5868) that start to fail after the #8030.