### PR TITLE
Send small blobs inline.

### DIFF
--- a/src/include/fb_types.h
+++ b/src/include/fb_types.h
@@ -81,6 +81,22 @@ typedef FB_UINT64 ISC_UINT64;
 
 typedef ISC_QUAD SQUAD;
 
+const SQUAD NULL_BLOB = { 0, 0 };
+
+inline bool operator==(const SQUAD& s1, const SQUAD& s2)
+{
+	return s1.gds_quad_high == s2.gds_quad_high &&
+		   s2.gds_quad_low == s1.gds_quad_low;
+}
+
+inline bool operator>(const SQUAD& s1, const SQUAD& s2)
+{
+	return (s1.gds_quad_high > s2.gds_quad_high) ||
+		(s1.gds_quad_high == s2.gds_quad_high &&
+		 s1.gds_quad_low > s2.gds_quad_low);
+}
+
+
 /*
  * TMN: some misc data types from all over the place
  */

--- a/src/include/firebird/FirebirdInterface.idl
+++ b/src/include/firebird/FirebirdInterface.idl
@@ -521,6 +521,11 @@ version:	// 3.0 => 4.0
 version:	// 3.0.7 => 3.0.8, 4.0.0 => 4.0.1
 	[notImplementedAction if ::FB_UsedInYValve then defaultAction else call deprecatedFree(status) endif]
 	void free(Status status);
+
+version:	// 6.0
+	// Inline blob transfer
+	uint getMaxInlineBlobSize(Status status);
+	void setMaxInlineBlobSize(Status status, uint size);
 }
 
 interface Batch : ReferenceCounted
@@ -713,6 +718,15 @@ version:	// 3.0.7 => 3.0.8, 4.0.0 => 4.0.1
 	void detach(Status status);
 	[notImplementedAction if ::FB_UsedInYValve then defaultAction else call deprecatedDropDatabase(status) endif]
 	void dropDatabase(Status status);
+
+version:	// 6.0
+	// Blob caching by client
+	uint getMaxBlobCacheSize(Status status);
+	void setMaxBlobCacheSize(Status status, uint size);
+
+	// Inline blob transfer
+	uint getMaxInlineBlobSize(Status status);
+	void setMaxInlineBlobSize(Status status, uint size);
 }
 
 interface Service : ReferenceCounted

--- a/src/include/firebird/IdlFbInterfaces.h
+++ b/src/include/firebird/IdlFbInterfaces.h
@@ -1869,7 +1869,7 @@ namespace Firebird
 		}
 	};
 
-#define FIREBIRD_ISTATEMENT_VERSION 5u
+#define FIREBIRD_ISTATEMENT_VERSION 6u
 
 	class IStatement : public IReferenceCounted
 	{
@@ -1891,6 +1891,8 @@ namespace Firebird
 			void (CLOOP_CARG *setTimeout)(IStatement* self, IStatus* status, unsigned timeOut) CLOOP_NOEXCEPT;
 			IBatch* (CLOOP_CARG *createBatch)(IStatement* self, IStatus* status, IMessageMetadata* inMetadata, unsigned parLength, const unsigned char* par) CLOOP_NOEXCEPT;
 			void (CLOOP_CARG *free)(IStatement* self, IStatus* status) CLOOP_NOEXCEPT;
+			unsigned (CLOOP_CARG *getMaxInlineBlobSize)(IStatement* self, IStatus* status) CLOOP_NOEXCEPT;
+			void (CLOOP_CARG *setMaxInlineBlobSize)(IStatement* self, IStatus* status, unsigned size) CLOOP_NOEXCEPT;
 		};
 
 	protected:
@@ -2062,6 +2064,33 @@ namespace Firebird
 			}
 			StatusType::clearException(status);
 			static_cast<VTable*>(this->cloopVTable)->free(this, status);
+			StatusType::checkException(status);
+		}
+
+		template <typename StatusType> unsigned getMaxInlineBlobSize(StatusType* status)
+		{
+			if (cloopVTable->version < 6)
+			{
+				StatusType::setVersionError(status, "IStatement", cloopVTable->version, 6);
+				StatusType::checkException(status);
+				return 0;
+			}
+			StatusType::clearException(status);
+			unsigned ret = static_cast<VTable*>(this->cloopVTable)->getMaxInlineBlobSize(this, status);
+			StatusType::checkException(status);
+			return ret;
+		}
+
+		template <typename StatusType> void setMaxInlineBlobSize(StatusType* status, unsigned size)
+		{
+			if (cloopVTable->version < 6)
+			{
+				StatusType::setVersionError(status, "IStatement", cloopVTable->version, 6);
+				StatusType::checkException(status);
+				return;
+			}
+			StatusType::clearException(status);
+			static_cast<VTable*>(this->cloopVTable)->setMaxInlineBlobSize(this, status, size);
 			StatusType::checkException(status);
 		}
 	};
@@ -2499,7 +2528,7 @@ namespace Firebird
 		}
 	};
 
-#define FIREBIRD_IATTACHMENT_VERSION 5u
+#define FIREBIRD_IATTACHMENT_VERSION 6u
 
 	class IAttachment : public IReferenceCounted
 	{
@@ -2532,6 +2561,10 @@ namespace Firebird
 			IReplicator* (CLOOP_CARG *createReplicator)(IAttachment* self, IStatus* status) CLOOP_NOEXCEPT;
 			void (CLOOP_CARG *detach)(IAttachment* self, IStatus* status) CLOOP_NOEXCEPT;
 			void (CLOOP_CARG *dropDatabase)(IAttachment* self, IStatus* status) CLOOP_NOEXCEPT;
+			unsigned (CLOOP_CARG *getMaxBlobCacheSize)(IAttachment* self, IStatus* status) CLOOP_NOEXCEPT;
+			void (CLOOP_CARG *setMaxBlobCacheSize)(IAttachment* self, IStatus* status, unsigned size) CLOOP_NOEXCEPT;
+			unsigned (CLOOP_CARG *getMaxInlineBlobSize)(IAttachment* self, IStatus* status) CLOOP_NOEXCEPT;
+			void (CLOOP_CARG *setMaxInlineBlobSize)(IAttachment* self, IStatus* status, unsigned size) CLOOP_NOEXCEPT;
 		};
 
 	protected:
@@ -2798,6 +2831,60 @@ namespace Firebird
 			}
 			StatusType::clearException(status);
 			static_cast<VTable*>(this->cloopVTable)->dropDatabase(this, status);
+			StatusType::checkException(status);
+		}
+
+		template <typename StatusType> unsigned getMaxBlobCacheSize(StatusType* status)
+		{
+			if (cloopVTable->version < 6)
+			{
+				StatusType::setVersionError(status, "IAttachment", cloopVTable->version, 6);
+				StatusType::checkException(status);
+				return 0;
+			}
+			StatusType::clearException(status);
+			unsigned ret = static_cast<VTable*>(this->cloopVTable)->getMaxBlobCacheSize(this, status);
+			StatusType::checkException(status);
+			return ret;
+		}
+
+		template <typename StatusType> void setMaxBlobCacheSize(StatusType* status, unsigned size)
+		{
+			if (cloopVTable->version < 6)
+			{
+				StatusType::setVersionError(status, "IAttachment", cloopVTable->version, 6);
+				StatusType::checkException(status);
+				return;
+			}
+			StatusType::clearException(status);
+			static_cast<VTable*>(this->cloopVTable)->setMaxBlobCacheSize(this, status, size);
+			StatusType::checkException(status);
+		}
+
+		template <typename StatusType> unsigned getMaxInlineBlobSize(StatusType* status)
+		{
+			if (cloopVTable->version < 6)
+			{
+				StatusType::setVersionError(status, "IAttachment", cloopVTable->version, 6);
+				StatusType::checkException(status);
+				return 0;
+			}
+			StatusType::clearException(status);
+			unsigned ret = static_cast<VTable*>(this->cloopVTable)->getMaxInlineBlobSize(this, status);
+			StatusType::checkException(status);
+			return ret;
+		}
+
+		template <typename StatusType> void setMaxInlineBlobSize(StatusType* status, unsigned size)
+		{
+			if (cloopVTable->version < 6)
+			{
+				StatusType::setVersionError(status, "IAttachment", cloopVTable->version, 6);
+				StatusType::checkException(status);
+				return;
+			}
+			StatusType::clearException(status);
+			static_cast<VTable*>(this->cloopVTable)->setMaxInlineBlobSize(this, status, size);
 			StatusType::checkException(status);
 		}
 	};
@@ -10525,6 +10612,8 @@ namespace Firebird
 					this->setTimeout = &Name::cloopsetTimeoutDispatcher;
 					this->createBatch = &Name::cloopcreateBatchDispatcher;
 					this->free = &Name::cloopfreeDispatcher;
+					this->getMaxInlineBlobSize = &Name::cloopgetMaxInlineBlobSizeDispatcher;
+					this->setMaxInlineBlobSize = &Name::cloopsetMaxInlineBlobSizeDispatcher;
 				}
 			} vTable;
 
@@ -10751,6 +10840,35 @@ namespace Firebird
 			}
 		}
 
+		static unsigned CLOOP_CARG cloopgetMaxInlineBlobSizeDispatcher(IStatement* self, IStatus* status) CLOOP_NOEXCEPT
+		{
+			StatusType status2(status);
+
+			try
+			{
+				return static_cast<Name*>(self)->Name::getMaxInlineBlobSize(&status2);
+			}
+			catch (...)
+			{
+				StatusType::catchException(&status2);
+				return static_cast<unsigned>(0);
+			}
+		}
+
+		static void CLOOP_CARG cloopsetMaxInlineBlobSizeDispatcher(IStatement* self, IStatus* status, unsigned size) CLOOP_NOEXCEPT
+		{
+			StatusType status2(status);
+
+			try
+			{
+				static_cast<Name*>(self)->Name::setMaxInlineBlobSize(&status2, size);
+			}
+			catch (...)
+			{
+				StatusType::catchException(&status2);
+			}
+		}
+
 		static void CLOOP_CARG cloopaddRefDispatcher(IReferenceCounted* self) CLOOP_NOEXCEPT
 		{
 			try
@@ -10805,6 +10923,8 @@ namespace Firebird
 		virtual void setTimeout(StatusType* status, unsigned timeOut) = 0;
 		virtual IBatch* createBatch(StatusType* status, IMessageMetadata* inMetadata, unsigned parLength, const unsigned char* par) = 0;
 		virtual void free(StatusType* status) = 0;
+		virtual unsigned getMaxInlineBlobSize(StatusType* status) = 0;
+		virtual void setMaxInlineBlobSize(StatusType* status, unsigned size) = 0;
 	};
 
 	template <typename Name, typename StatusType, typename Base>
@@ -11630,6 +11750,10 @@ namespace Firebird
 					this->createReplicator = &Name::cloopcreateReplicatorDispatcher;
 					this->detach = &Name::cloopdetachDispatcher;
 					this->dropDatabase = &Name::cloopdropDatabaseDispatcher;
+					this->getMaxBlobCacheSize = &Name::cloopgetBlobCacheSizeDispatcher;
+					this->setMaxBlobCacheSize = &Name::cloopsetBlobCacheSizeDispatcher;
+					this->getMaxInlineBlobSize = &Name::cloopgetMaxInlineBlobSizeDispatcher;
+					this->setMaxInlineBlobSize = &Name::cloopsetMaxInlineBlobSizeDispatcher;
 				}
 			} vTable;
 
@@ -12014,6 +12138,64 @@ namespace Firebird
 			}
 		}
 
+		static unsigned CLOOP_CARG cloopgetBlobCacheSizeDispatcher(IAttachment* self, IStatus* status) CLOOP_NOEXCEPT
+		{
+			StatusType status2(status);
+
+			try
+			{
+				return static_cast<Name*>(self)->Name::getMaxBlobCacheSize(&status2);
+			}
+			catch (...)
+			{
+				StatusType::catchException(&status2);
+				return static_cast<unsigned>(0);
+			}
+		}
+
+		static void CLOOP_CARG cloopsetBlobCacheSizeDispatcher(IAttachment* self, IStatus* status, unsigned size) CLOOP_NOEXCEPT
+		{
+			StatusType status2(status);
+
+			try
+			{
+				static_cast<Name*>(self)->Name::setMaxBlobCacheSize(&status2, size);
+			}
+			catch (...)
+			{
+				StatusType::catchException(&status2);
+			}
+		}
+
+		static unsigned CLOOP_CARG cloopgetMaxInlineBlobSizeDispatcher(IAttachment* self, IStatus* status) CLOOP_NOEXCEPT
+		{
+			StatusType status2(status);
+
+			try
+			{
+				return static_cast<Name*>(self)->Name::getMaxInlineBlobSize(&status2);
+			}
+			catch (...)
+			{
+				StatusType::catchException(&status2);
+				return static_cast<unsigned>(0);
+			}
+		}
+
+		static void CLOOP_CARG cloopsetMaxInlineBlobSizeDispatcher(IAttachment* self, IStatus* status, unsigned size) CLOOP_NOEXCEPT
+		{
+			StatusType status2(status);
+
+			try
+			{
+				static_cast<Name*>(self)->Name::setMaxInlineBlobSize(&status2, size);
+			}
+			catch (...)
+			{
+				StatusType::catchException(&status2);
+			}
+		}
+
 		static void CLOOP_CARG cloopaddRefDispatcher(IReferenceCounted* self) CLOOP_NOEXCEPT
 		{
 			try
@@ -12079,6 +12261,10 @@ namespace Firebird
 		virtual IReplicator* createReplicator(StatusType* status) = 0;
 		virtual void detach(StatusType* status) = 0;
 		virtual void dropDatabase(StatusType* status) = 0;
+		virtual unsigned getMaxBlobCacheSize(StatusType* status) = 0;
+		virtual void setMaxBlobCacheSize(StatusType* status, unsigned size) = 0;
+		virtual unsigned getMaxInlineBlobSize(StatusType* status) = 0;
+		virtual void setMaxInlineBlobSize(StatusType* status, unsigned size) = 0;
 	};
 
 	template <typename Name, typename StatusType, typename Base>

--- a/src/include/firebird/impl/consts_pub.h
+++ b/src/include/firebird/impl/consts_pub.h
@@ -133,6 +133,8 @@
 #define isc_dpb_parallel_workers		 100
 #define isc_dpb_worker_attach			 101
 #define isc_dpb_owner					 102
+#define isc_dpb_max_blob_cache_size		 103
+#define isc_dpb_max_inline_blob_size	 104
 
 
 /**************************************************/

--- a/src/include/firebird/impl/inf_pub.h
+++ b/src/include/firebird/impl/inf_pub.h
@@ -189,6 +189,9 @@ enum db_info_types
 	fb_info_wire_rcv_bytes = 157,
 	fb_info_wire_roundtrips = 158,
 
+	fb_info_max_blob_cache_size = 159,
+	fb_info_max_inline_blob_size = 160,
+
 	isc_info_db_last_value   /* Leave this LAST! */
 };
 

--- a/src/include/gen/Firebird.pas
+++ b/src/include/gen/Firebird.pas
@@ -4081,6 +4081,8 @@ const
 	isc_dpb_parallel_workers = byte(100);
 	isc_dpb_worker_attach = byte(101);
 	isc_dpb_owner = byte(102);
+	isc_dpb_max_blob_cache_size = byte(103);
+	isc_dpb_max_inline_blob_size = byte(104);
 	isc_dpb_address = byte(1);
 	isc_dpb_addr_protocol = byte(1);
 	isc_dpb_addr_endpoint = byte(2);
@@ -4540,6 +4542,8 @@ const
 	fb_info_wire_snd_bytes = byte(156);
 	fb_info_wire_rcv_bytes = byte(157);
 	fb_info_wire_roundtrips = byte(158);
+	fb_info_max_blob_cache_size = byte(159);
+	fb_info_max_inline_blob_size = byte(160);
 	fb_info_crypt_encrypted = $01;
 	fb_info_crypt_process = $02;
 	fb_feature_multi_statements = byte(1);

--- a/src/include/gen/Firebird.pas
+++ b/src/include/gen/Firebird.pas
@@ -358,6 +358,8 @@ type
 	IStatement_setTimeoutPtr = procedure(this: IStatement; status: IStatus; timeOut: Cardinal); cdecl;
 	IStatement_createBatchPtr = function(this: IStatement; status: IStatus; inMetadata: IMessageMetadata; parLength: Cardinal; par: BytePtr): IBatch; cdecl;
 	IStatement_freePtr = procedure(this: IStatement; status: IStatus); cdecl;
+	IStatement_getMaxInlineBlobSizePtr = function(this: IStatement; status: IStatus): Cardinal; cdecl;
+	IStatement_setMaxInlineBlobSizePtr = procedure(this: IStatement; status: IStatus; size: Cardinal); cdecl;
 	IBatch_addPtr = procedure(this: IBatch; status: IStatus; count: Cardinal; inBuffer: Pointer); cdecl;
 	IBatch_addBlobPtr = procedure(this: IBatch; status: IStatus; length: Cardinal; inBuffer: Pointer; blobId: ISC_QUADPtr; parLength: Cardinal; par: BytePtr); cdecl;
 	IBatch_appendBlobDataPtr = procedure(this: IBatch; status: IStatus; length: Cardinal; inBuffer: Pointer); cdecl;
@@ -414,6 +416,10 @@ type
 	IAttachment_createReplicatorPtr = function(this: IAttachment; status: IStatus): IReplicator; cdecl;
 	IAttachment_detachPtr = procedure(this: IAttachment; status: IStatus); cdecl;
 	IAttachment_dropDatabasePtr = procedure(this: IAttachment; status: IStatus); cdecl;
+	IAttachment_getMaxBlobCacheSizePtr = function(this: IAttachment; status: IStatus): Cardinal; cdecl;
+	IAttachment_setMaxBlobCacheSizePtr = procedure(this: IAttachment; status: IStatus; size: Cardinal); cdecl;
+	IAttachment_getMaxInlineBlobSizePtr = function(this: IAttachment; status: IStatus): Cardinal; cdecl;
+	IAttachment_setMaxInlineBlobSizePtr = procedure(this: IAttachment; status: IStatus; size: Cardinal); cdecl;
 	IService_deprecatedDetachPtr = procedure(this: IService; status: IStatus); cdecl;
 	IService_queryPtr = procedure(this: IService; status: IStatus; sendLength: Cardinal; sendItems: BytePtr; receiveLength: Cardinal; receiveItems: BytePtr; bufferLength: Cardinal; buffer: BytePtr); cdecl;
 	IService_startPtr = procedure(this: IService; status: IStatus; spbLength: Cardinal; spb: BytePtr); cdecl;
@@ -1523,10 +1529,12 @@ type
 		setTimeout: IStatement_setTimeoutPtr;
 		createBatch: IStatement_createBatchPtr;
 		free: IStatement_freePtr;
+		getMaxInlineBlobSize: IStatement_getMaxInlineBlobSizePtr;
+		setMaxInlineBlobSize: IStatement_setMaxInlineBlobSizePtr;
 	end;
 
 	IStatement = class(IReferenceCounted)
-		const VERSION = 5;
+		const VERSION = 6;
 		const PREPARE_PREFETCH_NONE = Cardinal($0);
 		const PREPARE_PREFETCH_TYPE = Cardinal($1);
 		const PREPARE_PREFETCH_INPUT_PARAMETERS = Cardinal($2);
@@ -1557,6 +1565,8 @@ type
 		procedure setTimeout(status: IStatus; timeOut: Cardinal);
 		function createBatch(status: IStatus; inMetadata: IMessageMetadata; parLength: Cardinal; par: BytePtr): IBatch;
 		procedure free(status: IStatus);
+		function getMaxInlineBlobSize(status: IStatus): Cardinal;
+		procedure setMaxInlineBlobSize(status: IStatus; size: Cardinal);
 	end;
 
 	IStatementImpl = class(IStatement)
@@ -1579,6 +1589,8 @@ type
 		procedure setTimeout(status: IStatus; timeOut: Cardinal); virtual; abstract;
 		function createBatch(status: IStatus; inMetadata: IMessageMetadata; parLength: Cardinal; par: BytePtr): IBatch; virtual; abstract;
 		procedure free(status: IStatus); virtual; abstract;
+		function getMaxInlineBlobSize(status: IStatus): Cardinal; virtual; abstract;
+		procedure setMaxInlineBlobSize(status: IStatus; size: Cardinal); virtual; abstract;
 	end;
 
 	BatchVTable = class(ReferenceCountedVTable)
@@ -1792,10 +1804,14 @@ type
 		createReplicator: IAttachment_createReplicatorPtr;
 		detach: IAttachment_detachPtr;
 		dropDatabase: IAttachment_dropDatabasePtr;
+		getMaxBlobCacheSize: IAttachment_getMaxBlobCacheSizePtr;
+		setMaxBlobCacheSize: IAttachment_setMaxBlobCacheSizePtr;
+		getMaxInlineBlobSize: IAttachment_getMaxInlineBlobSizePtr;
+		setMaxInlineBlobSize: IAttachment_setMaxInlineBlobSizePtr;
 	end;
 
 	IAttachment = class(IReferenceCounted)
-		const VERSION = 5;
+		const VERSION = 6;
 
 		procedure getInfo(status: IStatus; itemsLength: Cardinal; items: BytePtr; bufferLength: Cardinal; buffer: BytePtr);
 		function startTransaction(status: IStatus; tpbLength: Cardinal; tpb: BytePtr): ITransaction;
@@ -1823,6 +1839,10 @@ type
 		function createReplicator(status: IStatus): IReplicator;
 		procedure detach(status: IStatus);
 		procedure dropDatabase(status: IStatus);
+		function getMaxBlobCacheSize(status: IStatus): Cardinal;
+		procedure setMaxBlobCacheSize(status: IStatus; size: Cardinal);
+		function getMaxInlineBlobSize(status: IStatus): Cardinal;
+		procedure setMaxInlineBlobSize(status: IStatus; size: Cardinal);
 	end;
 
 	IAttachmentImpl = class(IAttachment)
@@ -1856,6 +1876,10 @@ type
 		function createReplicator(status: IStatus): IReplicator; virtual; abstract;
 		procedure detach(status: IStatus); virtual; abstract;
 		procedure dropDatabase(status: IStatus); virtual; abstract;
+		function getMaxBlobCacheSize(status: IStatus): Cardinal; virtual; abstract;
+		procedure setMaxBlobCacheSize(status: IStatus; size: Cardinal); virtual; abstract;
+		function getMaxInlineBlobSize(status: IStatus): Cardinal; virtual; abstract;
+		procedure setMaxInlineBlobSize(status: IStatus; size: Cardinal); virtual; abstract;
 	end;
 
 	ServiceVTable = class(ReferenceCountedVTable)
@@ -7220,6 +7244,29 @@ begin
 	FbException.checkException(status);
 end;
 
+function IStatement.getMaxInlineBlobSize(status: IStatus): Cardinal;
+begin
+	if (vTable.version < 6) then begin
+		FbException.setVersionError(status, 'IStatement', vTable.version, 6);
+		Result := 0;
+	end
+	else begin
+		Result := StatementVTable(vTable).getMaxInlineBlobSize(Self, status);
+	end;
+	FbException.checkException(status);
+end;
+
+procedure IStatement.setMaxInlineBlobSize(status: IStatus; size: Cardinal);
+begin
+	if (vTable.version < 6) then begin
+		FbException.setVersionError(status, 'IStatement', vTable.version, 6);
+	end
+	else begin
+		StatementVTable(vTable).setMaxInlineBlobSize(Self, status, size);
+	end;
+	FbException.checkException(status);
+end;
+
 procedure IBatch.add(status: IStatus; count: Cardinal; inBuffer: Pointer);
 begin
 	BatchVTable(vTable).add(Self, status, count, inBuffer);
@@ -7651,6 +7698,52 @@ begin
 	end
 	else begin
 		AttachmentVTable(vTable).dropDatabase(Self, status);
+	end;
+	FbException.checkException(status);
+end;
+
+function IAttachment.getMaxBlobCacheSize(status: IStatus): Cardinal;
+begin
+	if (vTable.version < 6) then begin
+		FbException.setVersionError(status, 'IAttachment', vTable.version, 6);
+		Result := 0;
+	end
+	else begin
+		Result := AttachmentVTable(vTable).getMaxBlobCacheSize(Self, status);
+	end;
+	FbException.checkException(status);
+end;
+
+procedure IAttachment.setMaxBlobCacheSize(status: IStatus; size: Cardinal);
+begin
+	if (vTable.version < 6) then begin
+		FbException.setVersionError(status, 'IAttachment', vTable.version, 6);
+	end
+	else begin
+		AttachmentVTable(vTable).setMaxBlobCacheSize(Self, status, size);
+	end;
+	FbException.checkException(status);
+end;
+
+function IAttachment.getMaxInlineBlobSize(status: IStatus): Cardinal;
+begin
+	if (vTable.version < 6) then begin
+		FbException.setVersionError(status, 'IAttachment', vTable.version, 6);
+		Result := 0;
+	end
+	else begin
+		Result := AttachmentVTable(vTable).getMaxInlineBlobSize(Self, status);
+	end;
+	FbException.checkException(status);
+end;
+
+procedure IAttachment.setMaxInlineBlobSize(status: IStatus; size: Cardinal);
+begin
+	if (vTable.version < 6) then begin
+		FbException.setVersionError(status, 'IAttachment', vTable.version, 6);
+	end
+	else begin
+		AttachmentVTable(vTable).setMaxInlineBlobSize(Self, status, size);
 	end;
 	FbException.checkException(status);
 end;
@@ -11577,6 +11670,25 @@ begin
 	end
 end;
 
+function IStatementImpl_getMaxInlineBlobSizeDispatcher(this: IStatement; status: IStatus): Cardinal; cdecl;
+begin
+	Result := 0;
+	try
+		Result := IStatementImpl(this).getMaxInlineBlobSize(status);
+	except
+		on e: Exception do FbException.catchException(status, e);
+	end
+end;
+
+procedure IStatementImpl_setMaxInlineBlobSizeDispatcher(this: IStatement; status: IStatus; size: Cardinal); cdecl;
+begin
+	try
+		IStatementImpl(this).setMaxInlineBlobSize(status, size);
+	except
+		on e: Exception do FbException.catchException(status, e);
+	end
+end;
+
 var
 	IStatementImpl_vTable: StatementVTable;
 
@@ -12248,6 +12360,44 @@ procedure IAttachmentImpl_dropDatabaseDispatcher(this: IAttachment; status: ISta
 begin
 	try
 		IAttachmentImpl(this).dropDatabase(status);
+	except
+		on e: Exception do FbException.catchException(status, e);
+	end
+end;
+
+function IAttachmentImpl_getMaxBlobCacheSizeDispatcher(this: IAttachment; status: IStatus): Cardinal; cdecl;
+begin
+	Result := 0;
+	try
+		Result := IAttachmentImpl(this).getMaxBlobCacheSize(status);
+	except
+		on e: Exception do FbException.catchException(status, e);
+	end
+end;
+
+procedure IAttachmentImpl_setMaxBlobCacheSizeDispatcher(this: IAttachment; status: IStatus; size: Cardinal); cdecl;
+begin
+	try
+		IAttachmentImpl(this).setMaxBlobCacheSize(status, size);
+	except
+		on e: Exception do FbException.catchException(status, e);
+	end
+end;
+
+function IAttachmentImpl_getMaxInlineBlobSizeDispatcher(this: IAttachment; status: IStatus): Cardinal; cdecl;
+begin
+	Result := 0;
+	try
+		Result := IAttachmentImpl(this).getMaxInlineBlobSize(status);
+	except
+		on e: Exception do FbException.catchException(status, e);
+	end
+end;
+
+procedure IAttachmentImpl_setMaxInlineBlobSizeDispatcher(this: IAttachment; status: IStatus; size: Cardinal); cdecl;
+begin
+	try
+		IAttachmentImpl(this).setMaxInlineBlobSize(status, size);
 	except
 		on e: Exception do FbException.catchException(status, e);
 	end
@@ -17319,7 +17469,7 @@ initialization
 	IResultSetImpl_vTable.getInfo := @IResultSetImpl_getInfoDispatcher;
 
 	IStatementImpl_vTable := StatementVTable.create;
-	IStatementImpl_vTable.version := 5;
+	IStatementImpl_vTable.version := 6;
 	IStatementImpl_vTable.addRef := @IStatementImpl_addRefDispatcher;
 	IStatementImpl_vTable.release := @IStatementImpl_releaseDispatcher;
 	IStatementImpl_vTable.getInfo := @IStatementImpl_getInfoDispatcher;
@@ -17337,6 +17487,8 @@ initialization
 	IStatementImpl_vTable.setTimeout := @IStatementImpl_setTimeoutDispatcher;
 	IStatementImpl_vTable.createBatch := @IStatementImpl_createBatchDispatcher;
 	IStatementImpl_vTable.free := @IStatementImpl_freeDispatcher;
+	IStatementImpl_vTable.getMaxInlineBlobSize := @IStatementImpl_getMaxInlineBlobSizeDispatcher;
+	IStatementImpl_vTable.setMaxInlineBlobSize := @IStatementImpl_setMaxInlineBlobSizeDispatcher;
 
 	IBatchImpl_vTable := BatchVTable.create;
 	IBatchImpl_vTable.version := 4;
@@ -17393,7 +17545,7 @@ initialization
 	IEventsImpl_vTable.cancel := @IEventsImpl_cancelDispatcher;
 
 	IAttachmentImpl_vTable := AttachmentVTable.create;
-	IAttachmentImpl_vTable.version := 5;
+	IAttachmentImpl_vTable.version := 6;
 	IAttachmentImpl_vTable.addRef := @IAttachmentImpl_addRefDispatcher;
 	IAttachmentImpl_vTable.release := @IAttachmentImpl_releaseDispatcher;
 	IAttachmentImpl_vTable.getInfo := @IAttachmentImpl_getInfoDispatcher;
@@ -17422,6 +17574,10 @@ initialization
 	IAttachmentImpl_vTable.createReplicator := @IAttachmentImpl_createReplicatorDispatcher;
 	IAttachmentImpl_vTable.detach := @IAttachmentImpl_detachDispatcher;
 	IAttachmentImpl_vTable.dropDatabase := @IAttachmentImpl_dropDatabaseDispatcher;
+	IAttachmentImpl_vTable.getMaxBlobCacheSize := @IAttachmentImpl_getMaxBlobCacheSizeDispatcher;
+	IAttachmentImpl_vTable.setMaxBlobCacheSize := @IAttachmentImpl_setMaxBlobCacheSizeDispatcher;
+	IAttachmentImpl_vTable.getMaxInlineBlobSize := @IAttachmentImpl_getMaxInlineBlobSizeDispatcher;
+	IAttachmentImpl_vTable.setMaxInlineBlobSize := @IAttachmentImpl_setMaxInlineBlobSizeDispatcher;
 
 	IServiceImpl_vTable := ServiceVTable.create;
 	IServiceImpl_vTable.version := 5;

--- a/src/jrd/EngineInterface.h
+++ b/src/jrd/EngineInterface.h
@@ -307,6 +307,9 @@ public:
 	JBatch* createBatch(Firebird::CheckStatusWrapper* status, Firebird::IMessageMetadata* inMetadata,
 		unsigned parLength, const unsigned char* par) override;
 
+	unsigned getMaxInlineBlobSize(Firebird::CheckStatusWrapper* status) override;
+	void setMaxInlineBlobSize(Firebird::CheckStatusWrapper* status, unsigned size) override;
+
 public:
 	JStatement(DsqlRequest* handle, StableAttachmentPart* sa, Firebird::Array<UCHAR>& meta);
 
@@ -460,6 +463,10 @@ public:
 		Firebird::IMessageMetadata* inMetadata, unsigned parLength, const unsigned char* par) override;
 	Firebird::IReplicator* createReplicator(Firebird::CheckStatusWrapper* status) override;
 
+	unsigned getMaxBlobCacheSize(Firebird::CheckStatusWrapper* status) override;
+	void setMaxBlobCacheSize(Firebird::CheckStatusWrapper* status, unsigned size) override;
+	unsigned getMaxInlineBlobSize(Firebird::CheckStatusWrapper* status) override;
+	void setMaxInlineBlobSize(Firebird::CheckStatusWrapper* status, unsigned size) override;
 public:
 	explicit JAttachment(StableAttachmentPart* js);
 

--- a/src/jrd/jrd.cpp
+++ b/src/jrd/jrd.cpp
@@ -5308,6 +5308,28 @@ IReplicator* JAttachment::createReplicator(CheckStatusWrapper* user_status)
 	return jr;
 }
 
+unsigned JAttachment::getMaxBlobCacheSize(CheckStatusWrapper* status)
+{
+	status->setErrors(Arg::Gds(isc_wish_list).value());
+	return 0;
+}
+
+void JAttachment::setMaxBlobCacheSize(CheckStatusWrapper* status, unsigned size)
+{
+	status->setErrors(Arg::Gds(isc_wish_list).value());
+}
+
+unsigned JAttachment::getMaxInlineBlobSize(CheckStatusWrapper* status)
+{
+	status->setErrors(Arg::Gds(isc_wish_list).value());
+	return 0;
+}
+
+void JAttachment::setMaxInlineBlobSize(CheckStatusWrapper* status, unsigned size)
+{
+	status->setErrors(Arg::Gds(isc_wish_list).value());
+}
+
 
 int JResultSet::fetchNext(CheckStatusWrapper* user_status, void* buffer)
 {
@@ -6088,6 +6110,17 @@ JBatch* JStatement::createBatch(Firebird::CheckStatusWrapper* status, Firebird::
 
 	successful_completion(status);
 	return batch;
+}
+
+unsigned JStatement::getMaxInlineBlobSize(CheckStatusWrapper* status)
+{
+	status->setErrors(Arg::Gds(isc_wish_list).value());
+	return 0;
+}
+
+void JStatement::setMaxInlineBlobSize(CheckStatusWrapper* status, unsigned size)
+{
+	status->setErrors(Arg::Gds(isc_wish_list).value());
 }
 
 

--- a/src/remote/client/interface.cpp
+++ b/src/remote/client/interface.cpp
@@ -1866,7 +1866,7 @@ IBlob* Attachment::createBlob(CheckStatusWrapper* status, ITransaction* apiTra, 
 		p_blob->p_blob_bpb.cstr_length = 0;
 		p_blob->p_blob_bpb.cstr_address = NULL;
 
-		Rbl* blob = FB_NEW Rbl();
+		Rbl* blob = FB_NEW Rbl(BLOB_LENGTH);
 		blob->rbl_blob_id = *blob_id = packet->p_resp.p_resp_blob_id;
 		blob->rbl_rdb = rdb;
 		blob->rbl_rtr = transaction;
@@ -6009,7 +6009,7 @@ IBlob* Attachment::openBlob(CheckStatusWrapper* status, ITransaction* apiTra, IS
 		//p_blob->p_blob_bpb.cstr_length = 0;
 		//p_blob->p_blob_bpb.cstr_address = NULL;
 
-		Rbl* blob = FB_NEW Rbl;
+		Rbl* blob = FB_NEW Rbl(BLOB_LENGTH);
 		blob->rbl_rdb = rdb;
 		blob->rbl_rtr = transaction;
 		blob->rbl_blob_id = *id;
@@ -9486,7 +9486,7 @@ static void release_blob( Rbl* blob)
 	if (blob->isCached())
 	{
 		// Assume buffer was not resized while blob was cached
-		rdb->decBlobCache(blob->rbl_data.getCapacity());
+		rdb->decBlobCache(blob->getCachedSize());
 	}
 	else
 		rdb->rdb_port->releaseObject(blob->rbl_id);

--- a/src/remote/client/interface.cpp
+++ b/src/remote/client/interface.cpp
@@ -9363,8 +9363,10 @@ static void release_blob( Rbl* blob)
 	Rdb* rdb = blob->rbl_rdb;
 
 	if (blob->isCached())
+	{
 		// Assume buffer was not resized while blob was cached
 		rdb->decBlobCache(blob->rbl_buffer_length);
+	}
 	else
 		rdb->rdb_port->releaseObject(blob->rbl_id);
 

--- a/src/remote/parser.cpp
+++ b/src/remote/parser.cpp
@@ -161,8 +161,9 @@ static rem_fmt* parse_format(const UCHAR*& blr, size_t& blr_length)
 
 	ULONG net_length = 0;
 	ULONG offset = 0;
+	dsc* const begin = format->fmt_desc.begin();
 
-	for (dsc* desc = format->fmt_desc.begin(); count; --count, ++desc)
+	for (dsc* desc = begin; count; --count, ++desc)
 	{
 		if (blr_length-- == 0)
 			return NULL;
@@ -262,6 +263,8 @@ static rem_fmt* parse_format(const UCHAR*& blr, size_t& blr_length)
 			desc->dsc_dtype = dtype_quad;
 			desc->dsc_length = sizeof(SLONG) * 2;
 			desc->dsc_scale = *blr++;
+
+			format->fmt_blob_idx.add(desc - begin);
 			break;
 
 		case blr_float:
@@ -312,6 +315,8 @@ static rem_fmt* parse_format(const UCHAR*& blr, size_t& blr_length)
 				USHORT textType = *blr++;
 				textType += (*blr++) << 8;
 				desc->setTextType(textType);
+
+				format->fmt_blob_idx.add(desc - begin);
 			}
 			break;
 

--- a/src/remote/protocol.cpp
+++ b/src/remote/protocol.cpp
@@ -670,6 +670,8 @@ bool_t xdr_protocol(RemoteXdr* xdrs, PACKET* p)
 			MAP(xdr_u_long, sqldata->p_sqldata_timeout);
 		if (port->port_protocol >= PROTOCOL_FETCH_SCROLL)
 			MAP(xdr_u_long, sqldata->p_sqldata_cursor_flags);
+		if (port->port_protocol >= PROTOCOL_INLINE_BLOB)
+			MAP(xdr_u_long, sqldata->p_sqldata_inline_blob_size);
 		DEBUG_PRINTSIZE(xdrs, p->p_operation);
 		return P_TRUE(xdrs, p);
 
@@ -691,6 +693,10 @@ bool_t xdr_protocol(RemoteXdr* xdrs, PACKET* p)
 			return P_FALSE(xdrs, p);
 		}
 		MAP(xdr_short, reinterpret_cast<SSHORT&>(prep_stmt->p_sqlst_out_message_number));
+
+		if (port->port_protocol >= PROTOCOL_INLINE_BLOB)
+			MAP(xdr_u_long, prep_stmt->p_sqlst_inline_blob_size);
+
 		// Fall into ...
 
 	case op_exec_immediate:

--- a/src/remote/protocol.cpp
+++ b/src/remote/protocol.cpp
@@ -120,7 +120,9 @@ static bool_t xdr_trrq_blr(RemoteXdr*, CSTRING*);
 static bool_t xdr_trrq_message(RemoteXdr*, USHORT);
 static bool_t xdr_bytes(RemoteXdr*, void*, ULONG);
 static bool_t xdr_blob_stream(RemoteXdr*, SSHORT, CSTRING*);
+static bool_t xdr_blobBuffer(RemoteXdr* xdrs, RemBlobBuffer* buff);
 static Rsr* getStatement(RemoteXdr*, USHORT);
+static Rtr* getTransaction(RemoteXdr*, USHORT);
 
 
 inline void fixupLength(const RemoteXdr* xdrs, ULONG& length)
@@ -1134,6 +1136,42 @@ bool_t xdr_protocol(RemoteXdr* xdrs, PACKET* p)
 			MAP(xdr_short, reinterpret_cast<SSHORT&>(repl->p_repl_database));
 			MAP(xdr_cstring_const, repl->p_repl_data);
 			DEBUG_PRINTSIZE(xdrs, p->p_operation);
+
+			return P_TRUE(xdrs, p);
+		}
+
+	case op_inline_blob:
+		{
+			P_INLINE_BLOB* p_blob = &p->p_inline_blob;
+			MAP(xdr_short, reinterpret_cast<SSHORT&>(p_blob->p_tran_id));
+			MAP(xdr_quad, p_blob->p_blob_id);
+
+			if (xdrs->x_op == XDR_ENCODE)
+			{
+				MAP(xdr_response, p_blob->p_blob_info);
+				if (!xdr_blobBuffer(xdrs, p_blob->p_blob_data))
+					return P_FALSE(xdrs, p);
+			}
+			else if (xdrs->x_op == XDR_DECODE)
+			{
+				Rtr* tran = getTransaction(xdrs, p_blob->p_tran_id);
+
+				if (!tran)
+					return P_FALSE(xdrs, p);
+
+				MAP(xdr_response, p_blob->p_blob_info);
+
+				Rbl* blb = tran->createInlineBlob();
+				p_blob->p_blob_data = &blb->rbl_data;
+
+				if (!xdr_blobBuffer(xdrs, p_blob->p_blob_data))
+				{
+					tran->rtr_inline_blob = nullptr;
+					delete blb;
+
+					return P_FALSE(xdrs, p);
+				}
+			}
 
 			return P_TRUE(xdrs, p);
 		}
@@ -2274,6 +2312,23 @@ static Rsr* getStatement(RemoteXdr* xdrs, USHORT statement_id)
 	return port->port_statement;
 }
 
+static Rtr* getTransaction(RemoteXdr* xdrs, USHORT tran_id)
+{
+	rem_port* port = xdrs->x_public;
+
+	if (tran_id >= port->port_objects.getCount())
+		return nullptr;
+
+	try
+	{
+		return port->port_objects[tran_id];
+	}
+	catch (const status_exception&)
+	{
+		return nullptr;
+	}
+}
+
 static bool_t xdr_blob_stream(RemoteXdr* xdrs, SSHORT statement_id, CSTRING* strmPortion)
 {
 	if (xdrs->x_op == XDR_FREE)
@@ -2491,4 +2546,54 @@ private:
 	statement->rsr_batch_stream = localStrm;
 
 	return TRUE;
+}
+
+static bool_t xdr_blobBuffer(RemoteXdr* xdrs, RemBlobBuffer* buff)
+{
+	SLONG len;
+	UCHAR* data;
+	static const SCHAR filler[4] = { 0, 0, 0, 0 };
+
+	switch (xdrs->x_op)
+	{
+	case XDR_ENCODE:
+		len = buff->getCount();
+		if (!xdr_long(xdrs, &len))
+			return FALSE;
+
+		data = buff->begin();
+		if (len && !xdrs->x_putbytes(reinterpret_cast<const SCHAR*>(data), len))
+			return FALSE;
+
+		len = (4 - len) & 3;
+		if (len)
+			return xdrs->x_putbytes(filler, len);
+
+		return TRUE;
+
+	case XDR_DECODE:
+		if (!xdr_long(xdrs, &len))
+			return FALSE;
+
+		if (len)
+		{
+			data = buff->getBuffer(len);
+			if (!xdrs->x_getbytes(reinterpret_cast<SCHAR*>(data), len))
+				return FALSE;
+		}
+
+		len = (4 - len) & 3;
+		if (len)
+		{
+			SCHAR trash[4];
+			return xdrs->x_getbytes(trash, len);
+		}
+
+		return TRUE;
+
+	case XDR_FREE:
+		return TRUE;
+	}
+
+	return FALSE;
 }

--- a/src/remote/protocol.cpp
+++ b/src/remote/protocol.cpp
@@ -1167,16 +1167,15 @@ bool_t xdr_protocol(RemoteXdr* xdrs, PACKET* p)
 
 				MAP(xdr_response, p_blob->p_blob_info);
 
-				Rbl* blb = tran->createInlineBlob();
+				AutoPtr<Rbl> blb = tran->createInlineBlob();
 				p_blob->p_blob_data = &blb->rbl_data;
 
 				if (!xdr_blobBuffer(xdrs, p_blob->p_blob_data))
 				{
 					tran->rtr_inline_blob = nullptr;
-					delete blb;
-
 					return P_FALSE(xdrs, p);
 				}
+				blb.release();
 			}
 
 			return P_TRUE(xdrs, p);

--- a/src/remote/protocol.h
+++ b/src/remote/protocol.h
@@ -630,6 +630,7 @@ typedef struct p_sqlst
     CSTRING	p_sqlst_out_blr;			// blr describing output message
     USHORT	p_sqlst_out_message_number;
 	USHORT	p_sqlst_flags;				// prepare flags
+	ULONG	p_sqlst_inline_blob_size;	// maximum size of inlined blob
 } P_SQLST;
 
 typedef struct p_sqldata
@@ -647,6 +648,7 @@ typedef struct p_sqldata
 	ULONG	p_sqldata_cursor_flags;		// cursor flags
 	P_FETCH	p_sqldata_fetch_op;			// Fetch operation
 	SLONG	p_sqldata_fetch_pos;		// Fetch position
+	ULONG	p_sqldata_inline_blob_size;	// maximum size of inlined blob
 } P_SQLDATA;
 
 typedef struct p_sqlfree

--- a/src/remote/protocol.h
+++ b/src/remote/protocol.h
@@ -38,6 +38,9 @@ namespace Firebird {
 	class DynamicStatusVector;
 }
 
+class RemBlobBuffer;	// see remote.h
+
+
 // dimitr: ask for asymmetric protocols only.
 // Comment it out to return back to FB 1.0 behaviour.
 #define ASYMMETRIC_PROTOCOLS_ONLY
@@ -106,8 +109,10 @@ const USHORT PROTOCOL_FETCH_SCROLL = PROTOCOL_VERSION18;
 
 // Protocol 19:
 //	- supports passing flags to IStatement::prepare
+//	- supports op_inline_blob
 
 const USHORT PROTOCOL_VERSION19 = (FB_PROTOCOL_FLAG | 19);
+const USHORT PROTOCOL_INLINE_BLOB = PROTOCOL_VERSION19;
 
 // Architecture types
 
@@ -323,6 +328,8 @@ enum P_OP
 
 	op_fetch_scroll			= 112,
 	op_info_cursor			= 113,
+
+	op_inline_blob			= 114,
 
 	op_max
 };
@@ -766,6 +773,14 @@ typedef struct p_replicate
      CSTRING_CONST	p_repl_data;		// replication data
 } P_REPLICATE;
 
+typedef struct p_inline_blob
+{
+	OBJCT			p_tran_id;			// transaction id
+	SQUAD			p_blob_id;			// blob id
+	CSTRING			p_blob_info;		// blob info
+	RemBlobBuffer*	p_blob_data;		// blob data
+} P_INLINE_BLOB;
+
 
 // Generalize packet (sic!)
 
@@ -819,6 +834,7 @@ typedef struct packet
 	P_BATCH_REGBLOB p_batch_regblob;	// Register already existing BLOB in batch
 	P_BATCH_SETBPB p_batch_setbpb;		// Set default BPB for batch
 	P_REPLICATE p_replicate;	// replicate
+	P_INLINE_BLOB p_inline_blob;		// inline blob
 
 public:
 	packet()

--- a/src/remote/remote.cpp
+++ b/src/remote/remote.cpp
@@ -963,7 +963,7 @@ Rbl* Rtr::createInlineBlob()
 {
 	fb_assert(!rtr_inline_blob);
 
-	Rbl* blb = FB_NEW Rbl;
+	Rbl* blb = FB_NEW Rbl(0);
 
 	blb->rbl_rdb = rtr_rdb;
 	blb->rbl_rtr = this;
@@ -989,7 +989,7 @@ void Rtr::setupInlineBlob(P_INLINE_BLOB* p_blob)
 	fb_assert(blb->rbl_data.getCount() <= MAX_USHORT);
 
 	blb->rbl_buffer_length = MIN(MAX_USHORT, blb->rbl_data.getCapacity());
-	if (!rtr_rdb->incBlobCache(blb->rbl_data.getCapacity()))
+	if (!rtr_rdb->incBlobCache(blb->getCachedSize()))
 	{
 		delete blb;
 		return;
@@ -1005,7 +1005,7 @@ void Rtr::setupInlineBlob(P_INLINE_BLOB* p_blob)
 		fb_assert(blb != old);
 		delete blb;
 
-		rtr_rdb->decBlobCache(blb->rbl_data.getCapacity());
+		rtr_rdb->decBlobCache(blb->getCachedSize());
 		return;
 	}
 

--- a/src/remote/remote.cpp
+++ b/src/remote/remote.cpp
@@ -959,6 +959,52 @@ void Rrq::saveStatus(IStatus* v) noexcept
 	}
 }
 
+Rbl* Rtr::createInlineBlob()
+{
+	fb_assert(!rtr_inline_blob);
+
+	Rbl* blb = FB_NEW Rbl;
+
+	blb->rbl_rdb = rtr_rdb;
+	blb->rbl_rtr = this;
+
+	blb->rbl_id = INVALID_OBJECT;
+	//SET_OBJECT(rdb, blb, blb->rbl_id);
+
+	blb->rbl_flags |= Rbl::CACHED;
+
+	rtr_inline_blob = blb;
+	return blb;
+};
+
+void Rtr::setupInlineBlob(P_INLINE_BLOB* p_blob)
+{
+	fb_assert(p_blob->p_tran_id == this->rtr_id);
+	fb_assert(rtr_inline_blob);
+
+	Rbl* blb = rtr_inline_blob;
+	rtr_inline_blob = nullptr;
+
+	blb->rbl_blob_id = p_blob->p_blob_id;
+	if (!rtr_blobs.add(blb))
+	{
+		// Blob with the same blob id already exists. It could be in use, or it
+		// could be opened by user explicitly with custom BPB - thus delete new one.
+		Rbl* old = rtr_blobs.current();
+
+		fb_assert(blb != old);
+		delete blb;
+
+		return;
+	}
+
+	blb->rbl_info.parseInfo(p_blob->p_blob_info.cstr_length, p_blob->p_blob_info.cstr_address);
+
+	blb->rbl_length = blb->rbl_data.getCount();
+	blb->rbl_ptr = blb->rbl_buffer = blb->rbl_data.begin();
+	blb->rbl_flags |= Rbl::EOF_PENDING;
+}
+
 void Rsr::saveException(const Exception& ex, bool overwrite)
 {
 	if (!rsr_status) {

--- a/src/remote/remote.cpp
+++ b/src/remote/remote.cpp
@@ -985,6 +985,13 @@ void Rtr::setupInlineBlob(P_INLINE_BLOB* p_blob)
 	Rbl* blb = rtr_inline_blob;
 	rtr_inline_blob = nullptr;
 
+	blb->rbl_buffer_length = blb->rbl_data.getCapacity();
+	if (!rtr_rdb->incBlobCache(blb->rbl_buffer_length))
+	{
+		delete blb;
+		return;
+	}
+
 	blb->rbl_blob_id = p_blob->p_blob_id;
 	if (!rtr_blobs.add(blb))
 	{
@@ -995,6 +1002,7 @@ void Rtr::setupInlineBlob(P_INLINE_BLOB* p_blob)
 		fb_assert(blb != old);
 		delete blb;
 
+		rtr_rdb->decBlobCache(blb->rbl_buffer_length);
 		return;
 	}
 

--- a/src/remote/remote.cpp
+++ b/src/remote/remote.cpp
@@ -985,8 +985,11 @@ void Rtr::setupInlineBlob(P_INLINE_BLOB* p_blob)
 	Rbl* blb = rtr_inline_blob;
 	rtr_inline_blob = nullptr;
 
-	blb->rbl_buffer_length = blb->rbl_data.getCapacity();
-	if (!rtr_rdb->incBlobCache(blb->rbl_buffer_length))
+	fb_assert(blb->rbl_data.getCount() <= MAX_INLINE_BLOB_SIZE);
+	fb_assert(blb->rbl_data.getCount() <= MAX_USHORT);
+
+	blb->rbl_buffer_length = MIN(MAX_USHORT, blb->rbl_data.getCapacity());
+	if (!rtr_rdb->incBlobCache(blb->rbl_data.getCapacity()))
 	{
 		delete blb;
 		return;
@@ -1002,7 +1005,7 @@ void Rtr::setupInlineBlob(P_INLINE_BLOB* p_blob)
 		fb_assert(blb != old);
 		delete blb;
 
-		rtr_rdb->decBlobCache(blb->rbl_buffer_length);
+		rtr_rdb->decBlobCache(blb->rbl_data.getCapacity());
 		return;
 	}
 

--- a/src/remote/remote.h
+++ b/src/remote/remote.h
@@ -283,9 +283,9 @@ struct RBlobInfo
 };
 
 // Used in XDR
-class RemBlobBuffer : public Firebird::HalfStaticArray<UCHAR, BLOB_LENGTH>
+class RemBlobBuffer : public Firebird::Array<UCHAR>
 {
-	using Firebird::HalfStaticArray<UCHAR, BLOB_LENGTH>::HalfStaticArray;
+	using Firebird::Array<UCHAR>::Array;
 };
 
 struct Rbl : public Firebird::GlobalStorage, public TypedHandle<rem_type_rbl>
@@ -319,11 +319,11 @@ public:
 	};
 
 public:
-	Rbl() :
+	Rbl(unsigned int initialSize) :
 		rbl_data(getPool()), rbl_rdb(0), rbl_rtr(0),
-		rbl_buffer(rbl_data.getBuffer(BLOB_LENGTH)), rbl_ptr(rbl_buffer), rbl_iface(NULL),
+		rbl_buffer(rbl_data.getBuffer(initialSize)), rbl_ptr(rbl_buffer), rbl_iface(NULL),
 		rbl_blob_id(NULL_BLOB), rbl_offset(0), rbl_id(0), rbl_flags(0),
-		rbl_buffer_length(BLOB_LENGTH), rbl_length(0), rbl_fragment_length(0),
+		rbl_buffer_length(initialSize), rbl_length(0), rbl_fragment_length(0),
 		rbl_source_interp(0), rbl_target_interp(0), rbl_self(NULL)
 	{ }
 
@@ -339,6 +339,7 @@ public:
 	static ISC_STATUS badHandle() { return isc_bad_segstr_handle; }
 
 	bool isCached() const { return rbl_flags & CACHED; }
+	unsigned getCachedSize() const { return sizeof(Rbl) + rbl_data.getCapacity(); }
 
 	static const SQUAD& generate(const void*, const Rbl* item) { return item->rbl_blob_id; }
 };

--- a/src/remote/remote.h
+++ b/src/remote/remote.h
@@ -193,21 +193,6 @@ public:
 };
 
 
-const SQUAD NULL_BLOB = {0, 0};
-
-inline bool operator==(const SQUAD& s1, const SQUAD& s2)
-{
-	return s1.gds_quad_high == s2.gds_quad_high &&
-		s2.gds_quad_low == s1.gds_quad_low;
-}
-
-inline bool operator>(const SQUAD& s1, const SQUAD& s2)
-{
-	return s1.gds_quad_high > s2.gds_quad_high ||
-		s1.gds_quad_high == s2.gds_quad_high &&
-		s1.gds_quad_low > s2.gds_quad_low;
-}
-
 struct Rtr : public Firebird::GlobalStorage, public TypedHandle<rem_type_rtr>
 {
 	using BlobsTree = Firebird::BePlusTree<struct Rbl*, SQUAD, MemoryPool, struct Rbl>;
@@ -268,10 +253,7 @@ struct RBlobInfo
 // Used in XDR
 class RemBlobBuffer : public Firebird::HalfStaticArray<UCHAR, BLOB_LENGTH>
 {
-public:
-	RemBlobBuffer(Firebird::MemoryPool& pool) :
-		Firebird::HalfStaticArray<UCHAR, BLOB_LENGTH>(pool)
-	{}
+	using Firebird::HalfStaticArray<UCHAR, BLOB_LENGTH>::HalfStaticArray;
 };
 
 struct Rbl : public Firebird::GlobalStorage, public TypedHandle<rem_type_rbl>

--- a/src/remote/remote.h
+++ b/src/remote/remote.h
@@ -42,7 +42,6 @@
 #include "../common/StatusHolder.h"
 #include "../common/classes/RefCounted.h"
 #include "../common/classes/GetPlugins.h"
-#include "../common/classes/RefMutex.h"
 
 #include "firebird/Interface.h"
 
@@ -93,7 +92,6 @@ const int BLOB_LENGTH		= 16384;
 
 #include "../remote/protocol.h"
 #include "fb_blk.h"
-#include "firebird/Interface.h"
 
 // Prefetch constants
 
@@ -105,7 +103,9 @@ const ULONG MAX_ROWS_PER_BATCH = 1000;
 const ULONG MAX_BATCH_CACHE_SIZE = 1024 * 1024; // 1 MB
 
 const ULONG	DEFAULT_BLOBS_CACHE_SIZE = 10 * 1024 * 1024;	// 10 MB
-const ULONG	DEFAULT_INLINE_BLOB_SIZE = BLOB_LENGTH;
+
+const ULONG	MAX_INLINE_BLOB_SIZE = MAX_USHORT;
+const ULONG	DEFAULT_INLINE_BLOB_SIZE = MAX_USHORT;
 
 // fwd. decl.
 namespace Firebird {

--- a/src/remote/server/server.cpp
+++ b/src/remote/server/server.cpp
@@ -6094,13 +6094,17 @@ bool rem_port::sendInlineBlob(PACKET* sendL, Rtr* rtr, SQUAD blobId, ULONG maxSi
 	if (!total_length)
 		return true;
 
-	if (total_length > maxSize)
-		return true;
-
 	if (!segmented)
 		num_segments = (total_length + max_segment - 1) / max_segment;
 
 	const ULONG dataLen = total_length + num_segments * 2;
+
+	fb_assert(maxSize <= MAX_INLINE_BLOB_SIZE);
+	if (maxSize > MAX_INLINE_BLOB_SIZE)
+		maxSize = MAX_INLINE_BLOB_SIZE;
+
+	if (dataLen > maxSize)
+		return true;
 
 	RemBlobBuffer buff(getPool());
 

--- a/src/remote/server/server.cpp
+++ b/src/remote/server/server.cpp
@@ -6011,7 +6011,7 @@ void rem_port::sendInlineBlobs(PACKET* sendL, Rtr* rtr, UCHAR* message, const re
 	const auto& descs = format->fmt_desc;
 	for (unsigned ind : format->fmt_blob_idx)
 	{
-		const auto offs = (ULONG) (UINT_PTR) descs[ind].dsc_address;
+		const auto offs = (ULONG) (U_IPTR) descs[ind].dsc_address;
 		const auto blobId = (ISC_QUAD*) (message + offs);
 		if (*blobId == NULL_BLOB)
 			continue;

--- a/src/remote/server/server.cpp
+++ b/src/remote/server/server.cpp
@@ -4825,7 +4825,7 @@ ISC_STATUS rem_port::open_blob(P_OP op, P_BLOB* stuff, PACKET* sendL)
 	USHORT object = 0;
 	if (!(status_vector.getState() & IStatus::STATE_ERRORS))
 	{
-		Rbl* blob = FB_NEW Rbl;
+		Rbl* blob = FB_NEW Rbl(BLOB_LENGTH);
 #ifdef DEBUG_REMOTE_MEMORY
 		printf("open_blob(server)         allocate blob    %x\n", blob);
 #endif

--- a/src/remote/server/server.cpp
+++ b/src/remote/server/server.cpp
@@ -54,6 +54,7 @@
 #include "../common/isc_proto.h"
 #include "../jrd/constants.h"
 #include "firebird/impl/inf_pub.h"
+#include "../common/classes/auto.h"
 #include "../common/classes/init.h"
 #include "../common/classes/semaphore.h"
 #include "../common/classes/ClumpletWriter.h"
@@ -3511,6 +3512,9 @@ ISC_STATUS rem_port::execute_immediate(P_OP op, P_SQLST * exnow, PACKET* sendL)
 	{
 		this->port_statement->rsr_format = this->port_statement->rsr_select_format;
 
+		if (out_msg)
+			sendInlineBlobs(sendL, transaction, out_msg, port_statement->rsr_select_format);
+
 		sendL->p_operation = op_sql_response;
 		sendL->p_sqldata.p_sqldata_messages =
 			((status_vector.getState() & IStatus::STATE_ERRORS) || !out_msg) ? 0 : 1;
@@ -3950,6 +3954,9 @@ ISC_STATUS rem_port::execute_statement(P_OP op, P_SQLDATA* sqldata, PACKET* send
 	{
 		this->port_statement->rsr_format = this->port_statement->rsr_select_format;
 
+		if (out_msg)
+			sendInlineBlobs(sendL, transaction, out_msg, port_statement->rsr_select_format);
+
 		sendL->p_operation = op_sql_response;
 		sendL->p_sqldata.p_sqldata_messages =
 			((status_vector.getState() & IStatus::STATE_ERRORS) || !out_msg) ? 0 : 1;
@@ -4246,6 +4253,15 @@ ISC_STATUS rem_port::fetch(P_SQLDATA * sqldata, PACKET* sendL, bool scroll)
 			// Take a message from the outqoing queue
 			fb_assert(statement->rsr_msgs_waiting >= 1);
 			statement->rsr_msgs_waiting--;
+		}
+
+		// send blob data inline
+		if (statement->haveBlobs())
+		{
+			AutoSaveRestore op(&sendL->p_operation);
+
+			sendInlineBlobs(sendL, statement->rsr_rtr, message->msg_buffer,
+				statement->rsr_select_format);
 		}
 
 		// There's a buffer waiting -- send it
@@ -4807,14 +4823,14 @@ ISC_STATUS rem_port::open_blob(P_OP op, P_BLOB* stuff, PACKET* sendL)
 #ifdef DEBUG_REMOTE_MEMORY
 		printf("open_blob(server)         allocate blob    %x\n", blob);
 #endif
+		blob->rbl_blob_id = stuff->p_blob_id;
 		blob->rbl_iface = iface;
 		blob->rbl_rdb = rdb;
 		if (blob->rbl_id = this->get_id(blob))
 		{
 			object = blob->rbl_id;
 			blob->rbl_rtr = transaction;
-			blob->rbl_next = transaction->rtr_blobs;
-			transaction->rtr_blobs = blob;
+			transaction->rtr_blobs.add(blob);
 		}
 		else
 		{
@@ -5777,14 +5793,8 @@ static void release_blob(Rbl* blob)
 
 	rdb->rdb_port->releaseObject(blob->rbl_id);
 
-	for (Rbl** p = &transaction->rtr_blobs; *p; p = &(*p)->rbl_next)
-	{
-		if (*p == blob)
-		{
-			*p = blob->rbl_next;
-			break;
-		}
-	}
+	if (transaction->rtr_blobs.locate(blob->rbl_blob_id))
+		transaction->rtr_blobs.fastRemove();
 
 #ifdef DEBUG_REMOTE_MEMORY
 	printf("release_blob(server)      free blob        %x\n", blob);
@@ -5930,8 +5940,8 @@ static void release_transaction( Rtr* transaction)
 	Rdb* rdb = transaction->rtr_rdb;
 	rdb->rdb_port->releaseObject(transaction->rtr_id);
 
-	while (transaction->rtr_blobs)
-		release_blob(transaction->rtr_blobs);
+	while (transaction->rtr_blobs.getFirst())
+		release_blob(transaction->rtr_blobs.current());
 
 	while (transaction->rtr_cursors.hasData())
 	{
@@ -5983,6 +5993,137 @@ ISC_STATUS rem_port::seek_blob(P_SEEK* seek, PACKET* sendL)
 	sendL->p_resp.p_resp_blob_id.gds_quad_low = result;
 
 	return this->send_response(sendL, 0, 0, &status_vector, false);
+}
+
+
+void rem_port::sendInlineBlobs(PACKET* sendL, Rtr* rtr, UCHAR* message, const rem_fmt* format)
+{
+	if (port_protocol < PROTOCOL_INLINE_BLOB || port_type == XNET)
+		return;
+
+	fb_assert(format && message);
+
+	if (!format || !format->haveBlobs() || !message)
+		return;
+
+	sendL->p_operation = op_inline_blob;
+
+	const auto& descs = format->fmt_desc;
+	for (unsigned ind : format->fmt_blob_idx)
+	{
+		const auto offs = (ULONG) (UINT_PTR) descs[ind].dsc_address;
+		const auto blobId = (ISC_QUAD*) (message + offs);
+		if (*blobId == NULL_BLOB)
+			continue;
+
+		if (!sendInlineBlob(sendL, rtr, *blobId))
+			break;
+	}
+}
+
+
+bool rem_port::sendInlineBlob(PACKET* sendL, Rtr* rtr, SQUAD blobId)
+{
+	P_INLINE_BLOB* p_blob = &sendL->p_inline_blob;
+
+	p_blob->p_tran_id = rtr->rtr_id;
+	p_blob->p_blob_id = blobId;
+
+	LocalStatus ls;
+	CheckStatusWrapper status(&ls);
+
+	ServAttachment att = port_context->rdb_iface;
+
+	ServBlob blob(att->openBlob(&status, rtr->rtr_iface, &blobId, 0, nullptr));
+	if (status.getState() & IStatus::STATE_ERRORS)
+		return false;
+
+	// ask blob info
+	const UCHAR items[] =  {
+		isc_info_blob_num_segments,
+		isc_info_blob_max_segment,
+		isc_info_blob_total_length,
+		isc_info_blob_type,
+		isc_info_end
+	};
+
+	UCHAR info[64];
+
+	blob->getInfo(&status, sizeof(items), items, sizeof(info), info);
+	if (status.getState() & IStatus::STATE_ERRORS)
+		return false;
+
+	bool	segmented;
+	ULONG	num_segments;
+	ULONG	max_segment;
+	ULONG	total_length;
+
+	ClumpletReader p(ClumpletReader::InfoResponse, info, sizeof(info));
+	for (; !p.isEof(); p.moveNext())
+	{
+		switch (p.getClumpTag())
+		{
+		case isc_info_blob_num_segments:
+			num_segments = p.getInt();
+			break;
+		case isc_info_blob_max_segment:
+			max_segment = p.getInt();
+			break;
+		case isc_info_blob_total_length:
+			total_length = p.getInt();
+			break;
+		case isc_info_blob_type:
+			segmented = (p.getInt() == 0);
+			break;
+		case isc_info_end:
+			p_blob->p_blob_info.cstr_length = p.getCurOffset() + 1;
+			break;
+		default:
+			fb_assert(false);
+			break;
+		}
+	}
+
+	if (!total_length)
+		return true;
+
+	// todo: set max inline blob size
+	if (total_length > 16384)
+		return true;
+
+	if (!segmented)
+		num_segments = (total_length + max_segment - 1) / max_segment;
+
+	const ULONG dataLen = total_length + num_segments * 2;
+
+	RemBlobBuffer buff(getPool());
+
+	UCHAR* ptr = buff.getBuffer(dataLen);
+	const UCHAR* const end = ptr + dataLen;
+
+	for (; num_segments; num_segments--)
+	{
+		const unsigned inLen = MIN(end - ptr, max_segment);
+		unsigned outLen;
+
+		const int res = blob->getSegment(&status, inLen, ptr + 2, &outLen);
+		if (res == IStatus::RESULT_ERROR)
+			return false;
+
+		ptr[0] = (UCHAR) outLen;
+		ptr[1] = (UCHAR) (outLen >> 8);
+
+		ptr += 2 + outLen;
+	}
+	fb_assert(ptr == end);
+
+	blob->close(&status);
+
+	p_blob->p_blob_info.cstr_address = info;
+	p_blob->p_blob_data = &buff;
+
+	this->send_partial(sendL);
+	return true;
 }
 
 

--- a/src/remote/server/server.cpp
+++ b/src/remote/server/server.cpp
@@ -3513,9 +3513,10 @@ ISC_STATUS rem_port::execute_immediate(P_OP op, P_SQLST * exnow, PACKET* sendL)
 		this->port_statement->rsr_format = this->port_statement->rsr_select_format;
 
 		if (out_msg && exnow->p_sqlst_inline_blob_size)
+		{
 			sendInlineBlobs(sendL, transaction, out_msg, port_statement->rsr_select_format,
 				exnow->p_sqlst_inline_blob_size);
-
+		}
 		sendL->p_operation = op_sql_response;
 		sendL->p_sqldata.p_sqldata_messages =
 			((status_vector.getState() & IStatus::STATE_ERRORS) || !out_msg) ? 0 : 1;
@@ -3958,9 +3959,10 @@ ISC_STATUS rem_port::execute_statement(P_OP op, P_SQLDATA* sqldata, PACKET* send
 		this->port_statement->rsr_format = this->port_statement->rsr_select_format;
 
 		if (out_msg && statement->rsr_inline_blob_size)
+		{
 			sendInlineBlobs(sendL, transaction, out_msg, port_statement->rsr_select_format,
 				statement->rsr_inline_blob_size);
-
+		}
 		sendL->p_operation = op_sql_response;
 		sendL->p_sqldata.p_sqldata_messages =
 			((status_vector.getState() & IStatus::STATE_ERRORS) || !out_msg) ? 0 : 1;

--- a/src/yvalve/YObjects.h
+++ b/src/yvalve/YObjects.h
@@ -477,6 +477,9 @@ public:
 	YBatch* createBatch(Firebird::CheckStatusWrapper* status, Firebird::IMessageMetadata* inMetadata,
 		unsigned parLength, const unsigned char* par);
 
+	unsigned getMaxInlineBlobSize(Firebird::CheckStatusWrapper* status) override;
+	void setMaxInlineBlobSize(Firebird::CheckStatusWrapper* status, unsigned size) override;
+
 public:
 	AtomicAttPtr attachment;
 	Firebird::Mutex statementMutex;
@@ -578,6 +581,11 @@ public:
 		unsigned stmtLength, const char* sqlStmt, unsigned dialect,
 		Firebird::IMessageMetadata* inMetadata, unsigned parLength, const unsigned char* par);
 	YReplicator* createReplicator(Firebird::CheckStatusWrapper* status);
+
+	unsigned getMaxBlobCacheSize(Firebird::CheckStatusWrapper* status) override;
+	void setMaxBlobCacheSize(Firebird::CheckStatusWrapper* status, unsigned size) override;
+	unsigned getMaxInlineBlobSize(Firebird::CheckStatusWrapper* status) override;
+	void setMaxInlineBlobSize(Firebird::CheckStatusWrapper* status, unsigned size) override;
 
 public:
 	Firebird::IProvider* provider;

--- a/src/yvalve/why.cpp
+++ b/src/yvalve/why.cpp
@@ -4582,6 +4582,36 @@ YBatch* YStatement::createBatch(CheckStatusWrapper* status, IMessageMetadata* in
 	return NULL;
 }
 
+
+unsigned YStatement::getMaxInlineBlobSize(CheckStatusWrapper* status)
+{
+	try
+	{
+		YEntry<YStatement> entry(status, this);
+		return entry.next()->getMaxInlineBlobSize(status);
+	}
+	catch (const Exception& e)
+	{
+		e.stuffException(status);
+	}
+
+	return 0;
+}
+
+
+void YStatement::setMaxInlineBlobSize(CheckStatusWrapper* status, unsigned size)
+{
+	try
+	{
+		YEntry<YStatement> entry(status, this);
+		entry.next()->setMaxInlineBlobSize(status, size);
+	}
+	catch (const Exception& e)
+	{
+		e.stuffException(status);
+	}
+}
+
 //-------------------------------------
 
 IscStatement::~IscStatement()
@@ -6217,6 +6247,66 @@ YReplicator* YAttachment::createReplicator(CheckStatusWrapper* status)
 	}
 
 	return NULL;
+}
+
+
+unsigned YAttachment::getMaxBlobCacheSize(CheckStatusWrapper* status)
+{
+	try
+	{
+		YEntry<YAttachment> entry(status, this);
+		return entry.next()->getMaxBlobCacheSize(status);
+	}
+	catch (const Exception& e)
+	{
+		e.stuffException(status);
+	}
+
+	return 0;
+}
+
+
+void YAttachment::setMaxBlobCacheSize(CheckStatusWrapper* status, unsigned size)
+{
+	try
+	{
+		YEntry<YAttachment> entry(status, this);
+		entry.next()->setMaxBlobCacheSize(status, size);
+	}
+	catch (const Exception& e)
+	{
+		e.stuffException(status);
+	}
+}
+
+
+unsigned YAttachment::getMaxInlineBlobSize(CheckStatusWrapper* status)
+{
+	try
+	{
+		YEntry<YAttachment> entry(status, this);
+		return entry.next()->getMaxInlineBlobSize(status);
+	}
+	catch (const Exception& e)
+	{
+		e.stuffException(status);
+	}
+
+	return 0;
+}
+
+
+void YAttachment::setMaxInlineBlobSize(CheckStatusWrapper* status, unsigned size)
+{
+	try
+	{
+		YEntry<YAttachment> entry(status, this);
+		entry.next()->setMaxInlineBlobSize(status, size);
+	}
+	catch (const Exception& e)
+	{
+		e.stuffException(status);
+	}
 }
 
 


### PR DESCRIPTION
The feature allows to send small blob contents in the same data stream as main resultset.
This lowers number of roundtrips required to get blob data and significantly improves performance on high latency networks.

The blob metadata and data is send using new type of packet `op_inline_blob` and new structure `P_INLINE_BLOB`.
The `op_inline_blob` packet is send before corresponding `op_sql_response` (in case of answer on `op_execute2` or `op_exec_immediate2`), or `op_fetch_response` (answer on `op_fetch`).
There could be as much `op_inline_blob` packets as number of blob fields in output format.
NULL blobs and too big blobs are not sent. 
The blob send as a whole, i.e. current implementation doesn't support sending of part of blob. The reasons - attempt to not over-complicate the code and the fact that `seek` is not implemented for segmented blobs.

Current, initial, implementation send all blobs that total size is not greater than 16KB.

The open questions is what API changes is required to allow user to customize this process:
- allow to enable and disable inline blob sending
- allow to set inline blob size limit
- decide on what level should be applicable settings above: per-attachment, per-statement, etc
- decide default and maximum values for inline blob size limit.

Also, will good to have but not required:
- allow to set BPB in advance
- allow to enable blob in-lining on per-field basis, if output format contains many blob fields.

This PR currently in draft state and published for the early testers and commenters.
