### PR TITLE
Fix #8109: Plan/Performance regression when using special construct for IN

### DIFF
--- a/src/dsql/BoolNodes.h
+++ b/src/dsql/BoolNodes.h
@@ -187,6 +187,9 @@ public:
 	void pass2Boolean(thread_db* tdbb, CompilerScratch* csb, std::function<void ()> process) override;
 	bool execute(thread_db* tdbb, Request* request) const override;
 
+private:
+	BoolExprNode* decompose(CompilerScratch* csb);
+
 public:
 	NestConst<ValueExprNode> arg;
 	NestConst<ValueListNode> list;


### PR DESCRIPTION
The solution is to decompose all list items containing field references inside into separate ORed equalities, so they could be optimized separately.