### PR TITLE
Fix use :@ characters and add sub-section to configure username and password for sync_replica

### DIFF
--- a/src/jrd/replication/Config.cpp
+++ b/src/jrd/replication/Config.cpp
@@ -246,12 +246,10 @@ Config* Config::get(const PathName& lookupName)
 								}
 								else if (key_source.equals(KEY_FILE))
 								{
-									const PathName sub_filename =
-										fb_utils::getPrefix(IConfigManager::DIR_CONF, sub_value.c_str());
-
+									const PathName sub_filename = sub_value.c_str();
 									AutoPtr<FILE> file(os_utils::fopen(sub_filename.c_str(), "rt"));
 									if (!file)
-										configError("missing file", value, sub_filename.c_str());
+										configError("missing or inaccessible file", value, sub_filename.c_str());
 
 									// skip first empty lines
 									sub_value = "";

--- a/src/jrd/replication/Config.cpp
+++ b/src/jrd/replication/Config.cpp
@@ -246,7 +246,11 @@ Config* Config::get(const PathName& lookupName)
 								}
 								else if (key_source.equals(KEY_FILE))
 								{
-									const PathName sub_filename = sub_value.c_str();
+									PathName sub_filename = sub_value.c_str();
+									PathUtils::fixupSeparators(sub_filename);
+									if (PathUtils::isRelative(sub_filename))
+										sub_filename = fb_utils::getPrefix(IConfigManager::DIR_CONF, sub_filename.c_str());
+
 									AutoPtr<FILE> file(os_utils::fopen(sub_filename.c_str(), "rt"));
 									if (!file)
 										configError("missing or inaccessible file", value, sub_filename.c_str());

--- a/src/jrd/replication/Config.h
+++ b/src/jrd/replication/Config.h
@@ -35,7 +35,7 @@ namespace Replication
 {
 	struct SyncReplica
 	{
-		SyncReplica(MemoryPool& p)
+		explicit SyncReplica(MemoryPool& p)
 			: database(p), username(p), password(p)
 		{}
 

--- a/src/jrd/replication/Config.h
+++ b/src/jrd/replication/Config.h
@@ -33,6 +33,21 @@
 
 namespace Replication
 {
+	struct SyncReplica
+	{
+		SyncReplica(MemoryPool& p)
+			: database(p), username(p), password(p)
+		{}
+
+		SyncReplica(MemoryPool& p, const SyncReplica& other)
+			: database(p, other.database), username(p, other.username), password(p, other.password)
+		{}
+
+		Firebird::string database;
+		Firebird::string username;
+		Firebird::string password;
+	};
+
 	struct Config : public Firebird::GlobalStorage
 	{
 		typedef Firebird::HalfStaticArray<Config*, 4> ReplicaList;
@@ -42,6 +57,8 @@ namespace Replication
 
 		static Config* get(const Firebird::PathName& dbName);
 		static void enumerate(ReplicaList& replicas);
+		static void splitConnectionString(const Firebird::string& input, Firebird::string& database,
+										  Firebird::string& username, Firebird::string& password);
 
 		Firebird::PathName dbName;
 		ULONG bufferSize;
@@ -55,7 +72,7 @@ namespace Replication
 		Firebird::PathName archiveDirectory;
 		Firebird::string archiveCommand;
 		ULONG archiveTimeout;
-		Firebird::ObjectsArray<Firebird::string> syncReplicas;
+		Firebird::ObjectsArray<SyncReplica> syncReplicas;
 		Firebird::PathName sourceDirectory;
 		std::optional<Firebird::Guid> sourceGuid;
 		bool verboseLogging;

--- a/src/jrd/replication/Manager.cpp
+++ b/src/jrd/replication/Manager.cpp
@@ -128,39 +128,18 @@ Manager::Manager(const string& dbId,
 
 	for (const auto& iter : m_config->syncReplicas)
 	{
-		string database = iter;
-		string login, password;
-
-		auto pos = database.find('@');
-		if (pos != string::npos)
-		{
-			const string temp = database.substr(0, pos);
-			database = database.substr(pos + 1);
-
-			pos = temp.find(':');
-			if (pos != string::npos)
-			{
-				login = temp.substr(0, pos);
-				password = temp.substr(pos + 1);
-			}
-			else
-			{
-				login = temp;
-			}
-		}
-
 		ClumpletWriter dpb(ClumpletReader::dpbList, MAX_DPB_SIZE);
 		dpb.insertByte(isc_dpb_no_db_triggers, 1);
 
-		if (login.hasData())
+		if (iter.username.hasData())
 		{
-			dpb.insertString(isc_dpb_user_name, login);
+			dpb.insertString(isc_dpb_user_name, iter.username);
 
-			if (password.hasData())
-				dpb.insertString(isc_dpb_password, password);
+			if (iter.password.hasData())
+				dpb.insertString(isc_dpb_password, iter.password);
 		}
 
-		const auto attachment = provider->attachDatabase(&localStatus, database.c_str(),
+		const auto attachment = provider->attachDatabase(&localStatus, iter.database.c_str(),
 												   	     dpb.getBufferLength(), dpb.getBuffer());
 		if (localStatus->getState() & IStatus::STATE_ERRORS)
 		{


### PR DESCRIPTION
There is a problem with using :@ characters in the connection string to a sync_replica

For example, if the username contains the @ symbol: `jonh@it-corp:qwe@rty@localhost:employee` - the parser split it as:
```
username = jonh                                 // wrong, should be jonh@it-corp
password = <null>                               // wrong, should be qwe@rty
database = it-corp:qwe@rty@localhost:employee   // wrong, should be localhost:employee
```

or only the password contains the @ symbol: `jonh:qwe@rty@db_alias`, then:
```
username = jonh                     // is correct
password = qwe                      // wrong, should be qwe@rty
database = rty@localhost:employee   // wrong, should be localhost:employee
```

In addition to fix it, this PR add a subsection to the sync_replica configuration. You can specify a username and password without any character restrictions, or specify where they should be read: from the first non-empty line of the file or from an environment variable.

Now in the replication.conf can:
```python
database = <master_path>
{
  # 1) old format with restrictions:
  #    @ can't be used in database
  #    : can't be used in username
  #    all characters can be used in password
  sync_replica = jonh@it-corp:qwe@rty@localhost:employee
    #  username = jonh@it-corp        // is correct
    #  password = qwe@rty             // is correct
    #  database = localhost:employee  // is correct

  # 2) new sub-stream config with plain username and password without restrictions (username can be : character)
  sync_replica = localhost/3051:employee
  {
    username = jonh:smith@it-corp
    password = qwe@rty
  }

  # 3) new sub-stream when read values from environment and file
  sync_replica = localhost/3052:employee
  {
    username_env = replication_user
    password_file = replication_pass
  }
}
```