### PR TITLE
Simplify clumplet reader/writer

### DIFF
--- a/src/common/classes/ClumpletReader.h
+++ b/src/common/classes/ClumpletReader.h
@@ -126,21 +126,18 @@ public:
 	// Return the tag for buffer (usually structure version)
 	UCHAR getBufferTag() const;
 	// true if buffer has tag
-	bool isTagged() const;
+	bool isTagged() const noexcept;
 	FB_SIZE_T getBufferLength() const
 	{
 		FB_SIZE_T rc = getBufferEnd() - getBuffer();
-		if (rc == 1 && kind != UnTagged     && kind != SpbStart &&
-					   kind != WideUnTagged && kind != SpbSendItems &&
-					   kind != SpbReceiveItems && kind != SpbResponse &&
-					   kind != InfoResponse && kind != InfoItems)
+		if (rc == 1 && isTagged())
 		{
 			rc = 0;
 		}
 		return rc;
 	}
-	FB_SIZE_T getCurOffset() const { return cur_offset; }
-	void setCurOffset(FB_SIZE_T newOffset) { cur_offset = newOffset; }
+	FB_SIZE_T getCurOffset() const noexcept { return cur_offset; }
+	void setCurOffset(FB_SIZE_T newOffset) noexcept { cur_offset = newOffset; }
 
 #ifdef DEBUG_CLUMPLETS
 	// Sometimes it's really useful to have it in case of errors
@@ -181,10 +178,10 @@ protected:
 	// sensible, certainly not overwrite memory or read past the end of buffer
 
 	// This appears to be a programming error in buffer access pattern
-	virtual void usage_mistake(const char* what) const;
+	[[noreturn]] virtual void usage_mistake(const char* what) const;
 
 	// This is called when passed buffer appears invalid
-	virtual void invalid_structure(const char* what, const int data = 0) const;
+	[[noreturn]] virtual void invalid_structure(const char* what, const int data = 0) const;
 
 private:
 	// Assignment not implemented.
@@ -205,13 +202,13 @@ public:
 class AuthReader : public ClumpletReader
 {
 public:
-	static const unsigned char AUTH_NAME = 1;		// name described by it's type
-	static const unsigned char AUTH_PLUGIN = 2;		// plugin which added a record
-	static const unsigned char AUTH_TYPE = 3;		// it can be user/group/role/etc. - what plugin sets
-	static const unsigned char AUTH_SECURE_DB = 4;	// sec. db in which context record was added
-													// missing when plugin is server-wide
-	static const unsigned char AUTH_ORIG_PLUG = 5;	// original plugin that added a mapped record
-													// (human information reasons only)
+	static constexpr unsigned char AUTH_NAME = 1;		// name described by it's type
+	static constexpr unsigned char AUTH_PLUGIN = 2;		// plugin which added a record
+	static constexpr unsigned char AUTH_TYPE = 3;		// it can be user/group/role/etc. - what plugin sets
+	static constexpr unsigned char AUTH_SECURE_DB = 4;	// sec. db in which context record was added
+														// missing when plugin is server-wide
+	static constexpr unsigned char AUTH_ORIG_PLUG = 5;	// original plugin that added a mapped record
+														// (human information reasons only)
 	typedef Array<UCHAR> AuthBlock;
 
 	struct Info
@@ -219,7 +216,7 @@ public:
 		NoCaseString type, name, plugin, secDb, origPlug;
 		unsigned found, current;
 
-		Info()
+		Info() noexcept
 			: found(0), current(0)
 		{ }
 
@@ -241,7 +238,7 @@ public:
 #ifdef AUTH_BLOCK_DEBUG
 void dumpAuthBlock(const char* text, ClumpletReader* pb, unsigned char param);
 #else
-static inline void dumpAuthBlock(const char*, ClumpletReader*, unsigned char) { }
+static inline void dumpAuthBlock(const char*, ClumpletReader*, unsigned char) noexcept { }
 #endif
 
 } // namespace Firebird

--- a/src/common/classes/ClumpletWriter.h
+++ b/src/common/classes/ClumpletWriter.h
@@ -35,7 +35,7 @@
 // This setting of maximum dpb size doesn't mean, that we
 // can't process larger DBPs! This is just recommended limit
 // cause it's hard to imagine sensefull DPB of even this size.
-const FB_SIZE_T MAX_DPB_SIZE = 1024 * 1024;
+constexpr FB_SIZE_T MAX_DPB_SIZE = 1024 * 1024;
 
 namespace Firebird {
 
@@ -100,14 +100,14 @@ public:
 	bool deleteWithTag(UCHAR tag);
 
 	const UCHAR* getBuffer() const override;
-	bool hasOverflow() const
+	bool hasOverflow() const noexcept
 	{
 		return flag_overflow;
 	}
 
 protected:
 	const UCHAR* getBufferEnd() const override;
-	virtual void size_overflow();
+	[[noreturn]] virtual void size_overflow();
 	void insertBytesLengthCheck(UCHAR tag, const void* bytes, const FB_SIZE_T length);
 	bool upgradeVersion();	// upgrade clumplet version - obtain newest from kindList
 

--- a/src/common/fb_exception.cpp
+++ b/src/common/fb_exception.cpp
@@ -126,19 +126,19 @@ const char* status_exception::what() const noexcept
 	return "Firebird::status_exception";
 }
 
-void status_exception::raise(const ISC_STATUS *status_vector)
+[[noreturn]] void status_exception::raise(const ISC_STATUS *status_vector)
 {
 	throw status_exception(status_vector);
 }
 
-void status_exception::raise(const IStatus* status)
+[[noreturn]] void status_exception::raise(const IStatus* status)
 {
 	StaticStatusVector status_vector;
 	status_vector.mergeStatus(status);
 	throw status_exception(status_vector.begin());
 }
 
-void status_exception::raise(const Arg::StatusVector& statusVector)
+[[noreturn]] void status_exception::raise(const Arg::StatusVector& statusVector)
 {
 	throw status_exception(statusVector.value());
 }
@@ -174,7 +174,7 @@ const char* BadAlloc::what() const noexcept
 
 // ********************************* LongJump ***************************
 
-void LongJump::raise()
+[[noreturn]] void LongJump::raise()
 {
 	throw LongJump();
 }
@@ -213,17 +213,17 @@ system_error::system_error(const char* syscall, const char* arg, int error_code)
 	set_status(temp.value());
 }
 
-void system_error::raise(const char* syscall, int error_code)
+[[noreturn]] void system_error::raise(const char* syscall, int error_code)
 {
 	throw system_error(syscall, nullptr, error_code);
 }
 
-void system_error::raise(const char* syscall)
+[[noreturn]] void system_error::raise(const char* syscall)
 {
 	throw system_error(syscall, nullptr, getSystemError());
 }
 
-int system_error::getSystemError()
+int system_error::getSystemError() noexcept
 {
 #ifdef WIN_NT
 	return GetLastError();
@@ -247,23 +247,23 @@ system_call_failed::system_call_failed(const char* syscall, const char* arg, int
 #endif
 }
 
-void system_call_failed::raise(const char* syscall, int error_code)
+[[noreturn]] void system_call_failed::raise(const char* syscall, int error_code)
 {
 	throw system_call_failed(syscall, nullptr, error_code);
 }
 
-void system_call_failed::raise(const char* syscall)
+[[noreturn]] void system_call_failed::raise(const char* syscall)
 {
 	throw system_call_failed(syscall, nullptr, getSystemError());
 }
 
 
-void system_call_failed::raise(const char* syscall, const char* arg, int error_code)
+[[noreturn]] void system_call_failed::raise(const char* syscall, const char* arg, int error_code)
 {
 	throw system_call_failed(syscall, arg, error_code);
 }
 
-void system_call_failed::raise(const char* syscall, const char* arg)
+[[noreturn]] void system_call_failed::raise(const char* syscall, const char* arg)
 {
 	raise(syscall, arg, getSystemError());
 }
@@ -291,12 +291,12 @@ const char* fatal_exception::what() const noexcept
 	return reinterpret_cast<const char*>(value()[3]);
 }
 
-void fatal_exception::raise(const char* message)
+[[noreturn]] void fatal_exception::raise(const char* message)
 {
 	throw fatal_exception(message);
 }
 
-void fatal_exception::raiseFmt(const char* format, ...)
+[[noreturn]] void fatal_exception::raiseFmt(const char* format, ...)
 {
 	va_list args;
 	va_start(args, format);

--- a/src/include/fb_exception.h
+++ b/src/include/fb_exception.h
@@ -74,7 +74,7 @@ class LongJump : public Exception
 public:
 	virtual void stuffByException(StaticStatusVector& status_vector) const noexcept;
 	virtual const char* what() const noexcept;
-	static void raise();
+	[[noreturn]] static void raise();
 	LongJump() noexcept : Exception() { }
 };
 
@@ -134,15 +134,15 @@ protected:
 	system_error(const char* syscall, const char* arg, int error_code);
 
 public:
-	static void raise(const char* syscall, int error_code);
-	static void raise(const char* syscall);
+	[[noreturn]] static void raise(const char* syscall, int error_code);
+	[[noreturn]] static void raise(const char* syscall);
 
-	int getErrorCode() const
+	int getErrorCode() const noexcept
 	{
 		return errorCode;
 	}
 
-	static int getSystemError();
+	static int getSystemError() noexcept;
 };
 
 // use this class if exception can't be handled
@@ -153,19 +153,19 @@ protected:
 	system_call_failed(const char* syscall, const char* arg, int error_code);
 
 public:
-	static void raise(const char* syscall, int error_code);
-	static void raise(const char* syscall);
-	static void raise(const char* syscall, const char* arg, int error_code);
-	static void raise(const char* syscall, const char* arg);
+	[[noreturn]] static void raise(const char* syscall, int error_code);
+	[[noreturn]] static void raise(const char* syscall);
+	[[noreturn]] static void raise(const char* syscall, const char* arg, int error_code);
+	[[noreturn]] static void raise(const char* syscall, const char* arg);
 };
 
 class fatal_exception : public status_exception
 {
 public:
 	explicit fatal_exception(const char* message);
-	static void raiseFmt(const char* format, ...);
+	[[noreturn]] static void raiseFmt(const char* format, ...);
 	const char* what() const noexcept;
-	static void raise(const char* message);
+	[[noreturn]] static void raise(const char* message);
 };
 
 


### PR DESCRIPTION
Simplify code surrounding tagged kind determination (and fixing some issues in ClumpletWriter not covering all untagged variants).

Also fixes some code quality warnings regarding switches.