### PR TITLE
fix(gbak): Stop blob reading when restore task receives stop signal

### DIFF
--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -12473,6 +12473,9 @@ inline void RestoreRelationTask::checkSpace(IOBuffer** pBuf, const FB_SIZE_T len
 	(*pBuf)->setUsed((*pBuf)->getSize() - *pSpace);
 
 	IOBuffer* newBuf = getCleanBuffer();
+	if (!newBuf)
+		LongJump::raise(); // We received command to stop our task (possible due to errors)
+
 	(*pBuf)->linkNext(newBuf);
 
 	if ((*pBuf)->getRecs())


### PR DESCRIPTION
Prevents SIGFAULT by immediately stopping blob processing when a stop signal is received during restore operations.
This can happen when restoring in multiple threads. The problem in `RestoreRelationTask::checkSpace` where we don't check the result of `getCleanBuffer()` for `nullptr` and it causes corruption in `IOBuffer` linked list. This can lead to a sigfault in `RestoreRelationTask::read_blob()` where the `checkSpace()` function is called multiple times.

This was already fixed in v6 ([commit](https://github.com/TreeHunter9/firebird/commit/d594a2b62f8d16294f69bec8a113952938be4f3f)), but I don't think the main purpose of that commit was to fix specifically this problem.