### PR TITLE
Fix error when changing force write mode

### DIFF
--- a/src/include/firebird/impl/msg/jrd.h
+++ b/src/include/firebird/impl/msg/jrd.h
@@ -968,3 +968,4 @@ FB_IMPL_MSG(JRD, 965, ods_upgrade_err, -901, "HY", "000", "ODS upgrade failed wh
 FB_IMPL_MSG(JRD, 966, bad_par_workers, -924, "HY", "000", "Wrong parallel workers value @1, valid range are from 1 to @2")
 FB_IMPL_MSG(JRD, 967, idx_expr_not_found, -902, "42", "000", "Definition of index expression is not found for index @1")
 FB_IMPL_MSG(JRD, 968, idx_cond_not_found, -902, "42", "000", "Definition of index condition is not found for index @1")
+FB_IMPL_MSG(JRD, 969, forced_write_change_err, -902, "42", "000", "Cannot change forced write mode for classic server while it has connections")

--- a/src/include/gen/Firebird.pas
+++ b/src/include/gen/Firebird.pas
@@ -5700,6 +5700,7 @@ const
 	 isc_bad_par_workers = 335545286;
 	 isc_idx_expr_not_found = 335545287;
 	 isc_idx_cond_not_found = 335545288;
+	 isc_forced_write_change_err = 335545289;
 	 isc_gfix_db_name = 335740929;
 	 isc_gfix_invalid_sw = 335740930;
 	 isc_gfix_incmp_sw = 335740932;

--- a/src/jrd/Database.cpp
+++ b/src/jrd/Database.cpp
@@ -130,7 +130,11 @@ namespace Jrd
 			const PageSpace* const pageSpace = dbb_page_manager.findPageSpace(DB_PAGE_SPACE);
 
 			UCharBuffer buffer;
-			os_utils::getUniqueFileId(pageSpace->file->fil_desc, buffer);
+			{
+				jrd_file* file = pageSpace->file;
+				ReadLockGuard readGuard(file->fil_desc_lock, FB_FUNCTION);
+				os_utils::getUniqueFileId(file->fil_desc, buffer);
+			}
 
 			auto ptr = dbb_file_id.getBuffer(2 * buffer.getCount());
 			for (const auto val : buffer)

--- a/src/jrd/nbak.cpp
+++ b/src/jrd/nbak.cpp
@@ -309,9 +309,13 @@ void BackupManager::beginBackup(thread_db* tdbb)
 			PageSpace* pageSpace = database->dbb_page_manager.findPageSpace(DB_PAGE_SPACE);
 			const char* func = NULL;
 
-			if (os_utils::fstat(pageSpace->file->fil_desc, &st) != 0)
 			{
-				func = "fstat";
+				jrd_file* file = pageSpace->file;
+				ReadLockGuard readGuard(file->fil_desc_lock, FB_FUNCTION);
+				if (os_utils::fstat(file->fil_desc, &st) != 0)
+				{
+					func = "fstat";
+				}
 			}
 
 			while (!func && fchown(diff_file->fil_desc, st.st_uid, st.st_gid) != 0)

--- a/src/jrd/os/pio.h
+++ b/src/jrd/os/pio.h
@@ -46,8 +46,9 @@ public:
 	ULONG fil_max_page;			// Maximum page number in file
 	USHORT fil_sequence;		// Sequence number of file
 	USHORT fil_fudge;			// Fudge factor for page relocation
-	int fil_desc;
+	int fil_desc;				// Lock fil_desc_lock before using
 	Firebird::Mutex fil_mutex;
+	mutable Firebird::RWLock fil_desc_lock;
 	USHORT fil_flags;
 	SCHAR fil_string[1];		// Expanded file name
 };
@@ -74,8 +75,9 @@ public:
 	ULONG fil_max_page;					// Maximum page number in file
 	USHORT fil_sequence;				// Sequence number of file
 	USHORT fil_fudge;					// Fudge factor for page relocation
-	HANDLE fil_desc;					// File descriptor
+	HANDLE fil_desc;					// File descriptor, lock fil_desc_lock before using
 	Firebird::RWLock* fil_ext_lock;		// file extend lock
+	mutable Firebird::RWLock fil_desc_lock;
 	USHORT fil_flags;
 	SCHAR fil_string[1];				// Expanded file name
 };


### PR DESCRIPTION
When we try to change force write mode on database that has connections, we can get various types of errors or asserts from PIO_ functions (Super Server mode only). These errors can be reproduced using TPCC load and changing force write mode.  
This patch fixes cases where someone tries to change force write mode when database has connections. This is done via RWLock for file descriptor, so we can be sure that some other thread won't close this descriptor while we're using it.  
For Classic Server we can change force write mode only with no connections.