### PR TITLE
Make return-type a compilation error

### DIFF
--- a/builds/posix/make.defaults
+++ b/builds/posix/make.defaults
@@ -111,7 +111,7 @@ GLOB_OPTIONS:=
 #____________________________________________________________________________
 
 # Global c++ flags: firebird needs no RTTI, choose build standard and c++ specific warnings level
-PLUSPLUS_FLAGS:= -fno-rtti -std=c++17 -Werror=delete-incomplete
+PLUSPLUS_FLAGS:= -fno-rtti -std=c++17 -Werror=delete-incomplete -Werror=return-type
 
 # If this is defined then we use special rules useful for developers only
 IsDeveloper = @DEVEL_FLG@

--- a/builds/win32/msvc15/FirebirdCommon.props
+++ b/builds/win32/msvc15/FirebirdCommon.props
@@ -28,6 +28,7 @@
       <UseFullPaths>false</UseFullPaths>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>
     </ClCompile>
     <Link>
       <SuppressStartupBanner>true</SuppressStartupBanner>

--- a/src/common/CvtFormat.cpp
+++ b/src/common/CvtFormat.cpp
@@ -1124,6 +1124,7 @@ namespace
 			return twelveHours == 12 ? twelveHours : 12 + twelveHours;
 
 		cb->err(Arg::Gds(isc_incorrect_hours_period) << string(period.data(), period.length()));
+		return 0; // suppress compiler warning/error
 	}
 
 	constexpr int roundYearPatternImplementation(int parsedRRValue, int currentYear)


### PR DESCRIPTION
This protects from undefined behavior cases that can be added to the code by mistake.