### PR TITLE
Add riscv64 define for cds

### DIFF
--- a/extern/libcds/cds/compiler/gcc/compiler_macro.h
+++ b/extern/libcds/cds/compiler/gcc/compiler_macro.h
@@ -132,6 +132,11 @@
 #   define CDS_PROCESSOR__NAME   "LOONGARCH"
 #   define CDS_PROCESSOR__NICK   "loongarch"
 #   define CDS_BUILD_BITS        64
+#elif defined(__riscv) && __riscv_xlen == 64
+#   define CDS_PROCESSOR_ARCH    CDS_PROCESSOR_RISCV64
+#   define CDS_PROCESSOR__NAME   "RISC-V64"
+#   define CDS_PROCESSOR__NICK   "riscv64"
+#   define CDS_BUILD_BITS        64
 #else
 #   if defined(CDS_USE_LIBCDS_ATOMIC)
 #       error "Libcds does not support atomic implementation for the processor architecture. Try to use C++11-compatible compiler and remove CDS_USE_LIBCDS_ATOMIC flag from compiler command line"


### PR DESCRIPTION
Fix build error on riscv64:

```text
In file included from /build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/cds/os/alloc_aligned.h:31,
                 from /build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/cds/user_setup/allocator.h:42,
                 from /build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/cds/details/allocator.h:12,
                 from /build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/cds/urcu/details/base.h:11,
                 from /build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/cds/urcu/details/gp_decl.h:9,
                 from /build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/cds/threading/details/_common.h:9,
                 from /build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/src/thread_data.cpp:6:
/build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/cds/algo/int_algo.h:80:28: error: redefinition of ‘uint64_t cds::beans::log2floor(uint64_t)’
   80 |     static inline uint64_t log2floor( uint64_t n )
      |                            ^~~~~~~~~
/build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/cds/algo/int_algo.h:13:26: note: ‘size_t cds::beans::log2floor(size_t)’ previously defined here
   13 |     static inline size_t log2floor( size_t n )
      |                          ^~~~~~~~~
/build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/cds/algo/int_algo.h:86:28: error: redefinition of ‘uint64_t cds::beans::log2ceil(uint64_t)’
   86 |     static inline uint64_t log2ceil( uint64_t n )
      |                            ^~~~~~~~
/build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/cds/algo/int_algo.h:19:26: note: ‘size_t cds::beans::log2ceil(size_t)’ previously defined here
   19 |     static inline size_t log2ceil( size_t n )
      |                          ^~~~~~~~
/build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/cds/algo/int_algo.h:106:28: error: redefinition of ‘uint64_t cds::beans::floor2(uint64_t)’
  106 |     static inline uint64_t floor2( uint64_t n )
      |                            ^~~~~~
/build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/cds/algo/int_algo.h:39:26: note: ‘size_t cds::beans::floor2(size_t)’ previously defined here
   39 |     static inline size_t floor2( size_t n )
      |                          ^~~~~~
/build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/cds/algo/int_algo.h:125:28: error: redefinition of ‘uint64_t cds::beans::ceil2(uint64_t)’
  125 |     static inline uint64_t ceil2( uint64_t n )
      |                            ^~~~~
/build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/cds/algo/int_algo.h:58:26: note: ‘size_t cds::beans::ceil2(size_t)’ previously defined here
   58 |     static inline size_t ceil2( size_t n )
      |                          ^~~~~
/build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/cds/algo/int_algo.h:131:34: error: redefinition of ‘constexpr bool cds::beans::is_power2(uint64_t)’
  131 |     constexpr static inline bool is_power2( uint64_t n ) noexcept
      |                                  ^~~~~~~~~
/build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/cds/algo/int_algo.h:64:34: note: ‘constexpr bool cds::beans::is_power2(size_t)’ previously defined here
   64 |     constexpr static inline bool is_power2( size_t n ) noexcept
      |                                  ^~~~~~~~~
/build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/cds/algo/int_algo.h:137:28: error: redefinition of ‘uint64_t cds::beans::log2(uint64_t)’
  137 |     static inline uint64_t log2( uint64_t n )
      |                            ^~~~
/build/libfbclient/src/Firebird-5.0.1.1469-0-source/extern/libcds/cds/algo/int_algo.h:70:26: note: ‘size_t cds::beans::log2(size_t)’ previously defined here
   70 |     static inline size_t log2( size_t n )
      |                          ^~~~
```