### PR TITLE
Ignore NULLs (if desired) while scanning keys during index navigation

### DIFF
--- a/src/jrd/btr.cpp
+++ b/src/jrd/btr.cpp
@@ -1241,8 +1241,8 @@ void BTR_evaluate(thread_db* tdbb, const IndexRetrieval* retrieval, RecordBitmap
 				{
 					// If we're walking in a descending index and we need to ignore NULLs
 					// then stop at the first NULL we see (only for single segment!)
-					if (descending && ignoreNulls && node.prefix == 0 &&
-						node.length >= 1 && node.data[0] == 255)
+					if (descending && ignoreNulls &&
+						node.prefix == 0 && node.length >= 1 && node.data[0] == 255)
 					{
 						break;
 					}
@@ -6906,18 +6906,13 @@ static bool scan(thread_db* tdbb, UCHAR* pointer, RecordBitmap** bitmap, RecordB
 			return true;
 		}
 
-		// Ignore NULL-values, this is currently only available for single segment indexes.
+		// Ignore NULL-values, this is currently only available for single segment indexes
 		if (ignoreNulls)
 		{
-			ignore = false;
-			if (descending)
-			{
-				if ((node.prefix == 0) && (node.length >= 1) && (node.data[0] == 255))
-					return false;
-			}
-			else {
-				ignore = (node.prefix + node.length == 0); // Ascending (prefix + length == 0)
-			}
+			if (descending && node.prefix == 0 && node.length >= 1 && node.data[0] == 255)
+				return false;
+
+			ignore = descending ? false : (node.prefix + node.length == 0);
 		}
 
 		if (skipLowerKey)

--- a/src/jrd/recsrc/IndexTableScan.cpp
+++ b/src/jrd/recsrc/IndexTableScan.cpp
@@ -198,6 +198,7 @@ bool IndexTableScan::internalGetRecord(thread_db* tdbb) const
 	}
 
 	index_desc* const idx = (index_desc*) ((SCHAR*) impure + m_offset);
+	const bool descending = (idx->idx_flags & idx_descending);
 
 	// find the last fetched position from the index
 	const USHORT pageSpaceID = m_relation->getPages(tdbb)->rel_pg_space_id;
@@ -205,6 +206,8 @@ bool IndexTableScan::internalGetRecord(thread_db* tdbb) const
 
 	const IndexRetrieval* const retrieval = m_index->retrieval;
 	const USHORT flags = retrieval->irb_generic & (irb_descending | irb_partial | irb_starting);
+	const bool ignoreNulls =
+		(retrieval->irb_generic & irb_ignore_null_value_key) && (idx->idx_count == 1);
 
 	do
 	{
@@ -252,6 +255,14 @@ bool IndexTableScan::internalGetRecord(thread_db* tdbb) const
 				continue;
 			}
 
+			// If we're walking in a descending index and we need to ignore NULLs
+			// then stop at the first NULL we see (only for single segment!)
+			if (descending && ignoreNulls && node.prefix == 0 &&
+				node.length >= 1 && node.data[0] == 255)
+			{
+				break;
+			}
+
 			// Build the current key value from the prefix and current node data.
 			memcpy(key.key_data + node.prefix, node.data, node.length);
 			key.key_length = node.length + node.prefix;
@@ -297,12 +308,16 @@ bool IndexTableScan::internalGetRecord(thread_db* tdbb) const
 				break;
 			}
 
-			// skip this record if:
-			// 1) there is an inversion tree for this index and this record
-			//    is not in the bitmap for the inversion, or
-			// 2) the record has already been visited
+			const bool skipNullKey = (ignoreNulls && !descending && !key.key_length);
 
-			if ((!(impure->irsb_flags & irsb_mustread) &&
+			// Skip this record if:
+			// 1) NULL key is found and we were asked to ignore them, or
+			// 2) there is an inversion tree for this index and this record
+			//    is not in the bitmap for the inversion, or
+			// 3) the record has already been visited
+
+			if (skipNullKey ||
+				(!(impure->irsb_flags & irsb_mustread) &&
 				(!impure->irsb_nav_bitmap ||
 					!RecordBitmap::test(*impure->irsb_nav_bitmap, number.getValue()))) ||
 				RecordBitmap::test(impure->irsb_nav_records_visited, number.getValue()))

--- a/src/jrd/recsrc/IndexTableScan.cpp
+++ b/src/jrd/recsrc/IndexTableScan.cpp
@@ -257,8 +257,8 @@ bool IndexTableScan::internalGetRecord(thread_db* tdbb) const
 
 			// If we're walking in a descending index and we need to ignore NULLs
 			// then stop at the first NULL we see (only for single segment!)
-			if (descending && ignoreNulls && node.prefix == 0 &&
-				node.length >= 1 && node.data[0] == 255)
+			if (descending && ignoreNulls &&
+				node.prefix == 0 && node.length >= 1 && node.data[0] == 255)
 			{
 				break;
 			}


### PR DESCRIPTION
See also #8291. This improvement completes the solution by extending the "ignore null" checks to the scan phase. The logic mostly matches `btr.cpp` (`BTR_evaluate()` and `scan()`).

With the same test case, results are:

before this PR:

```sql
SELECT count(*) from (SELECT ID FROM T WHERE ID < 3 ORDER BY ID);

Select Expression
    -> Aggregate
        -> Filter
            -> Table "T" Access By ID
                -> Index "IT" Range Scan (upper bound: 1/1)

                COUNT 
===================== 
                    1 

-- Fetches = 1775
```

after this PR:

```sql
-- Fetches = 7
```