### PR TITLE
ODS14: Store (and return via *_LENGTH functions) blob length longer than 4GB

### DIFF
--- a/src/dsql/ExprNodes.cpp
+++ b/src/dsql/ExprNodes.cpp
@@ -11079,7 +11079,7 @@ dsc* StrLenNode::execute(thread_db* tdbb, Request* request) const
 		switch (blrSubOp)
 		{
 			case blr_strlen_bit:
-				length = (FB_UINT64) blob->blb_length * 8;
+				length = blob->blb_length * 8;
 				break;
 
 			case blr_strlen_octet:

--- a/src/jrd/blb.h
+++ b/src/jrd/blb.h
@@ -76,7 +76,7 @@ public:
 	jrd_rel* blb_relation;			// Relation, if known
 	JBlob* blb_interface;
 
-	ULONG blb_length;				// Total length of data sans segments
+	FB_UINT64 blb_length;			// Blob's total length (in bytes)
 	USHORT blb_flags;				// Interesting stuff (see below)
 
 	SSHORT blb_sub_type;			// Blob's declared sub-type

--- a/src/jrd/ods.h
+++ b/src/jrd/ods.h
@@ -800,17 +800,16 @@ struct blh
 	ULONG blh_max_sequence;		// Number of data pages
 	USHORT blh_max_segment;		// Longest segment
 	USHORT blh_flags;			// flags, etc
-	UCHAR blh_level;			// Number of address levels, see blb_level in blb.h
 	ULONG blh_count;			// Total number of segments
-	ULONG blh_length;			// Total length of data
+	FB_UINT64 blh_length;		// Total length of data
 	USHORT blh_sub_type;		// Blob sub-type
-	UCHAR blh_charset;			// Blob charset (since ODS 11.1)
+	UCHAR blh_charset;			// Blob charset
+	UCHAR blh_level;			// Number of address levels, see blb_level in blb.h
 // Macro CHECK_BLOB_FIELD_ACCESS_FOR_SELECT is never defined, code under it was left for a case
 // we would like to have that check in a future.
 #ifdef CHECK_BLOB_FIELD_ACCESS_FOR_SELECT
 	USHORT blh_fld_id;			// Field ID
 #endif
-	UCHAR blh_unused;
 	ULONG blh_page[1];			// Page vector for blob pages
 };
 
@@ -819,16 +818,15 @@ static_assert(offsetof(struct blh, blh_lead_page) == 0, "blh_lead_page offset mi
 static_assert(offsetof(struct blh, blh_max_sequence) == 4, "blh_max_sequence offset mismatch");
 static_assert(offsetof(struct blh, blh_max_segment) == 8, "blh_max_segment offset mismatch");
 static_assert(offsetof(struct blh, blh_flags) == 10, "blh_flags offset mismatch");
-static_assert(offsetof(struct blh, blh_level) == 12, "blh_level offset mismatch");
-static_assert(offsetof(struct blh, blh_count) == 16, "blh_count offset mismatch");
-static_assert(offsetof(struct blh, blh_length) == 20, "blh_length offset mismatch");
+static_assert(offsetof(struct blh, blh_count) == 12, "blh_count offset mismatch");
+static_assert(offsetof(struct blh, blh_length) == 16, "blh_length offset mismatch");
 static_assert(offsetof(struct blh, blh_sub_type) == 24, "blh_sub_type offset mismatch");
 static_assert(offsetof(struct blh, blh_charset) == 26, "blh_charset offset mismatch");
-static_assert(offsetof(struct blh, blh_unused) == 27, "blh_unused offset mismatch");
+static_assert(offsetof(struct blh, blh_level) == 27, "blh_level offset mismatch");
 static_assert(offsetof(struct blh, blh_page) == 28, "blh_page offset mismatch");
 
-
 #define BLH_SIZE static_cast<FB_SIZE_T>(offsetof(Ods::blh, blh_page[0]))
+
 // rhd_flags, rhdf_flags and blh_flags
 
 // record_param flags in req.h must be an exact replica of ODS record header flags


### PR DESCRIPTION
This PR contains only ODS-related change (to be merged together with #8401 and #8340). The `blh` layout has been slightly modified to preserve the blob header size.

The code requires more changes to support bigger BLOBs properly, appropriate PR will be offered later.