### PR TITLE
Allow specifying exactly what type of database string is expected in the database section for trace configuration

### DIFF
--- a/src/common/config/config_file.cpp
+++ b/src/common/config/config_file.cpp
@@ -961,3 +961,37 @@ bool ConfigFile::Parameter::asBoolean() const
 		value.equalsNoCase("yes") ||
 		value.equalsNoCase("y");
 }
+
+/******************************************************************************
+ *
+ *	Parse name as a section key
+ */
+
+ConfigFile::SectionType ConfigFile::Parameter::parseSectionKey() const
+{
+	if (name == "database")
+	{
+		return SectionType::DATABASE;
+	}
+	else if (name == "databaseName")
+	{
+		return SectionType::DATABASE_NAME;
+	}
+	else if (name == "databaseRegex")
+	{
+		return SectionType::DATABASE_REGEX;
+	}
+	else if (name == "service")
+	{
+		return SectionType::SERVICE;
+	}
+	else
+	{
+		fatal_exception::raiseFmt("error while parsing trace configuration\n\t"
+			"line %d: wrong section header, \"database\", \"databaseName\", \"databaseRegex\" or \"service\" is expected",
+			line);
+
+		// Return something to calm down the compiler
+		return SectionType::DATABASE;
+	}
+}

--- a/src/common/config/config_file.h
+++ b/src/common/config/config_file.h
@@ -75,6 +75,15 @@ public:
 		virtual const char* getFileName() const = 0;
 	};
 
+	// Possible section types
+	enum class SectionType
+	{
+		DATABASE,
+		DATABASE_NAME,
+		DATABASE_REGEX,
+		SERVICE
+	};
+
 	struct Parameter : public AutoStorage
 	{
 		Parameter(MemoryPool& p, const Parameter& par)
@@ -87,6 +96,7 @@ public:
 
 		SINT64 asInteger() const;
 		bool asBoolean() const;
+		SectionType parseSectionKey() const;
 
 		KeyType name;
 		String value;

--- a/src/utilities/ntrace/TraceConfiguration.cpp
+++ b/src/utilities/ntrace/TraceConfiguration.cpp
@@ -90,7 +90,7 @@ void TraceCfgReader::readConfig()
 		const ConfigFile::Parameter* section = &params[n];
 
 		const ConfigFile::SectionType sectionType = section->parseSectionKey();
-		const bool isDatabase = sectionType != ConfigFile::SectionType::SERVICE;
+		const bool isDatabase = (sectionType != ConfigFile::SectionType::SERVICE);
 
 		const ConfigFile::String pattern = section->value;
 		bool match = false;

--- a/src/utilities/ntrace/fbtrace.conf
+++ b/src/utilities/ntrace/fbtrace.conf
@@ -11,10 +11,10 @@
 # expression which is matched against fully qualified database path name.
 #
 # For log file name Sed syntax for substitutions is supported.
-# I.e. \0 - whole matched string, \1 ... \9 - parenthesis subexpressions.
+# I.e. \0 - whole matched string, \1 ... \9 - parenthesis subexpressions. 
 # \\ is backslash.
 #
-# String values should be enclosed into double quotes if contains
+# String values should be enclosed into double quotes if contains 
 # spaces embedded, for example:
 # log_filename "C:\\Documents and Settings\\Firebird\\My Documents\\trace.log"
 # include_filter "Database Stats"
@@ -32,7 +32,6 @@
 #	database = regex (%[\\/](e[[:DIGIT:]]{{2}}).fdb)
 
 
-
 database
 {
 	# Do we trace database events or not
@@ -42,72 +41,72 @@ database
 	# Operations log file name. For use by system audit trace only
 	#log_filename = name
 
-	# Maximum size of log file (megabytes). Used by system audit trace for
+	# Maximum size of log file (megabytes). Used by system audit trace for 
 	# log's rotation : when current log file reached this limit it is renamed
-	# using current date and time and new log file is created. Value of zero
+	# using current date and time and new log file is created. Value of zero 
 	# means that the log file size is unlimited and rotation will never happen.
 	#max_log_size = 0
 
 
-	# SQL query filters.
+	# SQL query filters. 
 	#
-	# Only SQL statements falling under given regular expression are reported
+	# Only SQL statements falling under given regular expression are reported 
 	# in the log.
-	#include_filter
+	#include_filter 
 
-	# SQL statements falling under given regular expression are NOT reported
+	# SQL statements falling under given regular expression are NOT reported 
 	# in the log.
-	#exclude_filter
+	#exclude_filter 
 
 
-	# Put attach/detach log records
+	# Put attach/detach log records 
 	#log_connections = false
 
-	# Trace only given connection id. If zero - trace all connections
+	# Trace only given connection id. If zero - trace all connections 
 	#connection_id = 0
 
-	# Put transaction start/end records
+	# Put transaction start/end records 
 	#log_transactions = false
 
 
-	# Put sql statement prepare records
+	# Put sql statement prepare records 
 	#log_statement_prepare = false
 
-	# Put sql statement free records
+	# Put sql statement free records 
 	#log_statement_free = false
 
-	# Put sql statement execution start records
+	# Put sql statement execution start records 
 	#log_statement_start = false
-
-	# Put sql statement execution finish\fetch to eof records
+	
+	# Put sql statement execution finish\fetch to eof records 
 	#log_statement_finish = false
 
 
 	# Put record when stored procedure is being compiled
 	#log_procedure_compile = false
 
-	# Put record when stored procedure is start execution
+	# Put record when stored procedure is start execution 
 	#log_procedure_start = false
 
-	# Put record when stored procedure is finish execution
+	# Put record when stored procedure is finish execution 
 	#log_procedure_finish = false
 
 	# Put record when stored function is being compiled
 	#log_function_compile = false
 
-	# Put record when stored function is start execution
+	# Put record when stored function is start execution 
 	#log_function_start = false
 
-	# Put record when stored function is finish execution
+	# Put record when stored function is finish execution 
 	#log_function_finish = false
 
 	# Put record when trigger is being compiled
 	#log_trigger_compile = false
 
-	# Put trigger execute records
+	# Put trigger execute records 
 	#log_trigger_start = false
 
-	# Put trigger execute records
+	# Put trigger execute records 
 	#log_trigger_finish = false
 
 
@@ -149,13 +148,13 @@ database
 	#print_perf = false
 
 
-	# Put blr requests compile/execute records
+	# Put blr requests compile/execute records 
 	#log_blr_requests = false
 
 	# Print blr requests or not
 	#print_blr = false
 
-	# Put dyn requests execute records
+	# Put dyn requests execute records 
 	#log_dyn_requests = false
 
 	# Print dyn requests or not
@@ -165,19 +164,19 @@ database
 	# Put xxx_finish record only if its timing exceeds this number of milliseconds
 	#time_threshold = 100
 
-	# Maximum length of SQL string logged
+	# Maximum length of SQL string logged 
 	#max_sql_length = 300
 
-	# Maximum length of blr request logged
+	# Maximum length of blr request logged 
 	#max_blr_length = 500
 
-	# Maximum length of dyn request logged
+	# Maximum length of dyn request logged 
 	#max_dyn_length = 500
 
-	# Maximum length of individual string argument we log
+	# Maximum length of individual string argument we log 
 	#max_arg_length = 80
 
-	# Maximum number of query arguments to put in log
+	# Maximum number of query arguments to put in log 
 	#max_arg_count = 30
 }
 
@@ -185,7 +184,7 @@ database
 
 # default services section
 #
-# List of names of currently existing Firebird services (to use with service
+# List of names of currently existing Firebird services (to use with service 
 # filters below) :
 #	Backup Database
 #	Restore Database
@@ -210,7 +209,7 @@ database
 #	Display User with Admin Info
 #	Validate Database
 #
-services
+services 
 {
 	# Do we trace services events or not
 	#enabled = false
@@ -218,19 +217,19 @@ services
 	# Operations log file name. For use by system audit trace only
 	#log_filename = name
 
-	# Maximum size of log file (megabytes). Used by system audit trace for
-	# log's rotation
+	# Maximum size of log file (megabytes). Used by system audit trace for 
+	# log's rotation 
 	#max_log_size = 0
 
 	# Services filters.
 	#
-	# Only services whose names fall under given regular expression are
+	# Only services whose names fall under given regular expression are 
 	# reported in the log.
-	#include_filter
+	#include_filter 
 
-	# Services whose names fall under given regular expression are NOT
+	# Services whose names fall under given regular expression are NOT 
 	# reported in the log.
-	#exclude_filter
+	#exclude_filter 
 
 	# Put service attach, detach and start records
 	#log_services = false
@@ -272,7 +271,7 @@ database = %[\\/]my_database.fdb
 
 
 # Enable logging for test.fdb, azk2.fdb and rulez.fdb in any directory
-# into log file name matching database name - test.log, azk2.log and
+# into log file name matching database name - test.log, azk2.log and 
 # rulez.log appropriately
 #
 database = %[\\/](test|azk2|rulez).fdb

--- a/src/utilities/ntrace/fbtrace.conf
+++ b/src/utilities/ntrace/fbtrace.conf
@@ -11,10 +11,10 @@
 # expression which is matched against fully qualified database path name.
 #
 # For log file name Sed syntax for substitutions is supported.
-# I.e. \0 - whole matched string, \1 ... \9 - parenthesis subexpressions. 
+# I.e. \0 - whole matched string, \1 ... \9 - parenthesis subexpressions.
 # \\ is backslash.
 #
-# String values should be enclosed into double quotes if contains 
+# String values should be enclosed into double quotes if contains
 # spaces embedded, for example:
 # log_filename "C:\\Documents and Settings\\Firebird\\My Documents\\trace.log"
 # include_filter "Database Stats"
@@ -24,6 +24,13 @@
 #	database = (%[\\/](e[[:DIGIT:]]{2}).fdb)
 # type
 #	database = (%[\\/](e[[:DIGIT:]]{{2}}).fdb)
+#
+# It is also possible to specify exactly what type of database string is expected
+# For example:
+#	database = name /var/dbs/primary-db.fdb
+# type
+#	database = regex (%[\\/](e[[:DIGIT:]]{{2}}).fdb)
+
 
 
 database
@@ -35,72 +42,72 @@ database
 	# Operations log file name. For use by system audit trace only
 	#log_filename = name
 
-	# Maximum size of log file (megabytes). Used by system audit trace for 
+	# Maximum size of log file (megabytes). Used by system audit trace for
 	# log's rotation : when current log file reached this limit it is renamed
-	# using current date and time and new log file is created. Value of zero 
+	# using current date and time and new log file is created. Value of zero
 	# means that the log file size is unlimited and rotation will never happen.
 	#max_log_size = 0
 
 
-	# SQL query filters. 
+	# SQL query filters.
 	#
-	# Only SQL statements falling under given regular expression are reported 
+	# Only SQL statements falling under given regular expression are reported
 	# in the log.
-	#include_filter 
+	#include_filter
 
-	# SQL statements falling under given regular expression are NOT reported 
+	# SQL statements falling under given regular expression are NOT reported
 	# in the log.
-	#exclude_filter 
+	#exclude_filter
 
 
-	# Put attach/detach log records 
+	# Put attach/detach log records
 	#log_connections = false
 
-	# Trace only given connection id. If zero - trace all connections 
+	# Trace only given connection id. If zero - trace all connections
 	#connection_id = 0
 
-	# Put transaction start/end records 
+	# Put transaction start/end records
 	#log_transactions = false
 
 
-	# Put sql statement prepare records 
+	# Put sql statement prepare records
 	#log_statement_prepare = false
 
-	# Put sql statement free records 
+	# Put sql statement free records
 	#log_statement_free = false
 
-	# Put sql statement execution start records 
+	# Put sql statement execution start records
 	#log_statement_start = false
-	
-	# Put sql statement execution finish\fetch to eof records 
+
+	# Put sql statement execution finish\fetch to eof records
 	#log_statement_finish = false
 
 
 	# Put record when stored procedure is being compiled
 	#log_procedure_compile = false
 
-	# Put record when stored procedure is start execution 
+	# Put record when stored procedure is start execution
 	#log_procedure_start = false
 
-	# Put record when stored procedure is finish execution 
+	# Put record when stored procedure is finish execution
 	#log_procedure_finish = false
 
 	# Put record when stored function is being compiled
 	#log_function_compile = false
 
-	# Put record when stored function is start execution 
+	# Put record when stored function is start execution
 	#log_function_start = false
 
-	# Put record when stored function is finish execution 
+	# Put record when stored function is finish execution
 	#log_function_finish = false
 
 	# Put record when trigger is being compiled
 	#log_trigger_compile = false
 
-	# Put trigger execute records 
+	# Put trigger execute records
 	#log_trigger_start = false
 
-	# Put trigger execute records 
+	# Put trigger execute records
 	#log_trigger_finish = false
 
 
@@ -142,13 +149,13 @@ database
 	#print_perf = false
 
 
-	# Put blr requests compile/execute records 
+	# Put blr requests compile/execute records
 	#log_blr_requests = false
 
 	# Print blr requests or not
 	#print_blr = false
 
-	# Put dyn requests execute records 
+	# Put dyn requests execute records
 	#log_dyn_requests = false
 
 	# Print dyn requests or not
@@ -158,19 +165,19 @@ database
 	# Put xxx_finish record only if its timing exceeds this number of milliseconds
 	#time_threshold = 100
 
-	# Maximum length of SQL string logged 
+	# Maximum length of SQL string logged
 	#max_sql_length = 300
 
-	# Maximum length of blr request logged 
+	# Maximum length of blr request logged
 	#max_blr_length = 500
 
-	# Maximum length of dyn request logged 
+	# Maximum length of dyn request logged
 	#max_dyn_length = 500
 
-	# Maximum length of individual string argument we log 
+	# Maximum length of individual string argument we log
 	#max_arg_length = 80
 
-	# Maximum number of query arguments to put in log 
+	# Maximum number of query arguments to put in log
 	#max_arg_count = 30
 }
 
@@ -178,7 +185,7 @@ database
 
 # default services section
 #
-# List of names of currently existing Firebird services (to use with service 
+# List of names of currently existing Firebird services (to use with service
 # filters below) :
 #	Backup Database
 #	Restore Database
@@ -203,7 +210,7 @@ database
 #	Display User with Admin Info
 #	Validate Database
 #
-services 
+services
 {
 	# Do we trace services events or not
 	#enabled = false
@@ -211,19 +218,19 @@ services
 	# Operations log file name. For use by system audit trace only
 	#log_filename = name
 
-	# Maximum size of log file (megabytes). Used by system audit trace for 
-	# log's rotation 
+	# Maximum size of log file (megabytes). Used by system audit trace for
+	# log's rotation
 	#max_log_size = 0
 
 	# Services filters.
 	#
-	# Only services whose names fall under given regular expression are 
+	# Only services whose names fall under given regular expression are
 	# reported in the log.
-	#include_filter 
+	#include_filter
 
-	# Services whose names fall under given regular expression are NOT 
+	# Services whose names fall under given regular expression are NOT
 	# reported in the log.
-	#exclude_filter 
+	#exclude_filter
 
 	# Put service attach, detach and start records
 	#log_services = false
@@ -265,7 +272,7 @@ database = %[\\/]my_database.fdb
 
 
 # Enable logging for test.fdb, azk2.fdb and rulez.fdb in any directory
-# into log file name matching database name - test.log, azk2.log and 
+# into log file name matching database name - test.log, azk2.log and
 # rulez.log appropriately
 #
 database = %[\\/](test|azk2|rulez).fdb

--- a/src/utilities/ntrace/fbtrace.conf
+++ b/src/utilities/ntrace/fbtrace.conf
@@ -27,9 +27,9 @@
 #
 # It is also possible to specify exactly what type of database string is expected
 # For example:
-#	database = name /var/dbs/primary-db.fdb
+#	databaseName = /var/dbs/primary-db.fdb
 # type
-#	database = regex (%[\\/](e[[:DIGIT:]]{{2}}).fdb)
+#	databaseRegex = (%[\\/](e[[:DIGIT:]]{{2}}).fdb)
 
 
 database


### PR DESCRIPTION
The new syntax:  
  ```
database = name /var/primary-db.fdb  
{  
  enabled = true  
  log_errors = true  
}  

database = name /var/secondary.fdb  
{  
  enabled = true  
  log_connections = true  
}  

database = regex (%[\\/](e[[:DIGIT:]]{{2}}).fdb)  
{  
  enabled = true  
}  

# Default behavior for backward compatibility  
database = %[\\/]my_database.fdb  
{  
  enabled = true  
}  
```
  

I chose `database = name path.fdb` over `database name = path.fdb` because it is easier to implement and parse, but it doesn't look as great, so it can be reimplemented.  
