### PR TITLE
[MASTER] Fix for issue #8108 [frontported from FB4]

### DIFF
--- a/src/common/unicode_util.cpp
+++ b/src/common/unicode_util.cpp
@@ -427,7 +427,6 @@ private:
 		getEntryPoint("u_countChar32", module, u_countChar32);
 		getEntryPoint("utf8_nextCharSafeBody", module, utf8_nextCharSafeBody);
 
-		getEntryPoint("UCNV_FROM_U_CALLBACK_STOP", module, UCNV_FROM_U_CALLBACK_STOP);
 		getEntryPoint("UCNV_TO_U_CALLBACK_STOP", module, UCNV_TO_U_CALLBACK_STOP);
 		getEntryPoint("ucnv_fromUnicode", module, ucnv_fromUnicode);
 		getEntryPoint("ucnv_toUnicode", module, ucnv_toUnicode);

--- a/src/common/unicode_util.h
+++ b/src/common/unicode_util.h
@@ -66,14 +66,6 @@ public:
 
 		UChar32 (U_EXPORT2* utf8_nextCharSafeBody) (const uint8_t* s, int32_t* pi, int32_t length, UChar32 c, UBool strict);
 
-		void (U_EXPORT2* UCNV_FROM_U_CALLBACK_STOP) (
-                const void *context,
-                UConverterFromUnicodeArgs *fromUArgs,
-                const UChar* codeUnits,
-                int32_t length,
-                UChar32 codePoint,
-                UConverterCallbackReason reason,
-                UErrorCode * err);
 		void (U_EXPORT2* UCNV_TO_U_CALLBACK_STOP) (
                 const void *context,
                 UConverterToUnicodeArgs *toUArgs,

--- a/src/intl/cv_icu.cpp
+++ b/src/intl/cv_icu.cpp
@@ -31,6 +31,34 @@
 #include <unicode/ucnv.h>
 #include "../common/unicode_util.h"
 
+namespace {
+
+static void U_EXPORT2 FB_UCNV_FROM_U_CALLBACK_STOP(
+                const void* /*context*/,
+                UConverterFromUnicodeArgs* /*fromUArgs*/,
+                const UChar* /*codeUnits*/,
+                int32_t /*length*/,
+                UChar32 /*codePoint*/,
+                UConverterCallbackReason /*reason*/,
+                UErrorCode* /*err*/)
+{
+	/*
+	 * A stable implementation of callback function UCNV_FROM_U_CALLBACK_STOP.
+	 *
+	 * It is equal to a behaviour of old ICU (from FB2.1 and FB3).
+	 *
+	 * ICU from FB4 (v63.1) translates "ignorable" symbols (..., 0x115F, ...) into an empty string
+	 * and this is incompatible with conversion of built-in charsets where
+	 * a such case leads to a translation error.
+	 *
+	 */
+
+	/* the caller must have set the error code accordingly */
+	return;
+}
+
+} // namespace
+
 
 static UConverter* create_converter(csconvert* cv, UErrorCode* status)
 {
@@ -41,7 +69,7 @@ static UConverter* create_converter(csconvert* cv, UErrorCode* status)
 	UConverterFromUCallback oldFromAction;
 	cIcu.ucnv_setFromUCallBack(
 		conv,
-		cIcu.UCNV_FROM_U_CALLBACK_STOP,
+		FB_UCNV_FROM_U_CALLBACK_STOP,
 		NULL,
 		&oldFromAction,
 		&oldContext,


### PR DESCRIPTION
Server will use "stable" implementation of UCNV_FROM_U_CALLBACK_STOP function to provide one behaviour for built-in charset and ICU-charset when source unicode-string contains "ignorable" symbols.

It will always produces translation error.

This patch restores a behaviour of FB2.1-FB3 for "ignorable" symbols.

---
ATTENTION: These changes were not tested in a master tree (only in FB4).