### PR TITLE
Fix potential deadlock when starting the encryption thread

### DIFF
--- a/src/common/ThreadStart.cpp
+++ b/src/common/ThreadStart.cpp
@@ -219,9 +219,14 @@ ThreadId Thread::getId()
 #endif
 }
 
+bool Thread::isCurrent(InternalId iid)
+{
+	return pthread_equal(iid, pthread_self());
+}
+
 bool Thread::isCurrent()
 {
-	return pthread_equal(internalId, pthread_self());
+	return isCurrent(internalId);
 }
 
 void Thread::sleep(unsigned milliseconds)
@@ -363,9 +368,14 @@ ThreadId Thread::getId()
 	return GetCurrentThreadId();
 }
 
+bool Thread::isCurrent(InternalId iid)
+{
+	return GetCurrentThreadId() == iid;
+}
+
 bool Thread::isCurrent()
 {
-	return GetCurrentThreadId() == internalId;
+	return isCurrent(internalId);
 }
 
 void Thread::sleep(unsigned milliseconds)

--- a/src/common/ThreadStart.cpp
+++ b/src/common/ThreadStart.cpp
@@ -219,6 +219,11 @@ ThreadId Thread::getId()
 #endif
 }
 
+ThreadId Thread::getIdFromHandle(Handle threadHandle)
+{
+	return threadHandle;
+}
+
 bool Thread::isCurrent(InternalId iid)
 {
 	return pthread_equal(iid, pthread_self());
@@ -368,6 +373,11 @@ ThreadId Thread::getId()
 	return GetCurrentThreadId();
 }
 
+ThreadId Thread::getIdFromHandle(Handle threadHandle)
+{
+	return GetThreadId(threadHandle);
+}
+
 bool Thread::isCurrent(InternalId iid)
 {
 	return GetCurrentThreadId() == iid;
@@ -417,6 +427,10 @@ void Thread::kill(Handle&)
 }
 
 Thread::Handle Thread::getId()
+{
+}
+
+Thread::Handle Thread::getIdFromHandle(Handle)
 {
 }
 

--- a/src/common/ThreadStart.h
+++ b/src/common/ThreadStart.h
@@ -87,6 +87,7 @@ public:
 	static void sleep(unsigned milliseconds);
 	static void yield();
 
+	static bool isCurrent(InternalId iid);
 	bool isCurrent();
 
 	Thread()

--- a/src/common/ThreadStart.h
+++ b/src/common/ThreadStart.h
@@ -83,6 +83,7 @@ public:
 	static void kill(Handle& handle);
 
 	static ThreadId getId();
+	static ThreadId getIdFromHandle(Handle threadHandle);
 
 	static void sleep(unsigned milliseconds);
 	static void yield();

--- a/src/jrd/CryptoManager.cpp
+++ b/src/jrd/CryptoManager.cpp
@@ -319,7 +319,7 @@ namespace Jrd {
 		  keyConsumers(getPool()),
 		  hash(getPool()),
 		  dbInfo(FB_NEW DbInfo(this)),
-		  cryptThreadId(0),
+		  cryptThreadHandle(0),
 		  cryptPlugin(NULL),
 		  checkFactory(NULL),
 		  dbb(*tdbb->getDatabase()),
@@ -337,8 +337,8 @@ namespace Jrd {
 
 	CryptoManager::~CryptoManager()
 	{
-		if (cryptThreadId)
-			Thread::waitForCompletion(cryptThreadId);
+		if (cryptThreadHandle)
+			Thread::waitForCompletion(cryptThreadHandle);
 
 		delete stateLock;
 		delete threadLock;
@@ -925,10 +925,10 @@ namespace Jrd {
 	void CryptoManager::terminateCryptThread(thread_db*, bool wait)
 	{
 		flDown = true;
-		if (wait && cryptThreadId)
+		if (wait && cryptThreadHandle)
 		{
-			Thread::waitForCompletion(cryptThreadId);
-			cryptThreadId = 0;
+			Thread::waitForCompletion(cryptThreadHandle);
+			cryptThreadHandle = 0;
 		}
 	}
 
@@ -987,7 +987,7 @@ namespace Jrd {
 
 			// ready to go
 			guard.leave();		// release in advance to avoid races with cryptThread()
-			Thread::start(cryptThreadStatic, (THREAD_ENTRY_PARAM) this, THREAD_medium, &cryptThreadId);
+			Thread::start(cryptThreadStatic, (THREAD_ENTRY_PARAM) this, THREAD_medium, &cryptThreadHandle);
 		}
 		catch (const Firebird::Exception&)
 		{

--- a/src/jrd/CryptoManager.h
+++ b/src/jrd/CryptoManager.h
@@ -303,7 +303,7 @@ public:
 	const char* getPluginName() const;
 	Thread::Handle getCryptThreadHandle() const
 	{
-		return cryptThreadId;
+		return cryptThreadHandle;
 	}
 
 private:
@@ -382,7 +382,7 @@ private:
 	AttachmentsRefHolder keyProviders, keyConsumers;
 	Firebird::string hash;
 	Firebird::RefPtr<DbInfo> dbInfo;
-	Thread::Handle cryptThreadId;
+	Thread::Handle cryptThreadHandle;
 	Firebird::IDbCryptPlugin* cryptPlugin;
 	Factory* checkFactory;
 	Database& dbb;

--- a/src/jrd/CryptoManager.h
+++ b/src/jrd/CryptoManager.h
@@ -301,6 +301,10 @@ public:
 	UCHAR getCurrentState(thread_db* tdbb) const;
 	const char* getKeyName() const;
 	const char* getPluginName() const;
+	Thread::Handle getCryptThreadHandle() const
+	{
+		return cryptThreadId;
+	}
 
 private:
 	enum IoResult {SUCCESS_ALL, FAILED_CRYPT, FAILED_IO};

--- a/src/jrd/jrd.cpp
+++ b/src/jrd/jrd.cpp
@@ -7765,10 +7765,15 @@ void release_attachment(thread_db* tdbb, Jrd::Attachment* attachment, XThreadEns
 	XThreadEnsureUnlock* activeThreadGuard = dropGuard;
 	if (!activeThreadGuard)
 	{
-		if (dbb->dbb_crypto_manager && Thread::isCurrent(dbb->dbb_crypto_manager->getCryptThreadHandle()))
+		if (dbb->dbb_crypto_manager
+			&& Thread::isCurrent(Thread::getIdFromHandle(dbb->dbb_crypto_manager->getCryptThreadHandle())))
+		{
 			activeThreadGuard = &dummyGuard;
+		}
 		else
+		{
 			activeThreadGuard = &threadGuard;
+		}
 		activeThreadGuard->enter();
 	}
 


### PR DESCRIPTION
fixes #8402
add a check to verify thread matching between the encryption thread and the thread where we release the attachment. If they match, use a dummy mutex instead of the actual `dbb_thread_mutex` to avoid a deadlock