### PR TITLE
Fix implicitly used collations after ALTER DOMAIN

### DIFF
--- a/src/dsql/DdlNodes.epp
+++ b/src/dsql/DdlNodes.epp
@@ -6541,7 +6541,8 @@ void RelationNode::defineField(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch
 		}
 
 		fieldDefinition.defaultValue = defaultValue;
-		fieldDefinition.collationId = field->collationId;
+		if (field->typeOfName.isEmpty())
+			fieldDefinition.collationId = field->collationId;
 		fieldDefinition.store(tdbb, transaction);
 
 		// Define the field constraints.

--- a/src/dsql/DdlNodes.epp
+++ b/src/dsql/DdlNodes.epp
@@ -6480,11 +6480,10 @@ void RelationNode::defineField(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch
 			storeGlobalField(tdbb, transaction, fieldDefinition.fieldSource, field,
 				computedSource, computedValue);
 		}
-		else
+		else if (field->collate.hasData())
 		{
 			// Resolve possible additional collation for domains. For plain types it is already resolved above.
-			if (field->collate.hasData())
-				DDL_resolve_intl_type(dsqlScratch, field, field->collate);
+			DDL_resolve_intl_type(dsqlScratch, field, field->collate);
 		}
 
 		if ((relation->rel_flags & REL_external) &&
@@ -6541,7 +6540,7 @@ void RelationNode::defineField(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch
 		}
 
 		fieldDefinition.defaultValue = defaultValue;
-		if (field->typeOfName.isEmpty())
+		if (field->typeOfName.isEmpty() || field->collate.hasData())
 			fieldDefinition.collationId = field->collationId;
 		fieldDefinition.store(tdbb, transaction);
 

--- a/src/dsql/parse.y
+++ b/src/dsql/parse.y
@@ -4281,13 +4281,7 @@ alter_domain_op($alterDomainNode)
 	| TO symbol_column_name
 		{ setClause($alterDomainNode->renameTo, "DOMAIN NAME", *$2); }
 	| TYPE non_array_type
-		{
-			//// FIXME: ALTER DOMAIN doesn't support collations, and altered domain's
-			//// collation is always lost.
-			dsql_fld* type = $2;
-			type->collate = "";
-			setClause($alterDomainNode->type, "DOMAIN TYPE", type);
-		}
+		{ setClause($alterDomainNode->type, "DOMAIN TYPE", $2);}
 	;
 
 %type alter_ops(<relationNode>)


### PR DESCRIPTION
This is a postfix for PR #7748. Before this PR, if the field's collation was derived from some domain, RDB$COLLATION_ID was not filled inside RDB$RELATION_FIELDS and collation was inherited from the domain definition. Now it's broken.

Test case:

```sql
CREATE DOMAIN d1 VARCHAR(30) CHARACTER SET UTF8 COLLATE UNICODE;
CREATE TABLE test(data1 d1);
COMMIT;
INSERT INTO test VALUES('A');
INSERT INTO test VALUES('a');
COMMIT;

ALTER DOMAIN d1 TYPE VARCHAR(30) CHARACTER SET UTF8 COLLATE UNICODE_CI;
COMMIT;

SELECT data1 FROM test WHERE data1 = 'a';
```

```
DATA1                          
============================== 
a
```

Expected:

```
DATA1                          
============================== 
A                              
a
```