### PR TITLE
Fix windows warnings (C4554, C4018) and mark error message constants as constexpr (C26814)

### DIFF
--- a/src/burp/BurpTasks.cpp
+++ b/src/burp/BurpTasks.cpp
@@ -840,7 +840,7 @@ void RestoreRelationTask::verbRecs(FB_UINT64& records, bool total)
 
 void RestoreRelationTask::verbRecsFinal()
 {
-	if (m_verbRecs < m_records)
+	if (m_verbRecs < static_cast<FB_UINT64>(m_records))
 	{
 		m_verbRecs = m_records;
 		BURP_verbose(107, SafeArg() << m_verbRecs);

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -12406,7 +12406,7 @@ bool RestoreRelationTask::fileReader(Item& item)
 		const FB_SSIZE_T attLen = 1 + (tdgbl->gbl_sw_transportable ? 12 : 6);
 		const FB_SSIZE_T overhead = tdgbl->gbl_sw_compress ? (len / 127 + 1) : 0;
 
-		if (len + attLen + overhead > space)
+		if (static_cast<FB_SSIZE_T>(len) + attLen + overhead > space)
 		{
 			if (ioBuf)
 			{

--- a/src/common/unicode_util.cpp
+++ b/src/common/unicode_util.cpp
@@ -1615,7 +1615,7 @@ UnicodeUtil::Utf16Collation* UnicodeUtil::Utf16Collation::create(
 
 		if (len >= 2)
 		{
-			obj->maxContractionsPrefixLength = len - 1 > obj->maxContractionsPrefixLength ?
+			obj->maxContractionsPrefixLength = static_cast<ULONG>(len - 1) > obj->maxContractionsPrefixLength ?
 				len - 1 : obj->maxContractionsPrefixLength;
 
 			UCHAR key[100];
@@ -1865,7 +1865,7 @@ USHORT UnicodeUtil::Utf16Collation::stringToKey(USHORT srcLen, const USHORT* src
 						lastCharKeyLen = icu->ucolGetSortKey(coll,
 							reinterpret_cast<const UChar*>(src + srcLenLong), i, lastCharKey, sizeof(lastCharKey));
 
-						if (prefixLen == 0 || prefixLen > dstLen - 2 || prefixLen > MAX_USHORT ||
+						if (prefixLen == 0 || prefixLen > dstLen - 2u || prefixLen > MAX_USHORT ||
 							lastCharKeyLen == 0)
 						{
 							return INTL_BAD_KEY_LENGTH;
@@ -1895,7 +1895,7 @@ USHORT UnicodeUtil::Utf16Collation::stringToKey(USHORT srcLen, const USHORT* src
 
 						const ULONG keyLen = prefixLen + keyIt.getCount() - advance;
 
-						if (keyLen > dstLen - 2 || keyLen > MAX_USHORT)
+						if (keyLen > dstLen - 2u || keyLen > MAX_USHORT)
 							return INTL_BAD_KEY_LENGTH;
 
 						dst[0] = UCHAR(keyLen & 0xFF);
@@ -1920,7 +1920,7 @@ USHORT UnicodeUtil::Utf16Collation::stringToKey(USHORT srcLen, const USHORT* src
 		ULONG keyLen = icu->ucolGetSortKey(coll,
 			reinterpret_cast<const UChar*>(src), srcLenLong, originalDst + 2, originalDstLen - 3);
 
-		if (keyLen == 0 || keyLen > originalDstLen - 3 || keyLen > MAX_USHORT)
+		if (keyLen == 0 || keyLen > originalDstLen - 3u || keyLen > MAX_USHORT)
 			return INTL_BAD_KEY_LENGTH;
 
 		fb_assert(originalDst[2 + keyLen - 1] == '\0');

--- a/src/dsql/BoolNodes.cpp
+++ b/src/dsql/BoolNodes.cpp
@@ -1058,7 +1058,7 @@ bool ComparativeBoolNode::stringBoolean(thread_db* tdbb, Request* request, dsc* 
 			cache->matcher->reset();
 		else
 		{
-			if (cache && cache->keySize < patternLen + escapeLen)
+			if (cache && cache->keySize < static_cast<ULONG>(patternLen) + escapeLen)
 			{
 				delete cache;
 				cache = nullptr;

--- a/src/dsql/ExprNodes.cpp
+++ b/src/dsql/ExprNodes.cpp
@@ -12214,11 +12214,11 @@ dsc* SubstringSimilarNode::execute(thread_db* tdbb, Request* request) const
 
 	MoveBuffer patternBuffer;
 	UCHAR* patternStr;
-	int patternLen = MOV_make_string2(tdbb, patternDesc, textType, &patternStr, patternBuffer);
+	ULONG patternLen = MOV_make_string2(tdbb, patternDesc, textType, &patternStr, patternBuffer);
 
 	MoveBuffer escapeBuffer;
 	UCHAR* escapeStr;
-	int escapeLen = MOV_make_string2(tdbb, escapeDesc, textType, &escapeStr, escapeBuffer);
+	ULONG escapeLen = MOV_make_string2(tdbb, escapeDesc, textType, &escapeStr, escapeBuffer);
 
 	// Verify the correctness of the escape character.
 	if (escapeLen == 0 || charSet->length(escapeLen, escapeStr, true) != 1)

--- a/src/dsql/StmtNodes.cpp
+++ b/src/dsql/StmtNodes.cpp
@@ -3428,7 +3428,7 @@ ExecProcedureNode* ExecProcedureNode::dsqlPass(DsqlCompilerScratch* dsqlScratch)
 		const auto positionalArgCount = inputSources->items.getCount() -
 			(dsqlInputArgNames ? dsqlInputArgNames->getCount() : 0);
 
-		if (positionalArgCount > procedure->prc_in_count || dsqlInputArgNames)
+		if (static_cast<SSHORT>(positionalArgCount) > procedure->prc_in_count || dsqlInputArgNames)
 		{
 			const auto newInputs = FB_NEW_POOL(pool) ValueListNode(pool);
 			const auto newOutputs = FB_NEW_POOL(pool) ValueListNode(pool);
@@ -3443,7 +3443,7 @@ ExecProcedureNode* ExecProcedureNode::dsqlPass(DsqlCompilerScratch* dsqlScratch)
 
 			for (auto source : inputSources->items)
 			{
-				const bool isInput = (pos < positionalArgCount && pos < procedure->prc_in_count) ||
+				const bool isInput = (pos < positionalArgCount && pos < static_cast<unsigned>(procedure->prc_in_count)) ||
 					(pos >= positionalArgCount &&
 						!outFields.exist((*dsqlInputArgNames)[pos - positionalArgCount]));
 

--- a/src/include/firebird/iberror.h
+++ b/src/include/firebird/iberror.h
@@ -18,37 +18,37 @@
 #ifdef __cplusplus /* c++ definitions */
 
 #if __cplusplus >= 201703L // C++17 or later
-#define STATUS_CONST inline constexpr ISC_STATUS
+#define FB_STATUS_CONST inline constexpr ISC_STATUS
 #else
-#define STATUS_CONST const ISC_STATUS
+#define FB_STATUS_CONST const ISC_STATUS
 #endif
 
-STATUS_CONST isc_facility = 20;
-STATUS_CONST isc_base = isc_facility << 24;
-STATUS_CONST isc_factor = 1;
+FB_STATUS_CONST isc_facility = 20;
+FB_STATUS_CONST isc_base = isc_facility << 24;
+FB_STATUS_CONST isc_factor = 1;
 
-STATUS_CONST isc_arg_end				= 0;	// end of argument list
-STATUS_CONST isc_arg_gds				= 1;	// generic DSRI status value
-STATUS_CONST isc_arg_string			= 2;	// string argument
-STATUS_CONST isc_arg_cstring			= 3;	// count & string argument
-STATUS_CONST isc_arg_number			= 4;	// numeric argument (long)
-STATUS_CONST isc_arg_interpreted		= 5;	// interpreted status code (string)
-STATUS_CONST isc_arg_vms				= 6;	// VAX/VMS status code (long)
-STATUS_CONST isc_arg_unix			= 7;	// UNIX error code
-STATUS_CONST isc_arg_domain			= 8;	// Apollo/Domain error code
-STATUS_CONST isc_arg_dos				= 9;	// MSDOS/OS2 error code
-STATUS_CONST isc_arg_mpexl			= 10;	// HP MPE/XL error code
-STATUS_CONST isc_arg_mpexl_ipc		= 11;	// HP MPE/XL IPC error code
-STATUS_CONST isc_arg_next_mach		= 15;	// NeXT/Mach error code
-STATUS_CONST isc_arg_netware			= 16;	// NetWare error code
-STATUS_CONST isc_arg_win32			= 17;	// Win32 error code
-STATUS_CONST isc_arg_warning			= 18;	// warning argument
-STATUS_CONST isc_arg_sql_state		= 19;	// SQLSTATE
+FB_STATUS_CONST isc_arg_end				= 0;	// end of argument list
+FB_STATUS_CONST isc_arg_gds				= 1;	// generic DSRI status value
+FB_STATUS_CONST isc_arg_string			= 2;	// string argument
+FB_STATUS_CONST isc_arg_cstring			= 3;	// count & string argument
+FB_STATUS_CONST isc_arg_number			= 4;	// numeric argument (long)
+FB_STATUS_CONST isc_arg_interpreted		= 5;	// interpreted status code (string)
+FB_STATUS_CONST isc_arg_vms				= 6;	// VAX/VMS status code (long)
+FB_STATUS_CONST isc_arg_unix			= 7;	// UNIX error code
+FB_STATUS_CONST isc_arg_domain			= 8;	// Apollo/Domain error code
+FB_STATUS_CONST isc_arg_dos				= 9;	// MSDOS/OS2 error code
+FB_STATUS_CONST isc_arg_mpexl			= 10;	// HP MPE/XL error code
+FB_STATUS_CONST isc_arg_mpexl_ipc		= 11;	// HP MPE/XL IPC error code
+FB_STATUS_CONST isc_arg_next_mach		= 15;	// NeXT/Mach error code
+FB_STATUS_CONST isc_arg_netware			= 16;	// NetWare error code
+FB_STATUS_CONST isc_arg_win32			= 17;	// Win32 error code
+FB_STATUS_CONST isc_arg_warning			= 18;	// warning argument
+FB_STATUS_CONST isc_arg_sql_state		= 19;	// SQLSTATE
 
 #define FB_IMPL_MSG_NO_SYMBOL(facility, number, text)
 
 #define FB_IMPL_MSG_SYMBOL(facility, number, symbol, text) \
-	STATUS_CONST isc_##symbol = FB_IMPL_MSG_ENCODE(number, FB_IMPL_MSG_FACILITY_##facility);
+	FB_STATUS_CONST isc_##symbol = FB_IMPL_MSG_ENCODE(number, FB_IMPL_MSG_FACILITY_##facility);
 
 #define FB_IMPL_MSG(facility, number, symbol, sqlCode, sqlClass, sqlSubClass, text)	\
 	FB_IMPL_MSG_SYMBOL(facility, number, symbol, text)
@@ -59,7 +59,7 @@ STATUS_CONST isc_arg_sql_state		= 19;	// SQLSTATE
 #undef FB_IMPL_MSG_SYMBOL
 #undef FB_IMPL_MSG
 
-STATUS_CONST isc_err_max = 0
+FB_STATUS_CONST isc_err_max = 0
 	#define FB_IMPL_MSG_NO_SYMBOL(facility, number, text)
 	#define FB_IMPL_MSG_SYMBOL(facility, number, symbol, text)
 	#define FB_IMPL_MSG(facility, number, symbol, sqlCode, sqlClass, sqlSubClass, text) + 1
@@ -71,6 +71,8 @@ STATUS_CONST isc_err_max = 0
 	#undef FB_IMPL_MSG
 	;
 
+
+#undef FB_STATUS_CONST
 
 #else /* c definitions */
 

--- a/src/include/firebird/iberror.h
+++ b/src/include/firebird/iberror.h
@@ -17,32 +17,38 @@
 
 #ifdef __cplusplus /* c++ definitions */
 
-const ISC_STATUS isc_facility = 20;
-const ISC_STATUS isc_base = isc_facility << 24;
-const ISC_STATUS isc_factor = 1;
+#if __cplusplus >= 201703L // C++17 or later
+#define STATUS_CONST inline constexpr ISC_STATUS
+#else
+#define STATUS_CONST const ISC_STATUS
+#endif
 
-const ISC_STATUS isc_arg_end			= 0;	// end of argument list
-const ISC_STATUS isc_arg_gds			= 1;	// generic DSRI status value
-const ISC_STATUS isc_arg_string			= 2;	// string argument
-const ISC_STATUS isc_arg_cstring		= 3;	// count & string argument
-const ISC_STATUS isc_arg_number			= 4;	// numeric argument (long)
-const ISC_STATUS isc_arg_interpreted	= 5;	// interpreted status code (string)
-const ISC_STATUS isc_arg_vms			= 6;	// VAX/VMS status code (long)
-const ISC_STATUS isc_arg_unix			= 7;	// UNIX error code
-const ISC_STATUS isc_arg_domain			= 8;	// Apollo/Domain error code
-const ISC_STATUS isc_arg_dos			= 9;	// MSDOS/OS2 error code
-const ISC_STATUS isc_arg_mpexl			= 10;	// HP MPE/XL error code
-const ISC_STATUS isc_arg_mpexl_ipc		= 11;	// HP MPE/XL IPC error code
-const ISC_STATUS isc_arg_next_mach		= 15;	// NeXT/Mach error code
-const ISC_STATUS isc_arg_netware		= 16;	// NetWare error code
-const ISC_STATUS isc_arg_win32			= 17;	// Win32 error code
-const ISC_STATUS isc_arg_warning		= 18;	// warning argument
-const ISC_STATUS isc_arg_sql_state		= 19;	// SQLSTATE
+STATUS_CONST isc_facility = 20;
+STATUS_CONST isc_base = isc_facility << 24;
+STATUS_CONST isc_factor = 1;
+
+STATUS_CONST isc_arg_end				= 0;	// end of argument list
+STATUS_CONST isc_arg_gds				= 1;	// generic DSRI status value
+STATUS_CONST isc_arg_string			= 2;	// string argument
+STATUS_CONST isc_arg_cstring			= 3;	// count & string argument
+STATUS_CONST isc_arg_number			= 4;	// numeric argument (long)
+STATUS_CONST isc_arg_interpreted		= 5;	// interpreted status code (string)
+STATUS_CONST isc_arg_vms				= 6;	// VAX/VMS status code (long)
+STATUS_CONST isc_arg_unix			= 7;	// UNIX error code
+STATUS_CONST isc_arg_domain			= 8;	// Apollo/Domain error code
+STATUS_CONST isc_arg_dos				= 9;	// MSDOS/OS2 error code
+STATUS_CONST isc_arg_mpexl			= 10;	// HP MPE/XL error code
+STATUS_CONST isc_arg_mpexl_ipc		= 11;	// HP MPE/XL IPC error code
+STATUS_CONST isc_arg_next_mach		= 15;	// NeXT/Mach error code
+STATUS_CONST isc_arg_netware			= 16;	// NetWare error code
+STATUS_CONST isc_arg_win32			= 17;	// Win32 error code
+STATUS_CONST isc_arg_warning			= 18;	// warning argument
+STATUS_CONST isc_arg_sql_state		= 19;	// SQLSTATE
 
 #define FB_IMPL_MSG_NO_SYMBOL(facility, number, text)
 
 #define FB_IMPL_MSG_SYMBOL(facility, number, symbol, text) \
-	const ISC_STATUS isc_##symbol = FB_IMPL_MSG_ENCODE(number, FB_IMPL_MSG_FACILITY_##facility);
+	STATUS_CONST isc_##symbol = FB_IMPL_MSG_ENCODE(number, FB_IMPL_MSG_FACILITY_##facility);
 
 #define FB_IMPL_MSG(facility, number, symbol, sqlCode, sqlClass, sqlSubClass, text)	\
 	FB_IMPL_MSG_SYMBOL(facility, number, symbol, text)
@@ -53,7 +59,7 @@ const ISC_STATUS isc_arg_sql_state		= 19;	// SQLSTATE
 #undef FB_IMPL_MSG_SYMBOL
 #undef FB_IMPL_MSG
 
-const ISC_STATUS isc_err_max = 0
+STATUS_CONST isc_err_max = 0
 	#define FB_IMPL_MSG_NO_SYMBOL(facility, number, text)
 	#define FB_IMPL_MSG_SYMBOL(facility, number, symbol, text)
 	#define FB_IMPL_MSG(facility, number, symbol, sqlCode, sqlClass, sqlSubClass, text) + 1

--- a/src/isql/isql.h
+++ b/src/isql/isql.h
@@ -111,7 +111,7 @@ const int ISQL_MSG_FAC	= FB_IMPL_MSG_FACILITY_ISQL;
 #define FB_IMPL_MSG_NO_SYMBOL(facility, number, text)
 
 #define FB_IMPL_MSG_SYMBOL(facility, number, symbol, text) \
-	const int symbol = number;
+	inline constexpr int symbol = number;
 
 #define FB_IMPL_MSG(facility, number, symbol, sqlCode, sqlClass, sqlSubClass, text) \
 	FB_IMPL_MSG_SYMBOL(facility, number, symbol, text)

--- a/src/jrd/ExtEngineManager.cpp
+++ b/src/jrd/ExtEngineManager.cpp
@@ -318,7 +318,7 @@ namespace
 			  checkMessageEof(aCheckMessageEof)
 		{
 			// Iterate over the format items, except the EOF item.
-			for (unsigned i = 0; i < (fromMessage->format->fmt_count / 2) * 2; i += 2)
+			for (unsigned i = 0; i < (fromMessage->format->fmt_count / 2u) * 2u; i += 2)
 			{
 				auto flag = FB_NEW_POOL(pool) ParameterNode(pool);
 				flag->messageNumber = fromMessage->messageNumber;

--- a/src/jrd/idx.cpp
+++ b/src/jrd/idx.cpp
@@ -808,7 +808,7 @@ bool IndexCreateTask::getResult(IStatus* status)
 
 int IndexCreateTask::getMaxWorkers()
 {
-	const int parWorkers = m_items.getCount();
+	const FB_SIZE_T parWorkers = m_items.getCount();
 	if (parWorkers == 1 || m_countPP == 0)
 		return 1;
 

--- a/src/jrd/inf.cpp
+++ b/src/jrd/inf.cpp
@@ -785,7 +785,7 @@ void INF_database_info(thread_db* tdbb,
 					length = gds__vax_integer(items, 2);
 					items += 2;
 
-					if (end_items - items >= length)
+					if (static_cast<ULONG>(end_items - items) >= length)
 					{
 						pageNum = gds__vax_integer(items, length);
 						items += length;

--- a/src/jrd/sqz.cpp
+++ b/src/jrd/sqz.cpp
@@ -76,7 +76,7 @@ unsigned Compressor::nonCompressableRun(unsigned length)
 
 	if (m_runs.hasData() && m_runs.back() > 0 && m_runs.back() < MAX_NONCOMP_RUN)
 	{
-		const auto max = MIN(MAX_NONCOMP_RUN - m_runs.back(), length);
+		const auto max = MIN(static_cast<unsigned>(MAX_NONCOMP_RUN - m_runs.back()), length);
 		length -= max;
 		m_runs.back() += max;
 	}
@@ -558,7 +558,7 @@ ULONG Difference::apply(ULONG diffLength, ULONG outLength, UCHAR* const output)
 			BUGCHECK(177);	// msg 177 applied differences will not fit in record
 	}
 
-	const auto length = p - output;
+	const ULONG length = p - output;
 
 	if (length > outLength)
 		BUGCHECK(177);	// msg 177 applied differences will not fit in record

--- a/src/yvalve/why.cpp
+++ b/src/yvalve/why.cpp
@@ -1424,7 +1424,7 @@ static void setTextType(XSQLVAR* var, unsigned charSet)
 static int sqldaTruncateString(char* buffer, FB_SIZE_T size, const char* s)
 {
 	int ret = fb_utils::snprintf(buffer, size, "%s", s);
-	return MIN(ret, size - 1);
+	return MIN(ret, static_cast<int>(size - 1));
 }
 
 // Describe parameters metadata in an sqlda.


### PR DESCRIPTION
This is a replacement for my previous PR: FirebirdSQL/firebird/pull/8360.
I apologize for having to reopen it. The code is the same except for corrections addressing the last two issues from the original PR.