### PR TITLE
Fixed bug #8203 : Function MAKE_DBKEY may produce random errors if used with relation name

### DIFF
--- a/src/dsql/ExprNodes.cpp
+++ b/src/dsql/ExprNodes.cpp
@@ -8092,6 +8092,16 @@ dsc* LiteralNode::execute(thread_db* /*tdbb*/, Request* /*request*/) const
 	return const_cast<dsc*>(&litDesc);
 }
 
+bool LiteralNode::getMetaName(thread_db* tdbb, MetaName& name) const
+{
+	if (!DTYPE_IS_TEXT(litDesc.dsc_dtype))
+		return false;
+
+	CVT2_make_metaname(&litDesc, name, tdbb->getAttachment()->att_dec_status);
+
+	return true;
+}
+
 void LiteralNode::fixMinSInt64(MemoryPool& pool)
 {
 	// MIN_SINT64 should be stored as BIGINT, not 128-bit integer
@@ -12304,9 +12314,9 @@ DmlNode* SysFuncCallNode::parse(thread_db* tdbb, MemoryPool& pool, CompilerScrat
 
 		auto literal = nodeAs<LiteralNode>(node->args->items[0]);
 
-		if (literal && literal->litDesc.isText())
+		MetaName relName;
+		if (literal && literal->getMetaName(tdbb, relName))
 		{
-			const MetaName relName = literal->getText();
 			const jrd_rel* const relation = MET_lookup_relation(tdbb, relName);
 
 			if (relation)

--- a/src/dsql/ExprNodes.cpp
+++ b/src/dsql/ExprNodes.cpp
@@ -8092,16 +8092,6 @@ dsc* LiteralNode::execute(thread_db* /*tdbb*/, Request* /*request*/) const
 	return const_cast<dsc*>(&litDesc);
 }
 
-bool LiteralNode::getMetaName(thread_db* tdbb, MetaName& name) const
-{
-	if (!DTYPE_IS_TEXT(litDesc.dsc_dtype))
-		return false;
-
-	CVT2_make_metaname(&litDesc, name, tdbb->getAttachment()->att_dec_status);
-
-	return true;
-}
-
 void LiteralNode::fixMinSInt64(MemoryPool& pool)
 {
 	// MIN_SINT64 should be stored as BIGINT, not 128-bit integer
@@ -12314,9 +12304,11 @@ DmlNode* SysFuncCallNode::parse(thread_db* tdbb, MemoryPool& pool, CompilerScrat
 
 		auto literal = nodeAs<LiteralNode>(node->args->items[0]);
 
-		MetaName relName;
-		if (literal && literal->getMetaName(tdbb, relName))
+		if (literal && literal->litDesc.isText())
 		{
+			MetaName relName;
+			CVT2_make_metaname(&literal->litDesc, name, tdbb->getAttachment()->att_dec_status);
+
 			const jrd_rel* const relation = MET_lookup_relation(tdbb, relName);
 
 			if (relation)

--- a/src/dsql/ExprNodes.h
+++ b/src/dsql/ExprNodes.h
@@ -965,8 +965,6 @@ public:
 		return *reinterpret_cast<SLONG*>(litDesc.dsc_address);
 	}
 
-	bool getMetaName(thread_db* tdbb, MetaName& name) const;
-
 	void fixMinSInt32(MemoryPool& pool);
 	void fixMinSInt64(MemoryPool& pool);
 	void fixMinSInt128(MemoryPool& pool);

--- a/src/dsql/ExprNodes.h
+++ b/src/dsql/ExprNodes.h
@@ -965,11 +965,7 @@ public:
 		return *reinterpret_cast<SLONG*>(litDesc.dsc_address);
 	}
 
-	const char* getText() const
-	{
-		fb_assert(litDesc.dsc_dtype == dtype_text);
-		return reinterpret_cast<const char*>(litDesc.dsc_address);
-	}
+	bool getMetaName(thread_db* tdbb, MetaName& name) const;
 
 	void fixMinSInt32(MemoryPool& pool);
 	void fixMinSInt64(MemoryPool& pool);

--- a/src/jrd/SysFunction.cpp
+++ b/src/jrd/SysFunction.cpp
@@ -43,6 +43,7 @@
 #include "../jrd/blb_proto.h"
 #include "../jrd/cch_proto.h"
 #include "../jrd/cvt_proto.h"
+#include "../jrd/cvt2_proto.h"
 #include "../common/cvt.h"
 #include "../jrd/evl_proto.h"
 #include "../jrd/intl_proto.h"
@@ -5365,7 +5366,7 @@ dsc* evlMakeDbkey(Jrd::thread_db* tdbb, const SysFunction* function, const NestV
 	if (argDsc->isText())
 	{
 		MetaName relName;
-		MOV_get_metaname(tdbb, argDsc, relName);
+		CVT2_make_metaname(argDsc, relName, tdbb->getAttachment()->att_dec_status);
 
 		const jrd_rel* const relation = MET_lookup_relation(tdbb, relName);
 		if (!relation)

--- a/src/jrd/cvt2.cpp
+++ b/src/jrd/cvt2.cpp
@@ -914,6 +914,28 @@ int CVT2_blob_compare(const dsc* arg1, const dsc* arg2, DecimalStatus decSt)
 }
 
 
+void CVT2_make_metaname(const dsc* desc, MetaName& name, DecimalStatus decSt)
+/**************************************
+ *
+ *	C V T 2 _ m a k e _ m e t a n a m e
+ *
+ **************************************
+ *
+ * Functional description
+ *
+ *     Convert the data from the desc to a string in the metadata charset.
+ *     Then return the string as MetaName object.
+ *
+ **************************************/
+{
+	MoveBuffer buff;
+	UCHAR* ptr = nullptr;
+
+	const auto len = CVT2_make_string2(desc, CS_METADATA, &ptr, buff, decSt);
+	name.assign(reinterpret_cast<const char*>(ptr), len);
+}
+
+
 USHORT CVT2_make_string2(const dsc* desc, USHORT to_interp, UCHAR** address, MoveBuffer& temp, DecimalStatus decSt)
 {
 /**************************************

--- a/src/jrd/cvt2_proto.h
+++ b/src/jrd/cvt2_proto.h
@@ -31,6 +31,7 @@ extern const BYTE CVT2_compare_priority[];
 bool    CVT2_get_binary_comparable_desc(dsc*, const dsc*, const dsc*);
 int		CVT2_compare(const dsc*, const dsc*, Firebird::DecimalStatus);
 int		CVT2_blob_compare(const dsc*, const dsc*, Firebird::DecimalStatus);
+void	CVT2_make_metaname(const dsc* desc, Jrd::MetaName& name, Firebird::DecimalStatus);
 USHORT	CVT2_make_string2(const dsc*, USHORT, UCHAR**, Jrd::MoveBuffer&, Firebird::DecimalStatus);
 
 #endif // JRD_CVT2_PROTO_H


### PR DESCRIPTION
Also, corrected handling of non-ASCII tables names.