### PR TITLE
Fixed bug #8176 : Firebird 5 hang after starting remote profiling session

### DIFF
--- a/src/jrd/ProfilerManager.cpp
+++ b/src/jrd/ProfilerManager.cpp
@@ -841,7 +841,10 @@ void ProfilerIpc::internalSendAndReceive(thread_db* tdbb, Tag tag,
 
 	sharedMemory->eventPost(&header->serverEvent);
 
-	sharedMemory->eventWait(&header->clientEvent, value, 0);
+	{
+		EngineCheckout cout(tdbb, FB_FUNCTION);
+		sharedMemory->eventWait(&header->clientEvent, value, 0);
+	}
 
 	if (header->tag == Tag::RESPONSE)
 	{


### PR DESCRIPTION
The fix unblock "primary" profiler attachment to allows it to process ASTs.