### PR TITLE
Fix race condition in shutdownThread start that can cause server to be unable to stop

### DIFF
--- a/src/yvalve/why.cpp
+++ b/src/yvalve/why.cpp
@@ -831,11 +831,11 @@ private:
 		explicit CtrlCHandler(MemoryPool& p)
 			: ShutdownInit(p)
 		{
+			shutdownSemaphore = &semaphore;
 			Thread::start(shutdownThread, 0, 0, &handle);
 
 			procInt = ISC_signal(SIGINT, handlerInt, 0);
 			procTerm = ISC_signal(SIGTERM, handlerTerm, 0);
-			shutdownSemaphore = &semaphore;
 		}
 
 		~CtrlCHandler()


### PR DESCRIPTION
Previously we assign value to `shutdownSemaphore` after `shutdownThread` is started, where it was already needed. So we can have situation where `shutdownThread` instantly leaving due to `shutdownSemaphore == nullptr`, and we are left with a server that can only be stopped with kill -9.
I think this problem was hidden behind `fbguard` timeout and it's really hard to reproduce due to nature of race conditions, but in a synthetic environment using `sleep` to emulate high load and process switching in OS it is easily reproducible.