### PR TITLE
Fix #7783: Deadlock during index creation when parallel workers are used

### DIFF
--- a/src/jrd/Statement.cpp
+++ b/src/jrd/Statement.cpp
@@ -119,15 +119,8 @@ Statement::Statement(thread_db* tdbb, MemoryPool* p, CompilerScratch* csb)
 
 				case Resource::rsc_index:
 				{
-					jrd_rel* relation = resource->rsc_rel;
-					IndexLock* index = CMP_get_index_lock(tdbb, relation, resource->rsc_id);
-					if (index)
-					{
-						++index->idl_count;
-						if (index->idl_count == 1) {
-							LCK_lock(tdbb, index->idl_lock, LCK_SR, LCK_WAIT);
-						}
-					}
+					// No need to lock the index here because it is already
+					// locked by Optimizer::compileRelation.
 					break;
 				}
 


### PR DESCRIPTION
Deadlock is possible when index deletion and creation are performed in the same transaction and a deleted index is used by a computed field expression. Each worker attachment loads table's metadata, parses the expression and tries to get SR lock on the deleted index. They will never get it because the main thread holds EX lock and waits for worker attachments to complete. The solution is to prevent the optimizer from using deleted indexes by making an attempt to get SR lock with NO_WAIT.