### PR TITLE
Makes MON$COMPILED_STATEMENTS and MON$STATEMENTS share blobs with text and plan content of the same statement.

### DIFF
--- a/src/jrd/Monitoring.cpp
+++ b/src/jrd/Monitoring.cpp
@@ -550,7 +550,7 @@ MonitoringSnapshot::MonitoringSnapshot(thread_db* tdbb, MemoryPool& pool)
 	// Parse the dump
 
 	// BlobID's of statement text and plan
-	using StmtBlobs = struct { bid text; bid plan; };
+	struct StmtBlobs { bid text; bid plan; };
 
 	// Map compiled statement id to blobs ids
 	NonPooledMap<FB_UINT64, StmtBlobs> blobsMap(pool);


### PR DESCRIPTION
Table `MON$COMPILED_STATEMENTS` introduced in ODS 13.1 with FB5 contains `MON$SQL_TEXT` and `MON$EXPLAINED_PLAN` fields that duplicate contents of the same fields in `MON$STATEMENTS`. The size of SQL text and explained plan could be relatively big, thus it is feasible to not duplicate its, saving memory, disk and CPU circles. 

This PR makes engine to put statement text and plan into `MON$COMPILED_STATEMENTS` only and share blobs with corresponding record in `MON$STATEMENTS` (if present).
