### PR TITLE
Add manual delete for tra_dbcreators_list

### DIFF
--- a/src/jrd/tra.cpp
+++ b/src/jrd/tra.cpp
@@ -3792,6 +3792,7 @@ jrd_tra::~jrd_tra()
 	delete tra_user_management;
 	delete tra_timezone_snapshot;
 	delete tra_mapping_list;
+	delete tra_dbcreators_list;
 	delete tra_gen_ids;
 
 	if (!tra_outer)

--- a/src/jrd/tra.h
+++ b/src/jrd/tra.h
@@ -198,6 +198,7 @@ public:
 		tra_user_management(NULL),
 		tra_sec_db_context(NULL),
 		tra_mapping_list(NULL),
+		tra_dbcreators_list(nullptr),
 		tra_autonomous_pool(NULL),
 		tra_autonomous_cnt(0)
 	{


### PR DESCRIPTION
I found that if we try to write a lot of records to `RecordBuffer` (>MIN_TEMP_BLOCK_SIZE) we start increasing `m_tempCacheUsage`. When we don't need `RecordBuffer` anymore, it will be destroyed in `~SnapshotData()`, which will call  `~TempSpace()` for `Firebird::AutoPtr<TempSpace> space`, and in `~TempSpace()` we will decrease `m_tempCacheUsage`.
But this doesn't apply to `tra_dbcreators_list` because we delete it by dropping the transaction pool, so destructor doesn't kick in and we don't decrease `m_tempCacheUsage`. All of this will cause `fb_assert(m_tempCacheUsage == 0)` to be thrown, but I don't know what this might lead to in release build (nothing good, I suppose).
This is also true for Firebird 5.0.