### PR TITLE
Backport Fix potential deadlock when starting the encryption thread #8402

### DIFF
--- a/src/common/ThreadStart.cpp
+++ b/src/common/ThreadStart.cpp
@@ -219,9 +219,19 @@ ThreadId Thread::getId()
 #endif
 }
 
+ThreadId Thread::getIdFromHandle(Handle threadHandle)
+{
+	return threadHandle;
+}
+
+bool Thread::isCurrent(InternalId iid)
+{
+	return pthread_equal(iid, pthread_self());
+}
+
 bool Thread::isCurrent()
 {
-	return pthread_equal(internalId, pthread_self());
+	return isCurrent(internalId);
 }
 
 void Thread::sleep(unsigned milliseconds)
@@ -363,9 +373,19 @@ ThreadId Thread::getId()
 	return GetCurrentThreadId();
 }
 
+ThreadId Thread::getIdFromHandle(Handle threadHandle)
+{
+	return GetThreadId(threadHandle);
+}
+
+bool Thread::isCurrent(InternalId iid)
+{
+	return GetCurrentThreadId() == iid;
+}
+
 bool Thread::isCurrent()
 {
-	return GetCurrentThreadId() == internalId;
+	return isCurrent(internalId);
 }
 
 void Thread::sleep(unsigned milliseconds)
@@ -407,6 +427,10 @@ void Thread::kill(Handle&)
 }
 
 Thread::Handle Thread::getId()
+{
+}
+
+Thread::Handle Thread::getIdFromHandle(Handle)
 {
 }
 

--- a/src/common/ThreadStart.h
+++ b/src/common/ThreadStart.h
@@ -83,10 +83,12 @@ public:
 	static void kill(Handle& handle);
 
 	static ThreadId getId();
+	static ThreadId getIdFromHandle(Handle threadHandle);
 
 	static void sleep(unsigned milliseconds);
 	static void yield();
 
+	static bool isCurrent(InternalId iid);
 	bool isCurrent();
 
 	Thread()

--- a/src/jrd/CryptoManager.cpp
+++ b/src/jrd/CryptoManager.cpp
@@ -328,7 +328,7 @@ namespace Jrd {
 		  keyConsumers(getPool()),
 		  hash(getPool()),
 		  dbInfo(FB_NEW DbInfo(this)),
-		  cryptThreadId(0),
+		  cryptThreadHandle(0),
 		  cryptPlugin(NULL),
 		  checkFactory(NULL),
 		  dbb(*tdbb->getDatabase()),
@@ -346,8 +346,8 @@ namespace Jrd {
 
 	CryptoManager::~CryptoManager()
 	{
-		if (cryptThreadId)
-			Thread::waitForCompletion(cryptThreadId);
+		if (cryptThreadHandle)
+			Thread::waitForCompletion(cryptThreadHandle);
 
 		delete stateLock;
 		delete threadLock;
@@ -933,10 +933,10 @@ namespace Jrd {
 	void CryptoManager::terminateCryptThread(thread_db*, bool wait)
 	{
 		flDown = true;
-		if (wait && cryptThreadId)
+		if (wait && cryptThreadHandle)
 		{
-			Thread::waitForCompletion(cryptThreadId);
-			cryptThreadId = 0;
+			Thread::waitForCompletion(cryptThreadHandle);
+			cryptThreadHandle = 0;
 		}
 	}
 
@@ -995,7 +995,7 @@ namespace Jrd {
 
 			// ready to go
 			guard.leave();		// release in advance to avoid races with cryptThread()
-			Thread::start(cryptThreadStatic, (THREAD_ENTRY_PARAM) this, THREAD_medium, &cryptThreadId);
+			Thread::start(cryptThreadStatic, (THREAD_ENTRY_PARAM) this, THREAD_medium, &cryptThreadHandle);
 		}
 		catch (const Firebird::Exception&)
 		{

--- a/src/jrd/CryptoManager.h
+++ b/src/jrd/CryptoManager.h
@@ -302,6 +302,10 @@ public:
 	ULONG getCurrentPage(thread_db* tdbb) const;
 	UCHAR getCurrentState(thread_db* tdbb) const;
 	const char* getKeyName() const;
+	Thread::Handle getCryptThreadHandle() const
+	{
+		return cryptThreadHandle;
+	}
 
 private:
 	enum IoResult {SUCCESS_ALL, FAILED_CRYPT, FAILED_IO};
@@ -388,7 +392,7 @@ private:
 	AttachmentsRefHolder keyProviders, keyConsumers;
 	Firebird::string hash;
 	Firebird::RefPtr<DbInfo> dbInfo;
-	Thread::Handle cryptThreadId;
+	Thread::Handle cryptThreadHandle;
 	Firebird::IDbCryptPlugin* cryptPlugin;
 	Factory* checkFactory;
 	Database& dbb;


### PR DESCRIPTION
Backport for FB3  (fix for #8402)

add a check to verify thread matching between the encryption thread and the thread where we release the attachment. If they match, use a dummy mutex instead of the actual dbb_thread_mutex to avoid a deadlock