### PR TITLE
Ensure the standalone CS listener on Linux uses the SO_REUSEADDR socket option

### DIFF
--- a/src/remote/inet.cpp
+++ b/src/remote/inet.cpp
@@ -1074,7 +1074,7 @@ static rem_port* listener_socket(rem_port* port, USHORT flag, const addrinfo* pa
  *	binds the socket and calls listen().
  *  For multi-client server (SuperServer or SuperClassic) return listener
  *  port.
- *  For classic server - accept incoming connections and fork worker
+ *  For Classic server - accept incoming connections and fork worker
  *  processes, return NULL at exit;
  *  On error throw exception.
  *
@@ -1088,26 +1088,27 @@ static rem_port* listener_socket(rem_port* port, USHORT flag, const addrinfo* pa
 	if (n == -1)
 		gds__log("setsockopt: error setting IPV6_V6ONLY to %d", ipv6_v6only);
 
+#ifndef WIN_NT
+	// dimitr:	on Windows, lack of SO_REUSEADDR works the same way as it was specified on POSIX,
+	//			i.e. it allows binding to a port in a TIME_WAIT/FIN_WAIT state. If this option
+	//			is turned on explicitly, then a port can be re-bound regardless of its state,
+	//			e.g. while it's listening. This is surely not what we want.
+	//			We set this options for any kind of listener, including standalone Classic.
+
+	int optval = TRUE;
+	n = setsockopt(port->port_handle, SOL_SOCKET, SO_REUSEADDR,
+					(SCHAR*) &optval, sizeof(optval));
+	if (n == -1)
+	{
+		inet_error(true, port, "setsockopt REUSE", isc_net_connect_listen_err, INET_ERRNO);
+	}
+#endif
+
 	if (flag & SRVR_multi_client)
 	{
 		struct linger lingerInfo;
 		lingerInfo.l_onoff = 0;
 		lingerInfo.l_linger = 0;
-
-#ifndef WIN_NT
-		// dimitr:	on Windows, lack of SO_REUSEADDR works the same way as it was specified on POSIX,
-		//			i.e. it allows binding to a port in a TIME_WAIT/FIN_WAIT state. If this option
-		//			is turned on explicitly, then a port can be re-bound regardless of its state,
-		//			e.g. while it's listening. This is surely not what we want.
-
-		int optval = TRUE;
-		n = setsockopt(port->port_handle, SOL_SOCKET, SO_REUSEADDR,
-					   (SCHAR*) &optval, sizeof(optval));
-		if (n == -1)
-		{
-			inet_error(true, port, "setsockopt REUSE", isc_net_connect_listen_err, INET_ERRNO);
-		}
-#endif
 
 		// Get any values for SO_LINGER so that they can be reset during
 		// disconnect.  SO_LINGER should be set by default on the socket


### PR DESCRIPTION
In recent FB versions Classic on Linux uses its native listener instead of _xinetd/systemd_. While we usually don't expect it to crash, it's still possible. However, often it cannot continue listening the port immediately after restart because the port is still in the `FIN_WAIT` state and the `SO_REUSEADDR` socket option is not used by the standalone Classic listener, thus causing "address already in use" errors during startup. This patch ensures that any kind of listeners (SS/SC using `SRVR_multi_thread` and CS standalone server) uses the `SO_REUSEADDR` option to avoid the issue.

Maybe (after this patch) we should also cleanup the retry loop for `INET_ADDR_IN_USE` used later in this function, as it's likely to be pointless, but I leave it for another day.