### PR TITLE
Simplest fix for bug #8120 : Cast dies with numeric value is out of range error (5.0.1 snapshot)

### DIFF
--- a/src/common/cvt.cpp
+++ b/src/common/cvt.cpp
@@ -2577,9 +2577,10 @@ static SSHORT cvt_get_short(const dsc* desc, SSHORT scale, DecimalStatus decSt, 
 		const char* p;
 		USHORT length = CVT_make_string(desc, ttype_ascii, &p, &buffer, sizeof(buffer), decSt, err);
 
-		RetValue<SSHORTTraits> rv(&value);
-		scale -= cvt_decompose(p, length, &rv, err);
-
+		{
+			RetValue<SSHORTTraits> rv(&value);
+			scale -= cvt_decompose(p, length, &rv, err);
+		}
 		adjustForScale(value, scale, SHORT_LIMIT, err);
 	}
 	else {
@@ -4793,8 +4794,10 @@ SQUAD CVT_get_quad(const dsc* desc, SSHORT scale, DecimalStatus decSt, ErrorFunc
 				CVT_make_string(desc, ttype_ascii, &p, &buffer, sizeof(buffer), decSt, err);
 
 			SINT64 i64;
-			RetValue<SINT64Traits> rv(&i64);
-			scale -= cvt_decompose(p, length, &rv, err);
+			{
+				RetValue<SINT64Traits> rv(&i64);
+				scale -= cvt_decompose(p, length, &rv, err);
+			}
 			SINT64_to_SQUAD(i64, value);
 		}
 		break;


### PR DESCRIPTION
The problem in #8120 is that `RetValue` updates `value` in own destructor only, thus making impossible to work with `value` in the same scope as `RetValue`.
I found and fixed two occurrences of such code but it looks as fragile to me.
It would be better to not create such indirect dependencies, for example moving `RetValue` instance into `cvt_decompose()`.
