### PR TITLE
Fix incorrect maximum size when reading dbb parameter values in SHOW DATABASE

### DIFF
--- a/src/isql/show.epp
+++ b/src/isql/show.epp
@@ -438,12 +438,12 @@ void SHOW_dbb_parameters(Firebird::IAttachment* db_handle,
 			break;
 
 		case isc_info_page_size:
-			value_out = p.getInt();
+			value_out = p.getBigInt();
 			isqlGlob.printf("PAGE_SIZE %" SQUADFORMAT"%s", value_out, separator);
 			break;
 
 		case isc_info_db_size_in_pages:
-			value_out = p.getInt();
+			value_out = p.getBigInt();
 			if (translate)
 			{
 				IUTILS_msg_get(NUMBER_PAGES, msg, SafeArg() << value_out);
@@ -454,7 +454,7 @@ void SHOW_dbb_parameters(Firebird::IAttachment* db_handle,
 			break;
 
 		case fb_info_pages_used:
-			value_out = p.getInt();
+			value_out = p.getBigInt();
 			if (translate)
 			{
 				IUTILS_msg_get(NUMBER_USED_PAGES, msg, SafeArg() << value_out);
@@ -465,7 +465,7 @@ void SHOW_dbb_parameters(Firebird::IAttachment* db_handle,
 			break;
 
 		case fb_info_pages_free:
-			value_out = p.getInt();
+			value_out = p.getBigInt();
 			if (translate)
 			{
 				IUTILS_msg_get(NUMBER_FREE_PAGES, msg, SafeArg() << value_out);
@@ -476,7 +476,7 @@ void SHOW_dbb_parameters(Firebird::IAttachment* db_handle,
 			break;
 
 		case fb_info_crypt_state:
-			value_out = p.getInt();
+			value_out = p.getBigInt();
 			if (translate)
 			{
 				Firebird::string s;
@@ -506,7 +506,7 @@ void SHOW_dbb_parameters(Firebird::IAttachment* db_handle,
 			break;
 
 		case isc_info_sweep_interval:
-			value_out = p.getInt();
+			value_out = p.getBigInt();
 			if (translate)
 			{
 				IUTILS_msg_get(SWEEP_INTERV, msg, SafeArg() << value_out);
@@ -517,32 +517,32 @@ void SHOW_dbb_parameters(Firebird::IAttachment* db_handle,
 			break;
 
 		case isc_info_forced_writes:
-			value_out = p.getInt();
+			value_out = p.getBigInt();
 			isqlGlob.printf("Forced Writes are %s%s", (value_out == 1 ? "ON" : "OFF"), separator);
 			break;
 
 		case isc_info_oldest_transaction :
-			value_out = p.getInt();
+			value_out = p.getBigInt();
 			isqlGlob.printf("Transaction - oldest = %" SQUADFORMAT"%s", value_out, separator);
 			break;
 
 		case isc_info_oldest_active :
-			value_out = p.getInt();
+			value_out = p.getBigInt();
 			isqlGlob.printf("Transaction - oldest active = %" SQUADFORMAT"%s", value_out, separator);
 			break;
 
 		case isc_info_oldest_snapshot :
-			value_out = p.getInt();
+			value_out = p.getBigInt();
 			isqlGlob.printf("Transaction - oldest snapshot = %" SQUADFORMAT"%s", value_out, separator);
 			break;
 
 		case isc_info_next_transaction :
-			value_out = p.getInt();
+			value_out = p.getBigInt();
 			isqlGlob.printf("Transaction - Next = %" SQUADFORMAT"%s", value_out, separator);
 			break;
 
 		case isc_info_base_level:
-			value_out = p.getInt();
+			value_out = p.getBigInt();
 			if (translate)
 			{
 				IUTILS_msg_get(BASE_LEVEL, msg, SafeArg() << value_out);
@@ -553,7 +553,7 @@ void SHOW_dbb_parameters(Firebird::IAttachment* db_handle,
 			break;
 
 		case isc_info_limbo:
-			value_out = p.getInt();
+			value_out = p.getBigInt();
 			if (translate)
 			{
 				IUTILS_msg_get(LIMBO, msg, SafeArg() << value_out);
@@ -567,7 +567,7 @@ void SHOW_dbb_parameters(Firebird::IAttachment* db_handle,
 			isqlGlob.major_ods = p.getInt();
 			break;
 		case isc_info_ods_minor_version:
-			value_out = p.getInt();
+			value_out = p.getBigInt();
 			isqlGlob.printf("ODS = %" SLONGFORMAT".%" SQUADFORMAT"%s",
 					(SLONG) isqlGlob.major_ods, value_out, separator);
 			break;
@@ -578,7 +578,7 @@ void SHOW_dbb_parameters(Firebird::IAttachment* db_handle,
 			break;
 
 		case fb_info_protocol_version:
-			value_out = p.getInt();
+			value_out = p.getBigInt();
 			if (value_out)
 				isqlGlob.printf("Protocol version = %" SQUADFORMAT"%s", value_out, separator);
 			else
@@ -656,7 +656,7 @@ void SHOW_dbb_parameters(Firebird::IAttachment* db_handle,
 
 		case fb_info_replica_mode:
 			{
-				value_out = p.getInt();
+				value_out = p.getBigInt();
 				const char* mode =
 					(value_out == fb_info_replica_none) ? "NONE" :
 					(value_out == fb_info_replica_read_only) ? "READ_ONLY" :

--- a/src/isql/show.epp
+++ b/src/isql/show.epp
@@ -523,22 +523,22 @@ void SHOW_dbb_parameters(Firebird::IAttachment* db_handle,
 
 		case isc_info_oldest_transaction :
 			value_out = p.getBigInt();
-			isqlGlob.printf("Transaction - oldest = %" SQUADFORMAT"%s", value_out, separator);
+			isqlGlob.printf("Transaction - oldest = %" UQUADFORMAT"%s", static_cast<TraNumber>(value_out), separator);
 			break;
 
 		case isc_info_oldest_active :
 			value_out = p.getBigInt();
-			isqlGlob.printf("Transaction - oldest active = %" SQUADFORMAT"%s", value_out, separator);
+			isqlGlob.printf("Transaction - oldest active = %" UQUADFORMAT"%s", static_cast<TraNumber>(value_out), separator);
 			break;
 
 		case isc_info_oldest_snapshot :
 			value_out = p.getBigInt();
-			isqlGlob.printf("Transaction - oldest snapshot = %" SQUADFORMAT"%s", value_out, separator);
+			isqlGlob.printf("Transaction - oldest snapshot = %" UQUADFORMAT"%s", static_cast<TraNumber>(value_out), separator);
 			break;
 
 		case isc_info_next_transaction :
 			value_out = p.getBigInt();
-			isqlGlob.printf("Transaction - Next = %" SQUADFORMAT"%s", value_out, separator);
+			isqlGlob.printf("Transaction - Next = %" UQUADFORMAT"%s", static_cast<TraNumber>(value_out), separator);
 			break;
 
 		case isc_info_base_level:
@@ -560,7 +560,7 @@ void SHOW_dbb_parameters(Firebird::IAttachment* db_handle,
 				isqlGlob.printf("%s%s", msg, separator);
 			}
 			else
-				isqlGlob.printf("Transaction in limbo = %" SQUADFORMAT"%s", value_out, separator);
+				isqlGlob.printf("Transaction in limbo = %" UQUADFORMAT"%s", static_cast<TraNumber>(value_out), separator);
 			break;
 
 		case isc_info_ods_version:


### PR DESCRIPTION
Incorrect maximum size occurs for `isc_info_oldest_transaction`, `isc_info_oldest_active`, `isc_info_oldest_snapshot`, `isc_info_next_transaction` and `isc_info_limbo`. This leads to an error if the value is greater than `int`.
Also change maximum size for all parameter values, so we don't get the same error in future.

This bug also occurs in v3.0, v4.0 and v5.0. In v4.0 and v5.0 it can be easily cherry picked, but in v3.0 TraNumber is a signed type, so printf has to be changed.