### PR TITLE
Change FB_NELEM return type to unsigned and resolve all FB_NELEM related Wsign-compare warnings

### DIFF
--- a/src/common/CvtFormat.cpp
+++ b/src/common/CvtFormat.cpp
@@ -1331,7 +1331,7 @@ namespace
 					bool isFound = false;
 
 					std::string_view monthShortName = getSubstringFromString(str, strLength, strOffset, 3);
-					for (int i = 0; i < FB_NELEM(FB_SHORT_MONTHS) - 1; i++)
+					for (FB_SIZE_T i = 0; i < FB_NELEM(FB_SHORT_MONTHS) - 1; i++)
 					{
 						if (std::equal(monthShortName.begin(), monthShortName.end(),
 								FB_SHORT_MONTHS[i], FB_SHORT_MONTHS[i] + strlen(FB_SHORT_MONTHS[i]),
@@ -1352,7 +1352,7 @@ namespace
 					bool isFound = false;
 
 					std::string_view monthFullName = getSubstringFromString(str, strLength, strOffset);
-					for (int i = 0; i < FB_NELEM(FB_LONG_MONTHS_UPPER) - 1; i++)
+					for (FB_SIZE_T i = 0; i < FB_NELEM(FB_LONG_MONTHS_UPPER) - 1; i++)
 					{
 						if (std::equal(monthFullName.begin(), monthFullName.end(),
 								FB_LONG_MONTHS_UPPER[i], FB_LONG_MONTHS_UPPER[i] + strlen(FB_LONG_MONTHS_UPPER[i]),

--- a/src/common/SimilarToRegex.cpp
+++ b/src/common/SimilarToRegex.cpp
@@ -410,7 +410,7 @@ namespace
 						if (!hasPatternChar() || getPatternChar() != ']')
 							status_exception::raise(Arg::Gds(isc_invalid_similar_pattern));
 
-						for (item.clazz = 0; item.clazz < FB_NELEM(classes); ++item.clazz)
+						for (item.clazz = 0; static_cast<FB_SIZE_T>(item.clazz) < FB_NELEM(classes); ++item.clazz)
 						{
 							if (fb_utils::strnicmp(patternStr + charSavePos,
 									classes[item.clazz].similarClass, len) == 0)
@@ -419,7 +419,7 @@ namespace
 							}
 						}
 
-						if (item.clazz >= FB_NELEM(classes))
+						if (static_cast<FB_SIZE_T>(item.clazz) >= FB_NELEM(classes))
 							status_exception::raise(Arg::Gds(isc_invalid_similar_pattern));
 					}
 					else

--- a/src/common/TextType.cpp
+++ b/src/common/TextType.cpp
@@ -153,7 +153,7 @@ TextType::TextType(TTYPE_ID _type, texttype *_tt, USHORT _attributes, CharSet* _
 			{'S', CHAR_UPPER_S}
 		};
 
-	for (int i = 0; i < FB_NELEM(conversions); i++)
+	for (FB_SIZE_T i = 0; i < FB_NELEM(conversions); i++)
 	{
 		try
 		{

--- a/src/common/classes/NoThrowTimeStamp.cpp
+++ b/src/common/classes/NoThrowTimeStamp.cpp
@@ -330,7 +330,7 @@ void NoThrowTimeStamp::round_time(ISC_TIME &ntime, const int precision)
 	if (scale <= 0)
 		return;
 
-	fb_assert(scale < FB_NELEM(POW_10_TABLE));
+	fb_assert(static_cast<FB_SIZE_T>(scale) < FB_NELEM(POW_10_TABLE));
 
 	const ISC_TIME period = POW_10_TABLE[scale];
 

--- a/src/common/pretty.cpp
+++ b/src/common/pretty.cpp
@@ -159,7 +159,7 @@ int PRETTY_print_cdb(const UCHAR* blr, FPTR_PRINT_CALLBACK routine, void* user_a
 	while (parameter = BLR_BYTE)
 	{
 		const char* p;
-		if (parameter > FB_NELEM(cdb_table) || !(p = cdb_table[parameter]))
+		if (parameter > static_cast<SSHORT>(FB_NELEM(cdb_table)) || !(p = cdb_table[parameter]))
 		{
 			return error(control, 0, "*** cdb parameter %d is undefined ***\n", parameter);
 		}

--- a/src/common/pretty.cpp
+++ b/src/common/pretty.cpp
@@ -159,7 +159,7 @@ int PRETTY_print_cdb(const UCHAR* blr, FPTR_PRINT_CALLBACK routine, void* user_a
 	while (parameter = BLR_BYTE)
 	{
 		const char* p;
-		if (parameter > static_cast<SSHORT>(FB_NELEM(cdb_table)) || !(p = cdb_table[parameter]))
+		if (parameter > static_cast<FB_SSIZE_T>(FB_NELEM(cdb_table)) || !(p = cdb_table[parameter]))
 		{
 			return error(control, 0, "*** cdb parameter %d is undefined ***\n", parameter);
 		}

--- a/src/gpre/hsh.cpp
+++ b/src/gpre/hsh.cpp
@@ -38,7 +38,7 @@ static int hash(const SCHAR*);
 static bool scompare(const SCHAR*, const SCHAR*);
 static bool scompare2(const SCHAR*, const SCHAR*);
 
-const int HASH_SIZE = 211;
+const FB_SIZE_T HASH_SIZE = 211;
 
 static gpre_sym* hash_table[HASH_SIZE];
 static gpre_sym* key_symbols;
@@ -80,7 +80,7 @@ void HSH_init()
 {
 	//const char *string;
 
-	int i = 0;
+	FB_SIZE_T i = 0;
 	for (gpre_sym** ptr = hash_table; i < HASH_SIZE; i++)
 		*ptr++ = NULL;
 

--- a/src/include/fb_types.h
+++ b/src/include/fb_types.h
@@ -135,9 +135,9 @@ typedef int (*lock_ast_t)(void*);
 
 // Number of elements in an array
 template <typename T, std::size_t N>
-constexpr int FB_NELEM(const T (&)[N])
+constexpr FB_SIZE_T FB_NELEM(const T (&)[N])
 {
-	return N;
+	return static_cast<FB_SIZE_T>(N);
 }
 
 // Intl types

--- a/src/isql/isql.epp
+++ b/src/isql/isql.epp
@@ -904,7 +904,7 @@ int ISQL_main(int argc, char* argv[])
 			TEXT helpstring[158];
 			IUTILS_msg_get(USAGE, sizeof(helpstring), helpstring);
 			STDERROUT(helpstring);
-			for (int i = 0; i < FB_NELEM(isql_in_sw_table); i++)
+			for (FB_SIZE_T i = 0; i < FB_NELEM(isql_in_sw_table); i++)
 			{
 				if (isql_in_sw_table[i].in_sw_msg > 0)
 				{
@@ -5128,7 +5128,7 @@ static processing_state frontend(const TEXT* statement)
 	// Shift parms to upper case, leaving original case in lparms
 	typedef TEXT* isql_params_t[MAX_TERMS];
 	isql_params_t parms, lparms;
-	for (int iter = 0; iter < FB_NELEM(lparms); ++iter)
+	for (FB_SIZE_T iter = 0; iter < FB_NELEM(lparms); ++iter)
 	{
 		lparms[iter] = NULL;
 		parms[iter] = NULL;

--- a/src/isql/show.epp
+++ b/src/isql/show.epp
@@ -3752,7 +3752,7 @@ static processing_state show_dependencies(const char* object)
 
 	bool missing = true;
 
-	for (int i = 0; i < FB_NELEM(Object_types); ++i)
+	for (FB_SIZE_T i = 0; i < FB_NELEM(Object_types); ++i)
 	{
 		if (show_dependencies(object, i) == SKIP)
 		{

--- a/src/jrd/Collation.cpp
+++ b/src/jrd/Collation.cpp
@@ -898,7 +898,7 @@ private:
 			if (*control == *(CharType*) obj->getCanonicalChar(CHAR_GDML_SUBSTITUTE))
 			{
 				// Note: don't allow substitution characters larger than vector
-				CharType** const end_vector = vector + (((int) c < FB_NELEM(vector)) ? c : 0);
+				CharType** const end_vector = vector + ((static_cast<FB_SSIZE_T>(c) < static_cast<FB_SSIZE_T>(FB_NELEM(vector))) ? c : 0);
 				while (v <= end_vector)
 					*v++ = 0;
 				*end_vector = t;

--- a/src/jrd/SysFunction.cpp
+++ b/src/jrd/SysFunction.cpp
@@ -62,6 +62,7 @@
 #include "../common/classes/FpeControl.h"
 #include "../jrd/extds/ExtDS.h"
 #include "../jrd/align.h"
+#include "firebird/impl/types_pub.h"
 
 #include <functional>
 #include <cmath>
@@ -2709,7 +2710,7 @@ const char* extractParts[] =
 
 const char* getPartName(int n)
 {
-	if (n < 0 || n >= FB_NELEM(extractParts) || !extractParts[n])
+	if (n < 0 || static_cast<FB_SIZE_T>(n) >= FB_NELEM(extractParts) || !extractParts[n])
 		return "Unknown";
 
 	return extractParts[n];

--- a/src/jrd/blob_filter.cpp
+++ b/src/jrd/blob_filter.cpp
@@ -239,7 +239,7 @@ BlobFilter* BLF_lookup_internal_filter(thread_db* tdbb, SSHORT from, SSHORT to)
 
 	// Check for system defined filter
 
-	if (to == isc_blob_text && from >= 0 && from < FB_NELEM(filters))
+	if (to == isc_blob_text && from >= 0 && static_cast<FB_SIZE_T>(from) < FB_NELEM(filters))
 	{
 		BlobFilter* result = FB_NEW_POOL(*dbb->dbb_permanent) BlobFilter(*dbb->dbb_permanent);
 		result->blf_next = NULL;

--- a/src/jrd/extds/InternalDS.cpp
+++ b/src/jrd/extds/InternalDS.cpp
@@ -171,7 +171,7 @@ void InternalConnection::attach(thread_db* tdbb)
 
 	memset(m_features, false, sizeof(m_features));
 	static const info_features features[] = ENGINE_FEATURES;
-	for (int i = 0; i < FB_NELEM(features); i++)
+	for (FB_SIZE_T i = 0; i < FB_NELEM(features); i++)
 		setFeature(features[i]);
 }
 

--- a/src/jrd/filters.cpp
+++ b/src/jrd/filters.cpp
@@ -811,7 +811,7 @@ ISC_STATUS filter_transliterate_text(USHORT action, BlobControl* control)
 	{
 	case isc_blob_filter_open:
 	case isc_blob_filter_create:
-		for (USHORT i = 0; i < FB_NELEM(control->ctl_data); i++)
+		for (FB_SIZE_T i = 0; i < FB_NELEM(control->ctl_data); i++)
 			control->ctl_data[i] = 0;
 		aux = NULL;
 

--- a/src/jrd/filters.cpp
+++ b/src/jrd/filters.cpp
@@ -811,7 +811,7 @@ ISC_STATUS filter_transliterate_text(USHORT action, BlobControl* control)
 	{
 	case isc_blob_filter_open:
 	case isc_blob_filter_create:
-		for (SSHORT i = 0; i < FB_NELEM(control->ctl_data); i++)
+		for (USHORT i = 0; i < FB_NELEM(control->ctl_data); i++)
 			control->ctl_data[i] = 0;
 		aux = NULL;
 

--- a/src/jrd/ini.epp
+++ b/src/jrd/ini.epp
@@ -1619,7 +1619,7 @@ static void store_indices(thread_db* tdbb, USHORT odsVersion)
 
 	AutoRequest handle1, handle2, handle3;
 
-	for (int n = 0; n < SYSTEM_INDEX_COUNT; n++)
+	for (FB_SIZE_T n = 0; n < SYSTEM_INDEX_COUNT; n++)
 	{
 		const ini_idx_t* index = &indices[n];
 		const auto relation = MET_relation(tdbb, index->ini_idx_relid);

--- a/src/jrd/par.cpp
+++ b/src/jrd/par.cpp
@@ -1519,7 +1519,7 @@ DmlNode* PAR_parse_node(thread_db* tdbb, CompilerScratch* csb)
 	const ULONG blrOffset = csb->csb_blr_reader.getOffset();
 	const SSHORT blrOperator = csb->csb_blr_reader.getByte();
 
-	if (blrOperator < 0 || static_cast<USHORT>(blrOperator) >= FB_NELEM(blr_parsers))
+	if (blrOperator < 0 || static_cast<FB_SIZE_T>(blrOperator) >= FB_NELEM(blr_parsers))
 	{
         // NS: This error string is correct, please do not mangle it again and again.
 		// The whole error message is "BLR syntax error: expected %s at offset %d, encountered %d"

--- a/src/jrd/par.cpp
+++ b/src/jrd/par.cpp
@@ -1519,7 +1519,7 @@ DmlNode* PAR_parse_node(thread_db* tdbb, CompilerScratch* csb)
 	const ULONG blrOffset = csb->csb_blr_reader.getOffset();
 	const SSHORT blrOperator = csb->csb_blr_reader.getByte();
 
-	if (blrOperator < 0 || blrOperator >= FB_NELEM(blr_parsers))
+	if (blrOperator < 0 || static_cast<USHORT>(blrOperator) >= FB_NELEM(blr_parsers))
 	{
         // NS: This error string is correct, please do not mangle it again and again.
 		// The whole error message is "BLR syntax error: expected %s at offset %d, encountered %d"

--- a/src/jrd/sort.cpp
+++ b/src/jrd/sort.cpp
@@ -1525,7 +1525,7 @@ void Sort::mergeRuns(USHORT n)
 	// and there n < RUN_GROUP * MAX_MERGE_LEVEL
 	merge_control blks[RUN_GROUP * MAX_MERGE_LEVEL];
 
-	fb_assert((n - 1) <= FB_NELEM(blks));	// stack var big enough?
+	fb_assert(static_cast<FB_SIZE_T>(n - 1) <= FB_NELEM(blks));	// stack var big enough?
 
 	m_longs -= SIZEOF_SR_BCKPTR_IN_LONGS;
 

--- a/src/yvalve/alt.cpp
+++ b/src/yvalve/alt.cpp
@@ -250,7 +250,7 @@ ISC_STATUS API_ROUTINE_VARARG gds__start_transaction(ISC_STATUS* status_vector,
 	teb_t tebs[16];
 	teb_t* teb = tebs;
 
-	if (count > FB_NELEM(tebs))
+	if (static_cast<FB_SIZE_T>(count) > FB_NELEM(tebs))
 		teb = (teb_t*) gds__alloc(((SLONG) sizeof(teb_t) * count));
 	// FREE: later in this module
 

--- a/src/yvalve/gds.cpp
+++ b/src/yvalve/gds.cpp
@@ -4025,7 +4025,7 @@ static void blr_print_verb(gds_ctl* control, SSHORT level)
 					case blr_invoke_function_type:
 						n = control->ctl_blr_reader.getByte();
 
-						if (n == 0 || n >= FB_NELEM(typeSubCodes))
+						if (n == 0 || n >= static_cast<SSHORT>(FB_NELEM(typeSubCodes)))
 							blr_error(control, "*** invalid blr_invoke_function_type sub code ***");
 
 						blr_format(control, "blr_invoke_function_type_%s,", typeSubCodes[n]);
@@ -4123,7 +4123,7 @@ static void blr_print_verb(gds_ctl* control, SSHORT level)
 					case blr_invsel_procedure_type:
 						n = control->ctl_blr_reader.getByte();
 
-						if (n == 0 || n >= FB_NELEM(typeSubCodes))
+						if (n == 0 || n >= static_cast<SSHORT>(FB_NELEM(typeSubCodes)))
 							blr_error(control, "*** invalid blr_invsel_procedure_type sub code ***");
 
 						blr_format(control, "blr_invsel_procedure_type_%s,", typeSubCodes[n]);

--- a/src/yvalve/gds.cpp
+++ b/src/yvalve/gds.cpp
@@ -4025,7 +4025,7 @@ static void blr_print_verb(gds_ctl* control, SSHORT level)
 					case blr_invoke_function_type:
 						n = control->ctl_blr_reader.getByte();
 
-						if (n == 0 || n >= static_cast<SSHORT>(FB_NELEM(typeSubCodes)))
+						if (n == 0 || n >= static_cast<FB_SSIZE_T>(FB_NELEM(typeSubCodes)))
 							blr_error(control, "*** invalid blr_invoke_function_type sub code ***");
 
 						blr_format(control, "blr_invoke_function_type_%s,", typeSubCodes[n]);
@@ -4123,7 +4123,7 @@ static void blr_print_verb(gds_ctl* control, SSHORT level)
 					case blr_invsel_procedure_type:
 						n = control->ctl_blr_reader.getByte();
 
-						if (n == 0 || n >= static_cast<SSHORT>(FB_NELEM(typeSubCodes)))
+						if (n == 0 || n >= static_cast<FB_SSIZE_T>(FB_NELEM(typeSubCodes)))
 							blr_error(control, "*** invalid blr_invsel_procedure_type sub code ***");
 
 						blr_format(control, "blr_invsel_procedure_type_%s,", typeSubCodes[n]);


### PR DESCRIPTION
`FB_NELEM` returns the size of the input array, which is always unsigned, but the function returns an int. It is a bit confusing, so I decided to change the type. It fixed some `Wsign-compare` warnings but added a bunch of new ones. Therefore, I included resolving them in the PR.