### PR TITLE
Change fb_strlen to constexpr version

### DIFF
--- a/src/common/CvtFormat.cpp
+++ b/src/common/CvtFormat.cpp
@@ -228,11 +228,6 @@ namespace
 		return std::isalpha(static_cast<unsigned char>(symbol));
 	}
 
-	constexpr size_t fb_strlen_constexpr(const char* str)
-	{
-		return std::char_traits<char>::length(str);
-	}
-
 	constexpr bool isSeparator(char symbol)
 	{
 		switch (symbol)
@@ -1512,7 +1507,7 @@ namespace
 				{
 					// This is deferred pattern
 					std::string_view period = getSubstringFromString(str, strLength, strOffset,
-						fb_strlen_constexpr(FormatStr::AM), false);
+						fb_strlen(FormatStr::AM), false);
 					deferredTokens.push_back({*it, period});
 					break;
 				}

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -51,6 +51,7 @@
 #define COMMON_COMMON_H
 
 #include <string.h>
+#include <string>
 
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
@@ -1026,9 +1027,9 @@ inline const TEXT* const FB_LONG_DAYS_UPPER[] =
 
 const FB_SIZE_T FB_MAX_SIZEOF = ~FB_SIZE_T(0); // Assume FB_SIZE_T is unsigned
 
-inline FB_SIZE_T fb_strlen(const char* str)
+inline constexpr FB_SIZE_T fb_strlen(const char* str)
 {
-	return static_cast<FB_SIZE_T>(strlen(str));
+	return static_cast<FB_SIZE_T>(std::char_traits<char>::length(str));
 }
 
 namespace Firebird {


### PR DESCRIPTION
This change allows us to use fb_strlen in constexpr functions and get the result at compile time, I don't see any downside in this change.
Source: https://devblogs.microsoft.com/oldnewthing/20221114-00/?p=107393