### PR TITLE
Add `ALTER PACKAGE BODY` and `CREATE OR ALTER PACKAGE BODY` parse rules

### DIFF
--- a/doc/sql.extensions/README.packages.txt
+++ b/doc/sql.extensions/README.packages.txt
@@ -28,7 +28,7 @@ Syntax:
         PROCEDURE <name> [( <parameters> ) [RETURNS ( <parameters> )]]
 
     <package_body> ::=
-        { CREATE | RECREATE } PACKAGE BODY <name>
+        { CREATE [OR ALTER] | ALTER | RECREATE } PACKAGE BODY <name>
         AS
         BEGIN
             [ <package_item> ... ]

--- a/src/dsql/parse-conflicts.txt
+++ b/src/dsql/parse-conflicts.txt
@@ -1,1 +1,1 @@
-115 shift/reduce conflicts, 22 reduce/reduce conflicts.
+117 shift/reduce conflicts, 22 reduce/reduce conflicts.

--- a/src/dsql/parse.y
+++ b/src/dsql/parse.y
@@ -863,6 +863,7 @@ using namespace Firebird;
 	Jrd::SetDecFloatTrapsNode* setDecFloatTrapsNode;
 	Jrd::SetBindNode* setBindNode;
 	Jrd::SessionResetNode* sessionResetNode;
+	Jrd::RecreatePackageBodyNode* recreatePackageBodyNode;
 }
 
 %include types.y
@@ -1711,6 +1712,7 @@ replace_clause
 	| FUNCTION replace_function_clause			{ $$ = $2; }
 	| TRIGGER replace_trigger_clause			{ $$ = $2; }
 	| PACKAGE replace_package_clause			{ $$ = $2; }
+	| PACKAGE BODY replace_package_body_clause	{ $$ = $3; }
 	| VIEW replace_view_clause					{ $$ = $2; }
 	| EXCEPTION replace_exception_clause		{ $$ = $2; }
 	| GENERATOR replace_sequence_clause			{ $$ = $2; }
@@ -3228,6 +3230,12 @@ package_body_item
 	;
 
 
+%type <recreatePackageBodyNode> replace_package_body_clause
+replace_package_body_clause
+	: package_body_clause
+		{ $$ = newNode<RecreatePackageBodyNode>($1); }
+	;
+
 %type <localDeclarationsNode> local_declarations_opt
 local_declarations_opt
 	: local_forward_declarations_opt local_nonforward_declarations_opt
@@ -4294,6 +4302,7 @@ alter_clause
 	| TRIGGER alter_trigger_clause			{ $$ = $2; }
 	| PROCEDURE alter_procedure_clause		{ $$ = $2; }
 	| PACKAGE alter_package_clause			{ $$ = $2; }
+	| PACKAGE BODY replace_package_body_clause	{ $$ = $3; }
 	| DATABASE
 			{ $<alterDatabaseNode>$ = newNode<AlterDatabaseNode>(); }
 		alter_db($<alterDatabaseNode>2)

--- a/src/dsql/parse.y
+++ b/src/dsql/parse.y
@@ -863,7 +863,6 @@ using namespace Firebird;
 	Jrd::SetDecFloatTrapsNode* setDecFloatTrapsNode;
 	Jrd::SetBindNode* setBindNode;
 	Jrd::SessionResetNode* sessionResetNode;
-	Jrd::RecreatePackageBodyNode* recreatePackageBodyNode;
 }
 
 %include types.y
@@ -3230,7 +3229,7 @@ package_body_item
 	;
 
 
-%type <recreatePackageBodyNode> replace_package_body_clause
+%type <ddlNode> replace_package_body_clause
 replace_package_body_clause
 	: package_body_clause
 		{ $$ = newNode<RecreatePackageBodyNode>($1); }


### PR DESCRIPTION
Hello. 
Currently, it is possible to CREATE, ALTER, or RECREATE a PACKAGE 
```SQL
set autoterm;
CREATE PACKAGE TEST_PACKAGE
AS
BEGIN
    FUNCTION DUMMY() RETURNS INT;
END;

CREATE OR ALTER PACKAGE TEST_PACKAGE
AS
BEGIN
    FUNCTION DUMMY() RETURNS INT;
END;

ALTER PACKAGE TEST_PACKAGE
AS
BEGIN
    FUNCTION DUMMY() RETURNS INT;
END;

RECREATE PACKAGE TEST_PACKAGE
AS
BEGIN
    FUNCTION DUMMY() RETURNS INT;
END;
```

However, when it comes to a package body, some operations may fail:


```SQL
set term ^;
ALTER PACKAGE BODY TEST_PACKAGE
AS
BEGIN
    FUNCTION DUMMY() RETURNS INT
    AS
    BEGIN
        RETURN 1;
    END
END^
```

This results in the following error message:

```
Statement failed, SQLSTATE = 42000
Dynamic SQL Error
-SQL error code = -104
-Token unknown - line 1, column 20
-TEST_PACKAGE
```

This is a really confusing error message. The problem is that the PACKAGE BODY does not support the ALTER or CREATE OR ALTER statements, yet the message references the package name, which can be misleading.

I think it is worth adding this parse rules to not confuse the users.
From my perspective, ALTER PACKAGE BODY is essentially equivalent to RECREATE statement, so I used the RECREATE node without changing the package code.
