### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/extern/libtommath/bn_fast_s_mp_mul_digs.c
+++ b/extern/libtommath/bn_fast_s_mp_mul_digs.c
@@ -37,6 +37,10 @@ int fast_s_mp_mul_digs (mp_int * a, mp_int * b, mp_int * c, int digs)
   mp_digit W[MP_WARRAY];
   register mp_word  _W;
 
+  if (digs < 0) {
+    return MP_VAL;
+  }
+
   /* grow the destination as required */
   if (c->alloc < digs) {
     if ((res = mp_grow (c, digs)) != MP_OKAY) {

--- a/extern/libtommath/bn_fast_s_mp_mul_high_digs.c
+++ b/extern/libtommath/bn_fast_s_mp_mul_high_digs.c
@@ -30,6 +30,10 @@ int fast_s_mp_mul_high_digs (mp_int * a, mp_int * b, mp_int * c, int digs)
   mp_digit W[MP_WARRAY];
   mp_word  _W;
 
+  if (digs < 0) {
+    return MP_VAL;
+  }
+
   /* grow the destination as required */
   pa = a->used + b->used;
   if (c->alloc < pa) {

--- a/extern/libtommath/bn_mp_2expt.c
+++ b/extern/libtommath/bn_mp_2expt.c
@@ -25,6 +25,10 @@ mp_2expt (mp_int * a, int b)
 {
   int     res;
 
+  if (b < 0) {
+      return MP_VAL;
+   }
+
   /* zero a as per default */
   mp_zero (a);
 

--- a/extern/libtommath/bn_mp_grow.c
+++ b/extern/libtommath/bn_mp_grow.c
@@ -21,6 +21,10 @@ int mp_grow (mp_int * a, int size)
   int     i;
   mp_digit *tmp;
 
+  if (size < 0) {
+    return MP_VAL;
+  }
+
   /* if the alloc size is smaller alloc more ram */
   if (a->alloc < size) {
     /* ensure there are always at least MP_PREC digits extra on top */

--- a/extern/libtommath/bn_mp_init_size.c
+++ b/extern/libtommath/bn_mp_init_size.c
@@ -20,6 +20,10 @@ int mp_init_size (mp_int * a, int size)
 {
   int x;
 
+  if (size < 0) {
+    return MP_VAL;
+  }
+
   /* pad size so there are always extra digits */
   size += (MP_PREC * 2) - (size % MP_PREC);	
   

--- a/extern/libtommath/bn_mp_mul_2d.c
+++ b/extern/libtommath/bn_mp_mul_2d.c
@@ -21,6 +21,10 @@ int mp_mul_2d (mp_int * a, int b, mp_int * c)
   mp_digit d;
   int      res;
 
+  if (b < 0) {
+    return MP_VAL;
+  }
+
   /* copy */
   if (a != c) {
      if ((res = mp_copy (a, c)) != MP_OKAY) {

--- a/extern/libtommath/bn_s_mp_mul_digs.c
+++ b/extern/libtommath/bn_s_mp_mul_digs.c
@@ -27,6 +27,10 @@ int s_mp_mul_digs (mp_int * a, mp_int * b, mp_int * c, int digs)
   mp_word r;
   mp_digit tmpx, *tmpt, *tmpy;
 
+  if (digs < 0) {
+    return MP_VAL;
+  }
+
   /* can we use the fast multiplier? */
   if (((digs) < MP_WARRAY) &&
       MIN (a->used, b->used) < 

--- a/extern/libtommath/bn_s_mp_mul_high_digs.c
+++ b/extern/libtommath/bn_s_mp_mul_high_digs.c
@@ -27,6 +27,10 @@ s_mp_mul_high_digs (mp_int * a, mp_int * b, mp_int * c, int digs)
   mp_word r;
   mp_digit tmpx, *tmpt, *tmpy;
 
+  if (digs < 0) {
+    return MP_VAL;
+  }
+
   /* can we use the fast multiplier? */
 #ifdef BN_FAST_S_MP_MUL_HIGH_DIGS_C
   if (((a->used + b->used + 1) < MP_WARRAY)


### PR DESCRIPTION
Hi Development Team,

I identified a potential integer overflow in clone functions in files in `extern/libtommath` sourced from [libtom/libtommath](https://github.com/libtom/libtommath). This issue, originally reported in [CVE-2023-36328](https://nvd.nist.gov/vuln/detail/CVE-2023-36328), was resolved in the repository via this commit https://github.com/libtom/libtommath/commit/beba892bc0d4e4ded4d667ab1d2a94f4d75109a9.

This PR applies the corresponding patch to fix the vulnerability in this codebase.

Please review at your convenience. Thank you!