### PR TITLE
Get the modification time of a config file with a higher precision to fix cases when it's not reloaded after modification/replacement

### DIFF
--- a/src/common/config/ConfigCache.cpp
+++ b/src/common/config/ConfigCache.cpp
@@ -85,19 +85,17 @@ Firebird::PathName ConfigCache::getFileName()
 #ifdef WIN_NT
 void ConfigCache::File::getTime(DWORD& timeLow, DWORD& timeHigh)
 {
-	WIN32_FIND_DATA findFileData;
-	HANDLE hFind = FindFirstFile(fileName.c_str(), &findFileData);
+	WIN32_FILE_ATTRIBUTE_DATA fInfo;
 
-	if (hFind == INVALID_HANDLE_VALUE)
+	if (!GetFileAttributesEx(fileName.c_str(), GetFileExInfoStandard, &fInfo))
 	{
 		timeLow = 0;
 		timeHigh = 0;
 		return;
 	}
 
-	FindClose(hFind);
-	timeLow = findFileData.ftLastWriteTime.dwLowDateTime;
-	timeHigh = findFileData.ftLastWriteTime.dwHighDateTime;
+	timeLow = fInfo.ftLastWriteTime.dwLowDateTime;
+	timeHigh = fInfo.ftLastWriteTime.dwHighDateTime;
 }
 #else
 void ConfigCache::File::getTime(timespec& time)

--- a/src/common/config/ConfigCache.cpp
+++ b/src/common/config/ConfigCache.cpp
@@ -82,7 +82,25 @@ Firebird::PathName ConfigCache::getFileName()
 	return files->fileName;
 }
 
-time_t ConfigCache::File::getTime()
+#ifdef WIN_NT
+void ConfigCache::File::getTime(DWORD& timeLow, DWORD& timeHigh)
+{
+	WIN32_FIND_DATA findFileData;
+	HANDLE hFind = FindFirstFile(fileName.c_str(), &findFileData);
+
+	if (hFind == INVALID_HANDLE_VALUE)
+	{
+		timeLow = 0;
+		timeHigh = 0;
+		return;
+	}
+
+	FindClose(hFind);
+	timeLow = findFileData.ftLastWriteTime.dwLowDateTime;
+	timeHigh = findFileData.ftLastWriteTime.dwHighDateTime;
+}
+#else
+void ConfigCache::File::getTime(timespec& time)
 {
 	struct STAT st;
 
@@ -91,17 +109,30 @@ time_t ConfigCache::File::getTime()
 		if (errno == ENOENT)
 		{
 			// config file is missing, but this is not our problem
-			return 0;
+			time.tv_sec = 0;
+			time.tv_nsec = 0;
+			return;
 		}
 		system_call_failed::raise("stat");
 	}
 
-	return st.st_mtime;
+	time.tv_sec = st.st_mtim.tv_sec;
+	time.tv_nsec = st.st_mtim.tv_nsec;
 }
+#endif
 
 ConfigCache::File::File(MemoryPool& p, const PathName& fName)
-	: PermanentStorage(p), fileName(getPool(), fName), fileTime(0), next(NULL)
-{ }
+	: PermanentStorage(p), fileName(getPool(), fName),
+	next(NULL)
+{
+#ifdef WIN_NT
+	fileTimeLow = 0;
+	fileTimeHigh = 0;
+#else
+	fileTime.tv_sec = 0;
+	fileTime.tv_nsec = 0;
+#endif
+}
 
 ConfigCache::File::~File()
 {
@@ -110,15 +141,30 @@ ConfigCache::File::~File()
 
 bool ConfigCache::File::checkLoadConfig(bool set)
 {
-	time_t newTime = getTime();
-	if (fileTime == newTime)
+#ifdef WIN_NT
+	DWORD newTimeLow;
+	DWORD newTimeHigh;
+	getTime(newTimeLow, newTimeHigh);
+	if (fileTimeLow == newTimeLow && fileTimeHigh == newTimeHigh)
+#else
+	timespec newTime;
+	getTime(newTime);
+	if (fileTime.tv_sec == newTime.tv_sec && fileTime.tv_nsec == newTime.tv_nsec)
+#endif
 	{
 		return next ? next->checkLoadConfig(set) : true;
 	}
 
 	if (set)
 	{
-		fileTime = newTime;
+#ifdef WIN_NT
+		fileTimeLow = newTimeLow;
+		fileTimeHigh = newTimeHigh;
+#else
+		fileTime.tv_sec = newTime.tv_sec;
+		fileTime.tv_nsec = newTime.tv_nsec;
+#endif
+
 		if (next)
 		{
 			next->checkLoadConfig(set);

--- a/src/common/config/ConfigCache.cpp
+++ b/src/common/config/ConfigCache.cpp
@@ -114,8 +114,13 @@ void ConfigCache::File::getTime(timespec& time)
 		system_call_failed::raise("stat");
 	}
 
+#ifdef DARWIN
+	time.tv_sec = st.st_mtimespec.tv_sec;
+	time.tv_nsec = st.st_mtimespec.tv_nsec;
+#else
 	time.tv_sec = st.st_mtim.tv_sec;
 	time.tv_nsec = st.st_mtim.tv_nsec;
+#endif
 }
 #endif
 

--- a/src/common/config/ConfigCache.h
+++ b/src/common/config/ConfigCache.h
@@ -25,8 +25,8 @@
  *
  */
 
-#ifndef COMMON_CONFIG_CASHE_H
-#define COMMON_CONFIG_CASHE_H
+#ifndef COMMON_CONFIG_CACHE_H
+#define COMMON_CONFIG_CACHE_H
 
 #include "../common/classes/alloc.h"
 #include "../common/classes/fb_string.h"
@@ -103,4 +103,4 @@ public:
 	Firebird::RWLock rwLock;
 };
 
-#endif // COMMON_CONFIG_CASHE_H
+#endif // COMMON_CONFIG_CACHE_H

--- a/src/common/config/ConfigCache.h
+++ b/src/common/config/ConfigCache.h
@@ -60,9 +60,16 @@ private:
 		Firebird::PathName fileName;
 
 	private:
-		volatile time_t fileTime;
+#ifdef WIN_NT
+		volatile DWORD fileTimeLow;
+		volatile DWORD fileTimeHigh;
+		void getTime(DWORD& timeLow, DWORD& timeHigh);
+#else
+		volatile timespec fileTime;
+		void getTime(timespec& time);
+#endif
+
 		File* next;
-		time_t getTime();
 	};
 	File* files;
 


### PR DESCRIPTION
The fix is needed to avoid potential problems in Firebird QA.