### PR TITLE
Fix for #8105:  Master database could miss replication segments on Windows Classic Server

### DIFF
--- a/src/jrd/replication/ChangeLog.h
+++ b/src/jrd/replication/ChangeLog.h
@@ -181,6 +181,8 @@ namespace Replication
 				return m_filename;
 			}
 
+			void closeFile();
+
 		private:
 			void mapHeader();
 			void unmapHeader();
@@ -188,6 +190,7 @@ namespace Replication
 			Firebird::PathName m_filename;
 			int m_handle;
 			SegmentHeader* m_header;
+			SegmentHeader m_builtinHeader;		// used by free segments when there is no mapping
 
 	#ifdef WIN_NT
 			HANDLE m_mapping;


### PR DESCRIPTION
The main problem is that on Windows it is not allowed to rename open files with mapped memory section.
`rename()` for such file always set `errno` to `EACCES`, `GetLastError()` returns `ERROR_SHARING_VIOLATION`.