### PR TITLE
move the call of the checkArgsMismatch function before the call of th…

### DIFF
--- a/src/dsql/ExprNodes.cpp
+++ b/src/dsql/ExprNodes.cpp
@@ -12386,7 +12386,6 @@ void SysFuncCallNode::make(DsqlCompilerScratch* dsqlScratch, dsc* desc)
 	}
 
 	DSqlDataTypeUtil dataTypeUtil(dsqlScratch);
-	function->checkArgsMismatch(argsArray.getCount());
 	function->makeFunc(&dataTypeUtil, function, desc, argsArray.getCount(), argsArray.begin());
 }
 
@@ -12481,14 +12480,18 @@ ValueExprNode* SysFuncCallNode::dsqlPass(DsqlCompilerScratch* dsqlScratch)
 
 	if (node->function)
 	{
+		auto& items = node->args->items;
+
+		node->function->checkArgsMismatch(items.getCount());
+
 		if (node->function->setParamsFunc)
 		{
-			Array<dsc> tempDescs(node->args->items.getCount());
-			tempDescs.resize(node->args->items.getCount());
+			Array<dsc> tempDescs(items.getCount());
+			tempDescs.resize(items.getCount());
 
-			Array<dsc*> argsArray(node->args->items.getCount());
+			Array<dsc*> argsArray(items.getCount());
 
-			for (auto& item : node->args->items)
+			for (auto& item : items)
 			{
 				DsqlDescMaker::fromNode(dsqlScratch, item);
 
@@ -12507,7 +12510,7 @@ ValueExprNode* SysFuncCallNode::dsqlPass(DsqlCompilerScratch* dsqlScratch)
 			node->function->setParamsFunc(&dataTypeUtil, node->function,
 				argsArray.getCount(), argsArray.begin());
 
-			for (auto& item : node->args->items)
+			for (auto& item : items)
 			{
 				PASS1_set_parameter_type(dsqlScratch, item,
 					[&] (dsc* desc) { *desc = item->getDsqlDesc(); },


### PR DESCRIPTION
…e setParamsFunc function (fixed crash when calling make_dbkey function with wrong number of parameters)

First, I started to deal with the segfault that occurs when calling the make_dbkey function with zero or one parameter.
For example, SELECT MAKE_DBKEY() FROM RDB$DATABASE;
The solution is simple - the setParamsMakeDbkey function does not check for the number of arguments passed (if (argsCount > 1)).

I just don't understand the current logic, why checkArgsMismatch is executed after the setParamsFunc function and not before it?
I think it is more logical to make the checkArgsMismatch check at the place where I put it in the PR. This location is more advantageous because there will be no need to do extra work in the form of calling the setParamsFunc function and other things if you know in advance that the number of arguments is incorrect. 

Also, thanks to this location, we don't need to add the “if (argsCount > 1)” check to the setParamsMakeDbKey function, which saves us from unnecessary branching. If you are happy with this solution, I can remove these checks in the existing setParams functions. 
For example, you can see such branching in the setParamsPosition function. 

I doubt about removing the checkArgsMismatch function call in SysFuncCallNode::pass2. 
I haven't found what it might affect and don't understand why it was there.