### PR TITLE
fix(config): Prevent printf injection in replication.conf

### DIFF
--- a/src/jrd/replication/Config.cpp
+++ b/src/jrd/replication/Config.cpp
@@ -81,9 +81,7 @@ namespace
 
 	void configError(const string& type, const string& key, const string& value)
 	{
-		string msg;
-		msg.printf("%s specifies %s: %s", key.c_str(), type.c_str(), value.c_str());
-		raiseError("%s", msg.c_str());
+		raiseError("%s specifies %s: %s", key.c_str(), type.c_str(), value.c_str());
 	}
 
 	void checkAccess(const PathName& path, const string& key)

--- a/src/jrd/replication/Config.cpp
+++ b/src/jrd/replication/Config.cpp
@@ -83,7 +83,7 @@ namespace
 	{
 		string msg;
 		msg.printf("%s specifies %s: %s", key.c_str(), type.c_str(), value.c_str());
-		raiseError(msg.c_str());
+		raiseError("%s", msg.c_str());
 	}
 
 	void checkAccess(const PathName& path, const string& key)


### PR DESCRIPTION
The problem can be reproduced with this incorrect replication.conf:
```
database = <path/to/database>
{
	source_guid = 12%d%s%s%s3456
}
```
The server will crash on startup.

v5 has this bug too.