### PR TITLE
Fix server hang when trying to stop a server with active connections with event notifications

### DIFF
--- a/src/remote/inet.cpp
+++ b/src/remote/inet.cpp
@@ -1839,7 +1839,11 @@ static void force_close(rem_port* port)
  **************************************/
 
 	if (port->port_async)
-		abort_aux_connection(port->port_async);
+	{
+		rem_port* port_async = port->port_async;
+		abort_aux_connection(port_async);
+		port_async->force_close();
+	}
 
 	if (port->port_state != rem_port::PENDING)
 		return;


### PR DESCRIPTION
The reason for the hang is that we handle `port_async` in a strange way. When we create it in `aux_request()` it is added to chain of client ports (`port_clients`) via `alloc_port()`, but is not added to `inet_ports`. `inet_ports` used in `PortsCleanup::closePorts()` when we start shutdown server to close ports that we currently have. So, after closing all client ports, except `port_async`, we start looping over these active ports in `select_multi()`, hoping to get some data from them. This is happens because `port_async` is presented in `port_clients` chain and has `port_state = PENDING`.
My fix for this problem is to close `port_async` when we close it's parent port.

The hang can be reproduced by running `example/api/api16` and making one more additional connection to the database, then try to kill the server, it will hang with inability to receive new connections, it can only be stopped with `kill -9`.

This bug can also be reproduced in v5.0, I haven't tested it in older versions, but it seems the code is the same.