### PR TITLE
hotfix for Backport for FB3 (fix for #8402)

### DIFF
--- a/src/jrd/jrd.cpp
+++ b/src/jrd/jrd.cpp
@@ -6476,7 +6476,7 @@ static void release_attachment(thread_db* tdbb, Jrd::Attachment* attachment)
 		}
 
 		// Notify special threads
-		threadGuard.leave();
+		activeThreadGuard->leave();
 
 		// Sync with special threads
 		sync.unlock();


### PR DESCRIPTION
The wrong thread guard was released by mistake in the backport (#8412)