### PR TITLE
Mark FB_ALIGN as constexpr

### DIFF
--- a/src/include/fb_types.h
+++ b/src/include/fb_types.h
@@ -150,7 +150,7 @@ typedef ULONG StreamType;
 
 // Alignment rule
 template <typename T>
-inline T FB_ALIGN(T n, uintptr_t b)
+constexpr T FB_ALIGN(T n, uintptr_t b)
 {
 	return (T) ((((uintptr_t) n) + b - 1) & ~(b - 1));
 }


### PR DESCRIPTION
Since `FB_NELEM` is marked as constexpr, why not mark `FB_ALIGN` as constexpr too?