### PR TITLE
Simplify Clumplet Reader/Writer + code analysis issues

### DIFF
--- a/builds/win32/msvc15/common_test.vcxproj
+++ b/builds/win32/msvc15/common_test.vcxproj
@@ -176,6 +176,8 @@
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\src\common\classes\tests\ClumpletTest.cpp" />
+    <ClCompile Include="..\..\..\src\common\classes\tests\VectorTest.cpp" />
     <ClCompile Include="..\..\..\src\common\tests\CommonTest.cpp" />
     <ClCompile Include="..\..\..\src\common\tests\CvtTest.cpp" />
     <ClCompile Include="..\..\..\src\common\tests\StringTest.cpp" />

--- a/builds/win32/msvc15/common_test.vcxproj.filters
+++ b/builds/win32/msvc15/common_test.vcxproj.filters
@@ -36,5 +36,11 @@
     <ClCompile Include="..\..\..\src\yvalve\gds.cpp">
       <Filter>source</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\src\common\classes\tests\ClumpletTest.cpp">
+      <Filter>source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\src\common\classes\tests\VectorTest.cpp">
+      <Filter>source</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/common/classes/ClumpletReader.cpp
+++ b/src/common/classes/ClumpletReader.cpp
@@ -280,9 +280,9 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 		case isc_tpb_at_snapshot_number:
 			return TraditionalDpb;
 		default:
-			return SingleTpb;
+			break;
 		}
-		break;
+		return SingleTpb;
 	case SpbSendItems:
 		switch (tag)
 		{
@@ -294,9 +294,9 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 		case isc_info_flag_end:
 			return SingleTpb;
 		default:
-			return StringSpb;
+			break;
 		}
-		break;
+		return StringSpb;
 	case SpbReceiveItems:
 	case InfoItems:
 		return SingleTpb;
@@ -346,9 +346,9 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 			case isc_spb_res_replica_mode:
 				return ByteSpb;
 			default:
-				invalid_structure("unknown parameter for backup/restore", tag);
 				break;
 			}
+			invalid_structure("unknown parameter for backup/restore", tag);
 			break;
 		case isc_action_svc_repair:
 			switch (tag)
@@ -366,9 +366,9 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 			case isc_spb_rpr_recover_two_phase_64:
 				return BigIntSpb;
 			default:
-				invalid_structure("unknown parameter for repair", tag);
 				break;
 			}
+			invalid_structure("unknown parameter for repair", tag);
 			break;
 		case isc_action_svc_add_user:
 		case isc_action_svc_delete_user:
@@ -393,9 +393,9 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 			case isc_spb_sec_admin:
 				return IntSpb;
 			default:
-				invalid_structure("unknown parameter for security database operation", tag);
 				break;
 			}
+			invalid_structure("unknown parameter for security database operation", tag);
 			break;
 		case isc_action_svc_properties:
 			switch (tag)
@@ -421,9 +421,9 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 			case isc_spb_prp_replica_mode:
 				return ByteSpb;
 			default:
-				invalid_structure("unknown parameter for setting database properties", tag);
 				break;
 			}
+			invalid_structure("unknown parameter for setting database properties", tag);
 			break;
 //		case isc_action_svc_add_license:
 //		case isc_action_svc_remove_license:
@@ -437,9 +437,9 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 			case isc_spb_options:
 				return IntSpb;
 			default:
-				invalid_structure("unknown parameter for getting statistics", tag);
 				break;
 			}
+			invalid_structure("unknown parameter for getting statistics", tag);
 			break;
 		case isc_action_svc_get_ib_log:
 			invalid_structure("unknown parameter for getting log", tag);
@@ -461,9 +461,9 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 			case isc_spb_nbk_clean_history:
 				return SingleTpb;
 			default:
-				invalid_structure("unknown parameter for nbackup", tag);
 				break;
 			}
+			invalid_structure("unknown parameter for nbackup", tag);
 			break;
 		case isc_action_svc_nfix:
 			switch (tag)
@@ -473,9 +473,9 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 			case isc_spb_options:
 				return IntSpb;
 			default:
-				invalid_structure("unknown parameter for nbackup", tag);
 				break;
 			}
+			invalid_structure("unknown parameter for nbackup", tag);
 			break;
 		case isc_action_svc_trace_start:
 		case isc_action_svc_trace_stop:
@@ -489,9 +489,9 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 			case isc_spb_trc_id:
 				return IntSpb;
 			default:
-				invalid_structure("unknown parameter for trace", tag);
 				break;
 			}
+			invalid_structure("unknown parameter for trace", tag);
 			break;
 		case isc_action_svc_validate:
 			switch (tag)
@@ -505,14 +505,14 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 			case isc_spb_val_lock_timeout:
 				return IntSpb;
 			default:
-				invalid_structure("unknown parameter for validate", tag);
 				break;
 			}
+			invalid_structure("unknown parameter for validate", tag);
 			break;
 		default:
-			invalid_structure("wrong spb state", spbState);
 			break;
 		}
+		invalid_structure("wrong spb state", spbState);
 		break;
 	case SpbResponse:
 		switch(tag)
@@ -556,9 +556,9 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 		case isc_spb_tra_advise:
 			return ByteSpb;
 		default:
-			invalid_structure("unrecognized service response tag", tag);
 			break;
 		}
+		invalid_structure("unrecognized service response tag", tag);
 		break;
 	case InfoResponse:
 		switch (tag)
@@ -568,13 +568,13 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 		case isc_info_flag_end:
 			return SingleTpb;
 		default:
-			return StringSpb;
+			break;
 		}
-		break;
+		return StringSpb;
 	default:
-		invalid_structure("unknown clumplet kind", kind);
 		break;
 	}
+	invalid_structure("unknown clumplet kind", kind);
 	return SingleTpb;
 }
 
@@ -673,6 +673,7 @@ FB_SIZE_T ClumpletReader::getClumpletSize(bool wTag, bool wLength, bool wData) c
 
 	default:
 		invalid_structure("unknown clumplet type", t);
+		return rc;
 	}
 
 	const FB_SIZE_T total = 1 + lengthSize + dataSize;

--- a/src/common/classes/ClumpletReader.cpp
+++ b/src/common/classes/ClumpletReader.cpp
@@ -62,11 +62,11 @@ public:
 		return t2;
 	}
 protected:
-	virtual void usage_mistake(const char* what) const
+	[[noreturn]] virtual void usage_mistake(const char* what) const
 	{
 		fatal_exception::raiseFmt("Internal error when using clumplet API: %s", what);
 	}
-	virtual void invalid_structure(const char* what, const int data) const
+	[[noreturn]] virtual void invalid_structure(const char* what, const int data) const
 	{
 		fatal_exception::raiseFmt("Invalid clumplet buffer structure: %s (%d)", what, data);
 	}
@@ -86,8 +86,7 @@ void ClumpletReader::dump() const
 
 	try {
 		ClumpletDump d(kind, getBuffer(), getBufferLength());
-		int t = (kind == SpbStart || kind == UnTagged || kind == WideUnTagged || kind == SpbResponse || kind == InfoResponse) ?
-			-1 : d.getBufferTag();
+		const int t = isTagged() ? d.getBufferTag() : -1;
 		gds__log("Tag=%d Offset=%d Length=%d Eof=%d\n", t, getCurOffset(), getBufferLength(), isEof());
 		for (d.rewind(); !(d.isEof()); d.moveNext())
 		{
@@ -98,7 +97,7 @@ void ClumpletReader::dump() const
 	catch (const fatal_exception& x)
 	{
 		gds__log("Fatal exception during clumplet dump: %s", x.what());
-		FB_SIZE_T l = getBufferLength() - getCurOffset();
+		const FB_SIZE_T l = getBufferLength() - getCurOffset();
 		const UCHAR *p = getBuffer() + getCurOffset();
 		gds__log("Plain dump starting with offset %d: %s", getCurOffset(),
 			ClumpletDump::hexString(p, l).c_str());
@@ -189,7 +188,7 @@ const UCHAR* ClumpletReader::getBufferEnd() const
 	return static_buffer_end;
 }
 
-void ClumpletReader::usage_mistake(const char* what) const
+[[noreturn]] void ClumpletReader::usage_mistake(const char* what) const
 {
 #ifdef DEBUG_CLUMPLETS
 	dump();
@@ -197,7 +196,7 @@ void ClumpletReader::usage_mistake(const char* what) const
 	fatal_exception::raiseFmt("Internal error when using clumplet API: %s", what);
 }
 
-void ClumpletReader::invalid_structure(const char* what, const int data) const
+[[noreturn]] void ClumpletReader::invalid_structure(const char* what, const int data) const
 {
 #ifdef DEBUG_CLUMPLETS
 	dump();
@@ -205,7 +204,7 @@ void ClumpletReader::invalid_structure(const char* what, const int data) const
 	fatal_exception::raiseFmt("Invalid clumplet buffer structure: %s (%d)", what, data);
 }
 
-bool ClumpletReader::isTagged() const
+bool ClumpletReader::isTagged() const noexcept
 {
 	switch (kind)
 	{
@@ -214,13 +213,17 @@ bool ClumpletReader::isTagged() const
 	case WideTagged:
 	case SpbAttach:
 		return true;
+	default:
+		return false;
 	}
-
-	return false;
 }
 
 UCHAR ClumpletReader::getBufferTag() const
 {
+	if (!isTagged()) {
+		usage_mistake("buffer is not tagged");
+		return 0;
+	}
 	const UCHAR* const buffer_end = getBufferEnd();
 	const UCHAR* buffer_start = getBuffer();
 
@@ -235,16 +238,6 @@ UCHAR ClumpletReader::getBufferTag() const
 			return 0;
 		}
 		return buffer_start[0];
-	case SpbStart:
-	case UnTagged:
-	case WideUnTagged:
-	case SpbSendItems:
-	case SpbReceiveItems:
-	case SpbResponse:
-	case InfoResponse:
-	case InfoItems:
-		usage_mistake("buffer is not tagged");
-		return 0;
 	case SpbAttach:
 		if (buffer_end - buffer_start == 0)
 		{
@@ -552,17 +545,11 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 
 void ClumpletReader::adjustSpbState()
 {
-	switch (kind)
+	if (kind == SpbStart && 
+		spbState == 0 &&							// Just started with service start block ...
+		getClumpletSize(true, true, true) == 1)		// and this is action_XXX clumplet
 	{
-	case SpbStart:
-		if (spbState == 0 &&							// Just started with service start block ...
-			getClumpletSize(true, true, true) == 1)		// and this is action_XXX clumplet
-		{
-			spbState = getClumpTag();
-		}
-		break;
-	default:
-		break;
+		spbState = getClumpTag();
 	}
 }
 
@@ -582,7 +569,7 @@ FB_SIZE_T ClumpletReader::getClumpletSize(bool wTag, bool wLength, bool wData) c
 	FB_SIZE_T lengthSize = 0;
 	FB_SIZE_T dataSize = 0;
 
-	ClumpletType t = getClumpletType(clumplet[0]);
+	const ClumpletType t = getClumpletType(clumplet[0]);
 	switch (t)
 	{
 
@@ -657,7 +644,7 @@ FB_SIZE_T ClumpletReader::getClumpletSize(bool wTag, bool wLength, bool wData) c
 	if (clumplet + total > buffer_end)
 	{
 		invalid_structure("buffer end before end of clumplet - clumplet too long", total);
-		FB_SIZE_T delta = total - (buffer_end - clumplet);
+		const FB_SIZE_T delta = total - (buffer_end - clumplet);
 		if (delta > dataSize)
 			dataSize = 0;
 		else
@@ -678,9 +665,8 @@ void ClumpletReader::moveNext()
 	if (isEof())
 		return;		// no need to raise useless exceptions
 
-	switch (kind)
+	if (kind == InfoResponse)
 	{
-	case InfoResponse:
 		switch (getClumpTag())
 		{
 		case isc_info_end:
@@ -688,40 +674,24 @@ void ClumpletReader::moveNext()
 			// terminating clumplet
 			cur_offset = getBufferLength();
 			return;
+		default:
+			break;
 		}
 	}
 
-	FB_SIZE_T cs = getClumpletSize(true, true, true);
+	const FB_SIZE_T cs = getClumpletSize(true, true, true);
 	adjustSpbState();
 	cur_offset += cs;
 }
 
 void ClumpletReader::rewind()
 {
-	if (! getBuffer())
-	{
+	if (!getBuffer() || !isTagged())
 		cur_offset = 0;
-		spbState = 0;
-		return;
-	}
-	switch (kind)
-	{
-	case UnTagged:
-	case WideUnTagged:
-	case SpbStart:
-	case SpbSendItems:
-	case SpbReceiveItems:
-	case SpbResponse:
-	case InfoResponse:
-	case InfoItems:
-		cur_offset = 0;
-		break;
-	default:
-		if (kind == SpbAttach && getBufferLength() > 0 && getBuffer()[0] != isc_spb_version1)
-			cur_offset = 2;
-		else
-			cur_offset = 1;
-	}
+	else if (kind == SpbAttach && getBufferLength() > 0 && getBuffer()[0] == isc_spb_version)
+		cur_offset = 2;
+	else
+		cur_offset = 1;
 	spbState = 0;
 }
 
@@ -956,7 +926,7 @@ AuthReader::AuthReader(MemoryPool& pool, const AuthBlock& authBlock)
 	rewind();
 }
 
-static inline void erase(NoCaseString& s)
+static inline void erase(NoCaseString& s) noexcept
 {
 	s.erase();
 }

--- a/src/common/classes/ClumpletReader.cpp
+++ b/src/common/classes/ClumpletReader.cpp
@@ -62,11 +62,11 @@ public:
 		return t2;
 	}
 protected:
-	[[noreturn]] virtual void usage_mistake(const char* what) const
+	virtual void usage_mistake(const char* what) const
 	{
 		fatal_exception::raiseFmt("Internal error when using clumplet API: %s", what);
 	}
-	[[noreturn]] virtual void invalid_structure(const char* what, const int data) const
+	virtual void invalid_structure(const char* what, const int data) const
 	{
 		fatal_exception::raiseFmt("Invalid clumplet buffer structure: %s (%d)", what, data);
 	}

--- a/src/common/classes/ClumpletReader.cpp
+++ b/src/common/classes/ClumpletReader.cpp
@@ -188,7 +188,7 @@ const UCHAR* ClumpletReader::getBufferEnd() const
 	return static_buffer_end;
 }
 
-[[noreturn]] void ClumpletReader::usage_mistake(const char* what) const
+void ClumpletReader::usage_mistake(const char* what) const
 {
 #ifdef DEBUG_CLUMPLETS
 	dump();
@@ -196,7 +196,7 @@ const UCHAR* ClumpletReader::getBufferEnd() const
 	fatal_exception::raiseFmt("Internal error when using clumplet API: %s", what);
 }
 
-[[noreturn]] void ClumpletReader::invalid_structure(const char* what, const int data) const
+void ClumpletReader::invalid_structure(const char* what, const int data) const
 {
 #ifdef DEBUG_CLUMPLETS
 	dump();

--- a/src/common/classes/ClumpletReader.cpp
+++ b/src/common/classes/ClumpletReader.cpp
@@ -301,17 +301,6 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 	case InfoItems:
 		return SingleTpb;
 	case SpbStart:
-		switch(tag)
-		{
-		case isc_spb_auth_block:
-		case isc_spb_trusted_auth:
-		case isc_spb_auth_plugin_name:
-		case isc_spb_auth_plugin_list:
-			return Wide;
-		default:
-			// continues with spbState below
-			break;
-		}
 		switch (spbState)
 		{
 		case 0:

--- a/src/common/classes/ClumpletReader.cpp
+++ b/src/common/classes/ClumpletReader.cpp
@@ -279,8 +279,10 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 		case isc_tpb_lock_timeout:
 		case isc_tpb_at_snapshot_number:
 			return TraditionalDpb;
+		default:
+			return SingleTpb;
 		}
-		return SingleTpb;
+		break;
 	case SpbSendItems:
 		switch (tag)
 		{
@@ -291,8 +293,10 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 		case isc_info_length:
 		case isc_info_flag_end:
 			return SingleTpb;
+		default:
+			return StringSpb;
 		}
-		return StringSpb;
+		break;
 	case SpbReceiveItems:
 	case InfoItems:
 		return SingleTpb;
@@ -304,6 +308,9 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 		case isc_spb_auth_plugin_name:
 		case isc_spb_auth_plugin_list:
 			return Wide;
+		default:
+			// continues with spbState below
+			break;
 		}
 		switch (spbState)
 		{
@@ -338,8 +345,10 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 			case isc_spb_res_access_mode:
 			case isc_spb_res_replica_mode:
 				return ByteSpb;
+			default:
+				invalid_structure("unknown parameter for backup/restore", tag);
+				break;
 			}
-			invalid_structure("unknown parameter for backup/restore", tag);
 			break;
 		case isc_action_svc_repair:
 			switch (tag)
@@ -356,8 +365,10 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 			case isc_spb_rpr_rollback_trans_64:
 			case isc_spb_rpr_recover_two_phase_64:
 				return BigIntSpb;
+			default:
+				invalid_structure("unknown parameter for repair", tag);
+				break;
 			}
-			invalid_structure("unknown parameter for repair", tag);
 			break;
 		case isc_action_svc_add_user:
 		case isc_action_svc_delete_user:
@@ -381,8 +392,10 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 			case isc_spb_sec_groupid:
 			case isc_spb_sec_admin:
 				return IntSpb;
+			default:
+				invalid_structure("unknown parameter for security database operation", tag);
+				break;
 			}
-			invalid_structure("unknown parameter for security database operation", tag);
 			break;
 		case isc_action_svc_properties:
 			switch (tag)
@@ -407,8 +420,10 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 			case isc_spb_prp_online_mode:
 			case isc_spb_prp_replica_mode:
 				return ByteSpb;
+			default:
+				invalid_structure("unknown parameter for setting database properties", tag);
+				break;
 			}
-			invalid_structure("unknown parameter for setting database properties", tag);
 			break;
 //		case isc_action_svc_add_license:
 //		case isc_action_svc_remove_license:
@@ -421,8 +436,10 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 				return StringSpb;
 			case isc_spb_options:
 				return IntSpb;
+			default:
+				invalid_structure("unknown parameter for getting statistics", tag);
+				break;
 			}
-			invalid_structure("unknown parameter for getting statistics", tag);
 			break;
 		case isc_action_svc_get_ib_log:
 			invalid_structure("unknown parameter for getting log", tag);
@@ -443,8 +460,10 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 				return IntSpb;
 			case isc_spb_nbk_clean_history:
 				return SingleTpb;
+			default:
+				invalid_structure("unknown parameter for nbackup", tag);
+				break;
 			}
-			invalid_structure("unknown parameter for nbackup", tag);
 			break;
 		case isc_action_svc_nfix:
 			switch (tag)
@@ -453,8 +472,10 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 				return StringSpb;
 			case isc_spb_options:
 				return IntSpb;
+			default:
+				invalid_structure("unknown parameter for nbackup", tag);
+				break;
 			}
-			invalid_structure("unknown parameter for nbackup", tag);
 			break;
 		case isc_action_svc_trace_start:
 		case isc_action_svc_trace_stop:
@@ -467,6 +488,9 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 				return StringSpb;
 			case isc_spb_trc_id:
 				return IntSpb;
+			default:
+				invalid_structure("unknown parameter for trace", tag);
+				break;
 			}
 			break;
 		case isc_action_svc_validate:
@@ -480,10 +504,15 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 				return StringSpb;
 			case isc_spb_val_lock_timeout:
 				return IntSpb;
+			default:
+				invalid_structure("unknown parameter for validate", tag);
+				break;
 			}
 			break;
+		default:
+			invalid_structure("wrong spb state", spbState);
+			break;
 		}
-		invalid_structure("wrong spb state", spbState);
 		break;
 	case SpbResponse:
 		switch(tag)
@@ -526,8 +555,10 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 		case isc_spb_tra_state:
 		case isc_spb_tra_advise:
 			return ByteSpb;
+		default:
+			invalid_structure("unrecognized service response tag", tag);
+			break;
 		}
-		invalid_structure("unrecognized service response tag", tag);
 		break;
 	case InfoResponse:
 		switch (tag)
@@ -536,10 +567,14 @@ ClumpletReader::ClumpletType ClumpletReader::getClumpletType(UCHAR tag) const
 		case isc_info_truncated:
 		case isc_info_flag_end:
 			return SingleTpb;
+		default:
+			return StringSpb;
 		}
-		return StringSpb;
+		break;
+	default:
+		invalid_structure("unknown clumplet kind", kind);
+		break;
 	}
-	invalid_structure("unknown clumplet kind", kind);
 	return SingleTpb;
 }
 

--- a/src/common/classes/ClumpletReader.h
+++ b/src/common/classes/ClumpletReader.h
@@ -126,21 +126,18 @@ public:
 	// Return the tag for buffer (usually structure version)
 	UCHAR getBufferTag() const;
 	// true if buffer has tag
-	bool isTagged() const;
+	bool isTagged() const noexcept;
 	FB_SIZE_T getBufferLength() const
 	{
 		FB_SIZE_T rc = getBufferEnd() - getBuffer();
-		if (rc == 1 && kind != UnTagged     && kind != SpbStart &&
-					   kind != WideUnTagged && kind != SpbSendItems &&
-					   kind != SpbReceiveItems && kind != SpbResponse &&
-					   kind != InfoResponse && kind != InfoItems)
+		if (rc == 1 && isTagged())
 		{
 			rc = 0;
 		}
 		return rc;
 	}
-	FB_SIZE_T getCurOffset() const { return cur_offset; }
-	void setCurOffset(FB_SIZE_T newOffset) { cur_offset = newOffset; }
+	FB_SIZE_T getCurOffset() const noexcept { return cur_offset; }
+	void setCurOffset(FB_SIZE_T newOffset) noexcept { cur_offset = newOffset; }
 
 #ifdef DEBUG_CLUMPLETS
 	// Sometimes it's really useful to have it in case of errors
@@ -181,10 +178,10 @@ protected:
 	// sensible, certainly not overwrite memory or read past the end of buffer
 
 	// This appears to be a programming error in buffer access pattern
-	virtual void usage_mistake(const char* what) const;
+	[[noreturn]] virtual void usage_mistake(const char* what) const;
 
 	// This is called when passed buffer appears invalid
-	virtual void invalid_structure(const char* what, const int data = 0) const;
+	[[noreturn]] virtual void invalid_structure(const char* what, const int data = 0) const;
 
 private:
 	// Assignment not implemented.
@@ -205,13 +202,13 @@ public:
 class AuthReader : public ClumpletReader
 {
 public:
-	static const unsigned char AUTH_NAME = 1;		// name described by it's type
-	static const unsigned char AUTH_PLUGIN = 2;		// plugin which added a record
-	static const unsigned char AUTH_TYPE = 3;		// it can be user/group/role/etc. - what plugin sets
-	static const unsigned char AUTH_SECURE_DB = 4;	// sec. db in which context record was added
-													// missing when plugin is server-wide
-	static const unsigned char AUTH_ORIG_PLUG = 5;	// original plugin that added a mapped record
-													// (human information reasons only)
+	static constexpr unsigned char AUTH_NAME = 1;		// name described by it's type
+	static constexpr unsigned char AUTH_PLUGIN = 2;		// plugin which added a record
+	static constexpr unsigned char AUTH_TYPE = 3;		// it can be user/group/role/etc. - what plugin sets
+	static constexpr unsigned char AUTH_SECURE_DB = 4;	// sec. db in which context record was added
+														// missing when plugin is server-wide
+	static constexpr unsigned char AUTH_ORIG_PLUG = 5;	// original plugin that added a mapped record
+														// (human information reasons only)
 	typedef Array<UCHAR> AuthBlock;
 
 	struct Info
@@ -219,7 +216,7 @@ public:
 		NoCaseString type, name, plugin, secDb, origPlug;
 		unsigned found, current;
 
-		Info()
+		Info() noexcept
 			: found(0), current(0)
 		{ }
 
@@ -241,7 +238,7 @@ public:
 #ifdef AUTH_BLOCK_DEBUG
 void dumpAuthBlock(const char* text, ClumpletReader* pb, unsigned char param);
 #else
-static inline void dumpAuthBlock(const char*, ClumpletReader*, unsigned char) { }
+static inline void dumpAuthBlock(const char*, ClumpletReader*, unsigned char) noexcept { }
 #endif
 
 } // namespace Firebird

--- a/src/common/classes/ClumpletReader.h
+++ b/src/common/classes/ClumpletReader.h
@@ -178,10 +178,10 @@ protected:
 	// sensible, certainly not overwrite memory or read past the end of buffer
 
 	// This appears to be a programming error in buffer access pattern
-	[[noreturn]] virtual void usage_mistake(const char* what) const;
+	virtual void usage_mistake(const char* what) const;
 
 	// This is called when passed buffer appears invalid
-	[[noreturn]] virtual void invalid_structure(const char* what, const int data = 0) const;
+	virtual void invalid_structure(const char* what, const int data = 0) const;
 
 private:
 	// Assignment not implemented.

--- a/src/common/classes/ClumpletWriter.cpp
+++ b/src/common/classes/ClumpletWriter.cpp
@@ -214,13 +214,13 @@ void ClumpletWriter::reset(UCHAR tag)
 
 void ClumpletWriter::reset(const UCHAR* buffer, const FB_SIZE_T buffLen)
 {
+	const UCHAR tag = isTagged() ? getBufferTag() : 0;
 	dynamic_buffer.clear();
 	if (buffer && buffLen) {
 		dynamic_buffer.push(buffer, buffLen);
 	}
 	else
-	{
-		UCHAR tag = (kind == SpbStart || kind == UnTagged || kind == WideUnTagged) ? 0 : getBufferTag();
+	{	
 		initNewBuffer(tag);
 	}
 	rewind();

--- a/src/common/classes/ClumpletWriter.cpp
+++ b/src/common/classes/ClumpletWriter.cpp
@@ -232,7 +232,7 @@ void ClumpletWriter::reset(const ClumpletWriter& from)
 	reset(from.getBuffer(), from.getBufferEnd() - from.getBuffer());
 }
 
-void ClumpletWriter::size_overflow()
+[[noreturn]] void ClumpletWriter::size_overflow()
 {
 	fatal_exception::raise("Clumplet buffer size limit reached");
 }

--- a/src/common/classes/ClumpletWriter.cpp
+++ b/src/common/classes/ClumpletWriter.cpp
@@ -425,21 +425,21 @@ void ClumpletWriter::insertBytesLengthCheck(UCHAR tag, const void* bytes, const 
 		dynamic_buffer.insert(cur_offset++, static_cast<UCHAR>(length));
 		break;
 	case 2:
-	{
-		UCHAR b[2];
-		toVaxInteger(b, sizeof(b), length);
-		dynamic_buffer.insert(cur_offset, b, sizeof(b));
-		cur_offset += 2;
-	}
-	break;
+		{
+			UCHAR b[2];
+			toVaxInteger(b, sizeof(b), length);
+			dynamic_buffer.insert(cur_offset, b, sizeof(b));
+			cur_offset += 2;
+		}
+		break;
 	case 4:
-	{
-		UCHAR b[4];
-		toVaxInteger(b, sizeof(b), length);
-		dynamic_buffer.insert(cur_offset, b, sizeof(b));
-		cur_offset += 4;
-	}
-	break;
+		{
+			UCHAR b[4];
+			toVaxInteger(b, sizeof(b), length);
+			dynamic_buffer.insert(cur_offset, b, sizeof(b));
+			cur_offset += 4;
+		}
+		break;
 	default:
 		fb_assert(lenSize >= 0 && lenSize <= 2 || lenSize == 4);
 		return;

--- a/src/common/classes/ClumpletWriter.cpp
+++ b/src/common/classes/ClumpletWriter.cpp
@@ -175,6 +175,7 @@ ClumpletWriter::ClumpletWriter(MemoryPool& given_pool, Kind k, FB_SIZE_T limit,
 							   const UCHAR* buffer, FB_SIZE_T buffLen, UCHAR tag)
 	: ClumpletReader(given_pool, k, NULL, 0),
 	  sizeLimit(limit),
+	  kindList(NULL),
 	  dynamic_buffer(getPool()),
 	  flag_overflow(false)
 {

--- a/src/common/classes/ClumpletWriter.cpp
+++ b/src/common/classes/ClumpletWriter.cpp
@@ -73,11 +73,11 @@ void ClumpletWriter::initNewBuffer(UCHAR tag)
 	switch (kind)
 	{
 		case SpbAttach:
-			if (tag != isc_spb_version1)
+			if (tag == isc_spb_version)
 			{
 				dynamic_buffer.push(isc_spb_version);
 			}
-			// fall down ....
+			[[fallthrough]];
 		case Tagged:
 		case Tpb:
 		case WideTagged:
@@ -418,6 +418,8 @@ void ClumpletWriter::insertBytesLengthCheck(UCHAR tag, const void* bytes, const 
 	dynamic_buffer.insert(cur_offset++, tag);
 	switch (lenSize)
 	{
+	case 0:
+		break;
 	case 1:
 		dynamic_buffer.insert(cur_offset++, static_cast<UCHAR>(length));
 		break;
@@ -437,6 +439,9 @@ void ClumpletWriter::insertBytesLengthCheck(UCHAR tag, const void* bytes, const 
 			cur_offset += 4;
 		}
 		break;
+	default:
+		invalid_structure("invalid length size", lenSize);
+		return;
 	}
 	dynamic_buffer.insert(cur_offset, static_cast<const UCHAR*>(bytes), length);
 	const FB_SIZE_T new_offset = cur_offset + length;

--- a/src/common/classes/ClumpletWriter.cpp
+++ b/src/common/classes/ClumpletWriter.cpp
@@ -425,23 +425,23 @@ void ClumpletWriter::insertBytesLengthCheck(UCHAR tag, const void* bytes, const 
 		dynamic_buffer.insert(cur_offset++, static_cast<UCHAR>(length));
 		break;
 	case 2:
-		{
-			UCHAR b[2];
-			toVaxInteger(b, sizeof(b), length);
-			dynamic_buffer.insert(cur_offset, b, sizeof(b));
-			cur_offset += 2;
-		}
-		break;
+	{
+		UCHAR b[2];
+		toVaxInteger(b, sizeof(b), length);
+		dynamic_buffer.insert(cur_offset, b, sizeof(b));
+		cur_offset += 2;
+	}
+	break;
 	case 4:
-		{
-			UCHAR b[4];
-			toVaxInteger(b, sizeof(b), length);
-			dynamic_buffer.insert(cur_offset, b, sizeof(b));
-			cur_offset += 4;
-		}
-		break;
+	{
+		UCHAR b[4];
+		toVaxInteger(b, sizeof(b), length);
+		dynamic_buffer.insert(cur_offset, b, sizeof(b));
+		cur_offset += 4;
+	}
+	break;
 	default:
-		invalid_structure("invalid length size", lenSize);
+		fb_assert(lenSize >= 0 && lenSize <= 2 || lenSize == 4);
 		return;
 	}
 	dynamic_buffer.insert(cur_offset, static_cast<const UCHAR*>(bytes), length);

--- a/src/common/classes/ClumpletWriter.cpp
+++ b/src/common/classes/ClumpletWriter.cpp
@@ -232,7 +232,7 @@ void ClumpletWriter::reset(const ClumpletWriter& from)
 	reset(from.getBuffer(), from.getBufferEnd() - from.getBuffer());
 }
 
-[[noreturn]] void ClumpletWriter::size_overflow()
+void ClumpletWriter::size_overflow()
 {
 	fatal_exception::raise("Clumplet buffer size limit reached");
 }

--- a/src/common/classes/ClumpletWriter.h
+++ b/src/common/classes/ClumpletWriter.h
@@ -35,7 +35,7 @@
 // This setting of maximum dpb size doesn't mean, that we
 // can't process larger DBPs! This is just recommended limit
 // cause it's hard to imagine sensefull DPB of even this size.
-const FB_SIZE_T MAX_DPB_SIZE = 1024 * 1024;
+constexpr FB_SIZE_T MAX_DPB_SIZE = 1024 * 1024;
 
 namespace Firebird {
 
@@ -100,7 +100,7 @@ public:
 	bool deleteWithTag(UCHAR tag);
 
 	const UCHAR* getBuffer() const override;
-	bool hasOverflow() const
+	bool hasOverflow() const noexcept
 	{
 		return flag_overflow;
 	}

--- a/src/common/classes/ClumpletWriter.h
+++ b/src/common/classes/ClumpletWriter.h
@@ -107,7 +107,7 @@ public:
 
 protected:
 	const UCHAR* getBufferEnd() const override;
-	[[noreturn]] virtual void size_overflow();
+	virtual void size_overflow();
 	void insertBytesLengthCheck(UCHAR tag, const void* bytes, const FB_SIZE_T length);
 	bool upgradeVersion();	// upgrade clumplet version - obtain newest from kindList
 

--- a/src/common/classes/ClumpletWriter.h
+++ b/src/common/classes/ClumpletWriter.h
@@ -107,7 +107,7 @@ public:
 
 protected:
 	const UCHAR* getBufferEnd() const override;
-	virtual void size_overflow();
+	[[noreturn]] virtual void size_overflow();
 	void insertBytesLengthCheck(UCHAR tag, const void* bytes, const FB_SIZE_T length);
 	bool upgradeVersion();	// upgrade clumplet version - obtain newest from kindList
 

--- a/src/common/fb_exception.cpp
+++ b/src/common/fb_exception.cpp
@@ -126,19 +126,19 @@ const char* status_exception::what() const noexcept
 	return "Firebird::status_exception";
 }
 
-void status_exception::raise(const ISC_STATUS *status_vector)
+[[noreturn]] void status_exception::raise(const ISC_STATUS *status_vector)
 {
 	throw status_exception(status_vector);
 }
 
-void status_exception::raise(const IStatus* status)
+[[noreturn]] void status_exception::raise(const IStatus* status)
 {
 	StaticStatusVector status_vector;
 	status_vector.mergeStatus(status);
 	throw status_exception(status_vector.begin());
 }
 
-void status_exception::raise(const Arg::StatusVector& statusVector)
+[[noreturn]] void status_exception::raise(const Arg::StatusVector& statusVector)
 {
 	throw status_exception(statusVector.value());
 }
@@ -157,7 +157,7 @@ void status_exception::stuffByException(StaticStatusVector& status) const noexce
 
 // ********************************* BadAlloc ****************************
 
-void BadAlloc::raise()
+[[noreturn]] void BadAlloc::raise()
 {
 	throw BadAlloc();
 }
@@ -174,14 +174,14 @@ const char* BadAlloc::what() const noexcept
 
 // ********************************* LongJump ***************************
 
-void LongJump::raise()
+[[noreturn]] void LongJump::raise()
 {
 	throw LongJump();
 }
 
 void LongJump::stuffByException(StaticStatusVector& status) const noexcept
 {
-	ISC_STATUS sv[] = {isc_arg_gds, isc_random, isc_arg_string,
+	const ISC_STATUS sv[] = {isc_arg_gds, isc_random, isc_arg_string,
 		(ISC_STATUS)(IPTR) "Unexpected call to Firebird::LongJump::stuffException()", isc_arg_end};
 
 	try
@@ -202,7 +202,7 @@ const char* LongJump::what() const noexcept
 
 // ********************************* system_error ***************************
 
-system_error::system_error(const char* syscall, const char* arg, int error_code) :
+system_error::system_error(const char* syscall, const char* arg, int error_code) noexcept :
 	status_exception(), errorCode(error_code)
 {
 	Arg::Gds temp(isc_sys_request);
@@ -213,17 +213,17 @@ system_error::system_error(const char* syscall, const char* arg, int error_code)
 	set_status(temp.value());
 }
 
-void system_error::raise(const char* syscall, int error_code)
+[[noreturn]] void system_error::raise(const char* syscall, int error_code)
 {
 	throw system_error(syscall, nullptr, error_code);
 }
 
-void system_error::raise(const char* syscall)
+[[noreturn]] void system_error::raise(const char* syscall)
 {
 	throw system_error(syscall, nullptr, getSystemError());
 }
 
-int system_error::getSystemError()
+int system_error::getSystemError() noexcept
 {
 #ifdef WIN_NT
 	return GetLastError();
@@ -247,30 +247,29 @@ system_call_failed::system_call_failed(const char* syscall, const char* arg, int
 #endif
 }
 
-void system_call_failed::raise(const char* syscall, int error_code)
+[[noreturn]] void system_call_failed::raise(const char* syscall, int error_code)
 {
 	throw system_call_failed(syscall, nullptr, error_code);
 }
 
-void system_call_failed::raise(const char* syscall)
+[[noreturn]] void system_call_failed::raise(const char* syscall)
 {
 	throw system_call_failed(syscall, nullptr, getSystemError());
 }
 
-
-void system_call_failed::raise(const char* syscall, const char* arg, int error_code)
+[[noreturn]] void system_call_failed::raise(const char* syscall, const char* arg, int error_code)
 {
 	throw system_call_failed(syscall, arg, error_code);
 }
 
-void system_call_failed::raise(const char* syscall, const char* arg)
+[[noreturn]] void system_call_failed::raise(const char* syscall, const char* arg)
 {
 	raise(syscall, arg, getSystemError());
 }
 
 // ********************************* fatal_exception *******************************
 
-fatal_exception::fatal_exception(const char* message) :
+fatal_exception::fatal_exception(const char* message) noexcept :
 	status_exception()
 {
 	const ISC_STATUS temp[] =
@@ -291,12 +290,12 @@ const char* fatal_exception::what() const noexcept
 	return reinterpret_cast<const char*>(value()[3]);
 }
 
-void fatal_exception::raise(const char* message)
+[[noreturn]] void fatal_exception::raise(const char* message)
 {
 	throw fatal_exception(message);
 }
 
-void fatal_exception::raiseFmt(const char* format, ...)
+[[noreturn]] void fatal_exception::raiseFmt(const char* format, ...)
 {
 	va_list args;
 	va_start(args, format);

--- a/src/include/fb_exception.h
+++ b/src/include/fb_exception.h
@@ -74,7 +74,7 @@ class LongJump : public Exception
 public:
 	virtual void stuffByException(StaticStatusVector& status_vector) const noexcept;
 	virtual const char* what() const noexcept;
-	static void raise();
+	[[noreturn]] static void raise();
 	LongJump() noexcept : Exception() { }
 };
 
@@ -85,7 +85,7 @@ public:
 	BadAlloc() noexcept : std::bad_alloc(), Exception() { }
 	virtual void stuffByException(StaticStatusVector& status_vector) const noexcept;
 	virtual const char* what() const noexcept;
-	static void raise();
+	[[noreturn]] static void raise();
 };
 
 // Main exception class in firebird
@@ -131,18 +131,18 @@ private:
 	int errorCode;
 
 protected:
-	system_error(const char* syscall, const char* arg, int error_code);
+	system_error(const char* syscall, const char* arg, int error_code) noexcept;
 
 public:
-	static void raise(const char* syscall, int error_code);
-	static void raise(const char* syscall);
+	[[noreturn]] static void raise(const char* syscall, int error_code);
+	[[noreturn]] static void raise(const char* syscall);
 
-	int getErrorCode() const
+	int getErrorCode() const noexcept
 	{
 		return errorCode;
 	}
 
-	static int getSystemError();
+	static int getSystemError() noexcept;
 };
 
 // use this class if exception can't be handled
@@ -153,19 +153,19 @@ protected:
 	system_call_failed(const char* syscall, const char* arg, int error_code);
 
 public:
-	static void raise(const char* syscall, int error_code);
-	static void raise(const char* syscall);
-	static void raise(const char* syscall, const char* arg, int error_code);
-	static void raise(const char* syscall, const char* arg);
+	[[noreturn]] static void raise(const char* syscall, int error_code);
+	[[noreturn]] static void raise(const char* syscall);
+	[[noreturn]] static void raise(const char* syscall, const char* arg, int error_code);
+	[[noreturn]] static void raise(const char* syscall, const char* arg);
 };
 
 class fatal_exception : public status_exception
 {
 public:
-	explicit fatal_exception(const char* message);
-	static void raiseFmt(const char* format, ...);
+	explicit fatal_exception(const char* message) noexcept;
+	[[noreturn]] static void raiseFmt(const char* format, ...);
 	const char* what() const noexcept;
-	static void raise(const char* message);
+	[[noreturn]] static void raise(const char* message);
 };
 
 


### PR DESCRIPTION
Uses isTagged() instead of having three or four different ways of discerning tagged vs untagged (in some cases, missing some kinds). Some code cleanup, annotating [[noreturn]]/noexcept, addressing switch code analysis warnings.

Also fixes a bug where ClumpletWriter.reset(...) shouldn't work for tagged buffers (apparently not happening in production code?)