### PR TITLE
Fix reset of db guid in fixup

### DIFF
--- a/src/utilities/nbackup/nbackup.cpp
+++ b/src/utilities/nbackup/nbackup.cpp
@@ -859,9 +859,6 @@ void NBackup::fixup_database(bool repl_seq, bool set_readonly)
 
 	if (!repl_seq)
 	{
-		// Replace existing database GUID with a regenerated one
-		Guid::generate().copyTo(header->hdr_guid);
-
 		size = page_size;
 		header = reinterpret_cast<Ods::header_page*>(header_buffer.getBuffer(size));
 
@@ -869,6 +866,9 @@ void NBackup::fixup_database(bool repl_seq, bool set_readonly)
 
 		if (read_file(dbase, header, size) != size)
 			status_exception::raise(Arg::Gds(isc_nbackup_err_eofdb) << dbname.c_str());
+
+		// Replace existing database GUID with a regenerated one
+		Guid::generate().copyTo(header->hdr_guid);
 
 		auto p = header->hdr_data;
 		const auto end = (UCHAR*) header + header->hdr_page_size;


### PR DESCRIPTION
Fixes DB GUID not being reset by fixup. Caused by changes in 93db88084d5a04aaa3f98179e76cdfa092431fa8.