### PR TITLE
Cache vcpkg binary cache for macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -389,9 +389,8 @@ jobs:
         id: restore-vcpkg-cache
         with:
           path: ~/.cache/vcpkg/archives
-          key: vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('vcpkg-custom/**') }}
-          restore-keys: |
-            vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-
+          # We're always matching on a partial key here!
+          key: vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-
 
       - name: Build
         run: |
@@ -421,10 +420,10 @@ jobs:
 
       - name: Save vcpkg cache
         uses: actions/cache/save@v4
-        # if: steps.restore-vcpkg-cache.outputs.cache-hit != 'true'
+        if: steps.restore-vcpkg-cache.outputs.cache-matched-key != 'vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('~/.cache/vcpkg/archives/**') }}'
         with:
           path: ~/.cache/vcpkg/archives
-          key: ${{ steps.restore-vcpkg-cache.outputs.cache-primary-key }}
+          key: vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('~/.cache/vcpkg/archives/**') }}
 
       - name: Upload installer
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -421,7 +421,7 @@ jobs:
 
       - name: Save vcpkg cache
         uses: actions/cache/save@v4
-        if: steps.restore-vcpkg-cache.outputs.cache-hit != 'true'
+        # if: steps.restore-vcpkg-cache.outputs.cache-hit != 'true'
         with:
           path: ~/.cache/vcpkg/archives
           key: ${{ steps.restore-vcpkg-cache.outputs.cache-primary-key }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -362,8 +362,6 @@ jobs:
   build-macos:
     name: build-macos-${{ matrix.arch }}
     runs-on: ${{ (matrix.arch == 'arm64' && 'macos-14') || 'macos-13' }}
-    env:
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
     strategy:
       fail-fast: false
@@ -386,12 +384,13 @@ jobs:
         run: |
           brew install automake autoconf-archive libtool ninja
 
-      - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
+      - name: Restore vcpkg cache
+        uses: actions/cache/restore@v4
         with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+          path: ~/.cache/vcpkg/archives
+          key: vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-${{ github.run_id }}
+          restore-keys: |
+            vcpkg-vcpackage-${{ runner.os }}-${{ matrix.arch }}
 
       - name: Build
         run: |
@@ -418,6 +417,12 @@ jobs:
           mv gen2 gen
           mkdir gen/artifacts
           mv gen/Release/*.pkg gen/artifacts
+
+      - name: Save vcpkg cache
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/vcpkg/archives
+          key: vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-${{ github.run_id }}
 
       - name: Upload installer
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -421,6 +421,7 @@ jobs:
 
       - name: Save vcpkg cache
         uses: actions/cache/save@v4
+        # Saves if the key changed (with hash based on contents of vcpkg/ and vcpkg-custom/)
         if: steps.restore-vcpkg-cache.outputs.cache-hit != 'true'
         with:
           path: ~/.cache/vcpkg/archives

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -389,8 +389,9 @@ jobs:
         id: restore-vcpkg-cache
         with:
           path: ~/.cache/vcpkg/archives
-          # We're always matching on a partial key here!
-          key: vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-
+          key: vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('vcpkg-custom/**', 'vcpkg/**') }}
+          restore-keys: |
+            vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-
 
       - name: Build
         run: |
@@ -420,10 +421,10 @@ jobs:
 
       - name: Save vcpkg cache
         uses: actions/cache/save@v4
-        if: steps.restore-vcpkg-cache.outputs.cache-matched-key != 'vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('~/.cache/vcpkg/archives/**') }}'
+        if: steps.restore-vcpkg-cache.outputs.cache-hit != 'true'
         with:
           path: ~/.cache/vcpkg/archives
-          key: vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('~/.cache/vcpkg/archives/**') }}
+          key: ${{ steps.restore-vcpkg-cache.outputs.cache-primary-key }}
 
       - name: Upload installer
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -389,7 +389,7 @@ jobs:
         id: restore-vcpkg-cache
         with:
           path: ~/.cache/vcpkg/archives
-          key: vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('vcpkg-custom/**', 'vcpkg/**') }}
+          key: vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('vcpkg-custom/**', 'vcpkg.json', 'vcpkg-configuration.json') }}
           restore-keys: |
             vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-
 
@@ -421,7 +421,7 @@ jobs:
 
       - name: Save vcpkg cache
         uses: actions/cache/save@v4
-        # Saves if the key changed (with hash based on contents of vcpkg/ and vcpkg-custom/)
+        # Saves if the key changed (hashes on vcpkg/**, vcpkg.json, vcpkg-configuration.json)
         if: steps.restore-vcpkg-cache.outputs.cache-hit != 'true'
         with:
           path: ~/.cache/vcpkg/archives

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -382,10 +382,11 @@ jobs:
 
       - name: Prepare - Install tools
         run: |
-          brew install automake autoconf-archive libtool ninja
+          brew install --quiet automake autoconf-archive libtool ninja
 
       - name: Restore vcpkg cache
         uses: actions/cache/restore@v4
+        id: restore-vcpkg-cache
         with:
           path: ~/.cache/vcpkg/archives
           key: vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-${{ github.run_id }}
@@ -422,7 +423,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ~/.cache/vcpkg/archives
-          key: vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-${{ github.run_id }}
+          key: ${{ steps.restore-vcpkg-cache.outputs.cache-primary-key }}
 
       - name: Upload installer
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -389,7 +389,7 @@ jobs:
         id: restore-vcpkg-cache
         with:
           path: ~/.cache/vcpkg/archives
-          key: vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-${{ github.run_id }}
+          key: vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('vcpkg-custom/**') }}
           restore-keys: |
             vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-
 
@@ -421,6 +421,7 @@ jobs:
 
       - name: Save vcpkg cache
         uses: actions/cache/save@v4
+        if: steps.restore-vcpkg-cache.outputs.cache-hit != 'true'
         with:
           path: ~/.cache/vcpkg/archives
           key: ${{ steps.restore-vcpkg-cache.outputs.cache-primary-key }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -391,7 +391,7 @@ jobs:
           path: ~/.cache/vcpkg/archives
           key: vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-${{ github.run_id }}
           restore-keys: |
-            vcpkg-vcpackage-${{ runner.os }}-${{ matrix.arch }}
+            vcpkg-cache-${{ runner.os }}-${{ matrix.arch }}-
 
       - name: Build
         run: |

--- a/vcpkg-custom/DELETE-ME.txt
+++ b/vcpkg-custom/DELETE-ME.txt
@@ -1,1 +1,0 @@
-Test for https://github.com/FirebirdSQL/firebird/pull/8560, should not be merged

--- a/vcpkg-custom/DELETE-ME.txt
+++ b/vcpkg-custom/DELETE-ME.txt
@@ -1,0 +1,1 @@
+Test for https://github.com/FirebirdSQL/firebird/pull/8560, should not be merged


### PR DESCRIPTION
Due to https://github.com/microsoft/vcpkg-tool/pull/1662, the original caching is no longer working.