### PR TITLE
Fix a bug where the shutdown handler could be called again

### DIFF
--- a/src/remote/server/os/posix/inet_server.cpp
+++ b/src/remote/server/os/posix/inet_server.cpp
@@ -646,7 +646,7 @@ static void signal_handler(int)
 	++INET_SERVER_start;
 }
 
-static void shutdown_handler(int)
+static void shutdown_handler(int shutdown_signal_code)
 {
 /**************************************
  *
@@ -655,11 +655,13 @@ static void shutdown_handler(int)
  **************************************
  *
  * Functional description
- *	Forward sigterm signal to all child processes.
+ *	Forward shutdown signal to all child processes.
  *
  **************************************/
 
-	kill(-1 * getpid(), SIGTERM);
+	signal(shutdown_signal_code, SIG_IGN);
+
+	kill(-1 * getpid(), shutdown_signal_code);
 
 	exit(FINI_OK);
 }


### PR DESCRIPTION
Two problems have been solved:
1) Calling shutdown_handler with the SIGINT signal could have thrown the SIGTERM signal causing an unnecessary handler call. This was solved by throwing the same signal that was received.
2) Although the signal is blocked during its handler, but apparently it is marked in the signal mask and with some probability can be processed during exit. This could cause a crash. This can be solved by changing the signal disposition to ignore in the handler.