### PR TITLE
Fix #8187 - Performance regression in generating of UUID values after introducing GUID-v7

### DIFF
--- a/builds/win32/msvc15/FirebirdCommon.props
+++ b/builds/win32/msvc15/FirebirdCommon.props
@@ -34,7 +34,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(IntDir)$(TargetName).pdb</ProgramDatabaseFile>
       <ImportLibrary>$(IntDir)$(TargetName).lib</ImportLibrary>
-      <AdditionalDependencies>psapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>bcrypt.lib;psapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>../../../extern/re2/builds/$(PlatformName)/$(Configuration)</AdditionalLibraryDirectories>
     </Link>
     <Bscmake>

--- a/src/common/os/win32/guid.cpp
+++ b/src/common/os/win32/guid.cpp
@@ -32,7 +32,7 @@
 #endif
 
 #include <windows.h>
-#include <wincrypt.h>
+#include <bcrypt.h>
 #include <objbase.h>
 #include <stdio.h>
 
@@ -40,38 +40,15 @@
 #include "../common/os/guid.h"
 #include "fb_exception.h"
 
+#pragma comment(lib, "bcrypt.lib")
+
 namespace Firebird {
 
 
 void GenerateRandomBytes(void* buffer, FB_SIZE_T size)
 {
-	HCRYPTPROV hProv;
-
-	// Acquire crypto-provider context handle.
-	if (! CryptAcquireContext(&hProv, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
-	{
-		if (GetLastError() == NTE_BAD_KEYSET)
-		{
-			// A common cause of this error is that the key container does not exist.
-			// To create a key container, call CryptAcquireContext
-			// using the CRYPT_NEWKEYSET flag.
-			if (! CryptAcquireContext(&hProv, NULL, NULL, PROV_RSA_FULL,
-					CRYPT_VERIFYCONTEXT | CRYPT_NEWKEYSET))
-			{
-				Firebird::system_call_failed::raise("CryptAcquireContext");
-			}
-		}
-		else
-		{
-			Firebird::system_call_failed::raise("CryptAcquireContext");
-		}
-	}
-
-	if (! CryptGenRandom(hProv, size, static_cast<UCHAR*>(buffer)))
-	{
-		Firebird::system_call_failed::raise("CryptGenRandom");
-	}
-	CryptReleaseContext(hProv, 0);
+	if (BCryptGenRandom(nullptr, static_cast<UCHAR*>(buffer), size, BCRYPT_USE_SYSTEM_PREFERRED_RNG) != S_OK)
+		Firebird::system_call_failed::raise("BCryptGenRandom");
 }
 
 void GenerateGuid(UUID* guid)

--- a/src/common/os/win32/guid.cpp
+++ b/src/common/os/win32/guid.cpp
@@ -40,8 +40,6 @@
 #include "../common/os/guid.h"
 #include "fb_exception.h"
 
-#pragma comment(lib, "bcrypt.lib")
-
 namespace Firebird {
 
 


### PR DESCRIPTION
Replacing deprecated win32 crypto functions.