### PR TITLE
Add missing implementation for SYMBOL and NO_SYMBOL messages

### DIFF
--- a/builds/win32/make_boot.bat
+++ b/builds/win32/make_boot.bat
@@ -177,9 +177,9 @@ goto :EOF
 @echo Building ttmath (%FB_OBJ_DIR%)...
 @mkdir %FB_ROOT_PATH%\extern\ttmath\%FB_CONFIG% 2>nul
 if /I "%FB_CONFIG%"=="debug" (
-  @ml64.exe /c /Zi /Fo %FB_ROOT_PATH%\extern\ttmath\%FB_CONFIG%\ttmathuint_x86_64_msvc.obj %FB_ROOT_PATH%\extern\ttmath\ttmathuint_x86_64_msvc.asm
+  C:\"Program Files"\"Microsoft Visual Studio"\2022\Community\VC\Tools\MSVC\14.37.32822\bin\Hostx64\x64\ml64.exe /c /Zi /Fo %FB_ROOT_PATH%\extern\ttmath\%FB_CONFIG%\ttmathuint_x86_64_msvc.obj %FB_ROOT_PATH%\extern\ttmath\ttmathuint_x86_64_msvc.asm
 ) else (
-  @ml64.exe /c /Fo %FB_ROOT_PATH%\extern\ttmath\%FB_CONFIG%\ttmathuint_x86_64_msvc.obj %FB_ROOT_PATH%\extern\ttmath\ttmathuint_x86_64_msvc.asm
+  C:\"Program Files"\"Microsoft Visual Studio"\2022\Community\VC\Tools\MSVC\14.37.32822\bin\Hostx64\x64\ml64.exe.exe /c /Fo %FB_ROOT_PATH%\extern\ttmath\%FB_CONFIG%\ttmathuint_x86_64_msvc.obj %FB_ROOT_PATH%\extern\ttmath\ttmathuint_x86_64_msvc.asm
 )
 if errorlevel 1 call :boot2 ttmath_%FB_OBJ_DIR%
 goto :EOF

--- a/builds/win32/make_boot.bat
+++ b/builds/win32/make_boot.bat
@@ -177,9 +177,9 @@ goto :EOF
 @echo Building ttmath (%FB_OBJ_DIR%)...
 @mkdir %FB_ROOT_PATH%\extern\ttmath\%FB_CONFIG% 2>nul
 if /I "%FB_CONFIG%"=="debug" (
-  C:\"Program Files"\"Microsoft Visual Studio"\2022\Community\VC\Tools\MSVC\14.37.32822\bin\Hostx64\x64\ml64.exe /c /Zi /Fo %FB_ROOT_PATH%\extern\ttmath\%FB_CONFIG%\ttmathuint_x86_64_msvc.obj %FB_ROOT_PATH%\extern\ttmath\ttmathuint_x86_64_msvc.asm
+  @ml64.exe /c /Zi /Fo %FB_ROOT_PATH%\extern\ttmath\%FB_CONFIG%\ttmathuint_x86_64_msvc.obj %FB_ROOT_PATH%\extern\ttmath\ttmathuint_x86_64_msvc.asm
 ) else (
-  C:\"Program Files"\"Microsoft Visual Studio"\2022\Community\VC\Tools\MSVC\14.37.32822\bin\Hostx64\x64\ml64.exe.exe /c /Fo %FB_ROOT_PATH%\extern\ttmath\%FB_CONFIG%\ttmathuint_x86_64_msvc.obj %FB_ROOT_PATH%\extern\ttmath\ttmathuint_x86_64_msvc.asm
+  @ml64.exe.exe /c /Fo %FB_ROOT_PATH%\extern\ttmath\%FB_CONFIG%\ttmathuint_x86_64_msvc.obj %FB_ROOT_PATH%\extern\ttmath\ttmathuint_x86_64_msvc.asm
 )
 if errorlevel 1 call :boot2 ttmath_%FB_OBJ_DIR%
 goto :EOF

--- a/builds/win32/make_boot.bat
+++ b/builds/win32/make_boot.bat
@@ -179,7 +179,7 @@ goto :EOF
 if /I "%FB_CONFIG%"=="debug" (
   @ml64.exe /c /Zi /Fo %FB_ROOT_PATH%\extern\ttmath\%FB_CONFIG%\ttmathuint_x86_64_msvc.obj %FB_ROOT_PATH%\extern\ttmath\ttmathuint_x86_64_msvc.asm
 ) else (
-  @ml64.exe.exe /c /Fo %FB_ROOT_PATH%\extern\ttmath\%FB_CONFIG%\ttmathuint_x86_64_msvc.obj %FB_ROOT_PATH%\extern\ttmath\ttmathuint_x86_64_msvc.asm
+  @ml64.exe /c /Fo %FB_ROOT_PATH%\extern\ttmath\%FB_CONFIG%\ttmathuint_x86_64_msvc.obj %FB_ROOT_PATH%\extern\ttmath\ttmathuint_x86_64_msvc.asm
 )
 if errorlevel 1 call :boot2 ttmath_%FB_OBJ_DIR%
 goto :EOF

--- a/src/yvalve/gds.cpp
+++ b/src/yvalve/gds.cpp
@@ -124,9 +124,11 @@ static char* fb_prefix = NULL;
 static char* fb_prefix_lock = NULL;
 static char* fb_prefix_msg = NULL;
 
-#define FB_IMPL_MSG_NO_SYMBOL(facility, number, text)
+#define FB_IMPL_MSG_NO_SYMBOL(facility, number, text) \
+	{ENCODE_ISC_MSG(number, FB_IMPL_MSG_FACILITY_##facility), text},
 
-#define FB_IMPL_MSG_SYMBOL(facility, number, symbol, text)
+#define FB_IMPL_MSG_SYMBOL(facility, number, symbol, text) \
+	{ENCODE_ISC_MSG(number, FB_IMPL_MSG_FACILITY_##facility), text},
 
 #define FB_IMPL_MSG(facility, number, symbol, sqlCode, sqlClass, sqlSubClass, text) \
 	{ENCODE_ISC_MSG(number, FB_IMPL_MSG_FACILITY_##facility), text},


### PR DESCRIPTION
This is a fix for https://github.com/FirebirdSQL/firebird/issues/8505. In the fix, I added the missing message to the exported one. Previously, the program displayed the error: `"unknown ISC error 336067776"`, Now the program outputs: `"Function TEST_FUNC already exists"`. The original problem was reproduced in Windows