### PR TITLE
Improve vscode settings for debugging

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,9 @@
 	"files.insertFinalNewline": true,
 	"files.associations": {
 		"*.epp": "cpp"
+	},
+	"search.exclude":{
+		"temp/**": true,
+		"gen/**": true
 	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,4 +13,7 @@
 	},
 
 	"files.insertFinalNewline": true,
+	"files.associations": {
+		"*.epp": "cpp"
+	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,11 +8,9 @@
 	"[markdown]": {
 		"files.trimTrailingWhitespace": false
 	},
+	"files.readonlyInclude": {
+		"temp/**":true
+	},
 
 	"files.insertFinalNewline": true,
-
-	"files.exclude": {
-		"temp": true,
-		"gen": true
-	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
 		"files.trimTrailingWhitespace": false
 	},
 	"files.readonlyInclude": {
-		"temp/**":true
+		"temp/**": true
 	},
 
 	"files.insertFinalNewline": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,7 @@
 	"files.associations": {
 		"*.epp": "cpp"
 	},
-	"search.exclude":{
+	"search.exclude": {
 		"temp/**": true,
 		"gen/**": true
 	}


### PR DESCRIPTION
It is sometimes necessary to debug gpre-generated files, but this is challenging in VS Code due to the current settings. All temporary files are excluded, making it impossible to access them from the VS Code file explorer. Therefore, I propose removing the exclusion option and instead marking these files as read-only.

Excluding generated files is also inconvenient for debugging because it prevents the setup of config files.

Additionally, I have added an association for .epp files with C++. Editing them with syntax errors is less problematic than editing them as plain text.  