### PR TITLE
Fix #8590 - Line "BLR to Source mapping:" may look broken when procedures.rdb$debug_info is queried using remote protocol.

### DIFF
--- a/src/isql/isql.epp
+++ b/src/isql/isql.epp
@@ -7755,23 +7755,7 @@ processing_state ISQL_print_item_blob(FILE* fp, const IsqlVar* var, Firebird::IT
 			break;
 
 		buffer[length] = 0;
-
-		// Special displays for blr or acl subtypes
-
-		if (blob_subtype > isc_blob_text && blob_subtype < isc_blob_max_predefined_subtype)
-		{
-			for (char* b = buffer + length - 1; b >= buffer;)
-			{
-				if (*b == '\n' || *b == '\t' || *b == BLANK)
-					*b-- = 0;
-				else
-					break;
-			}
-
-			IUTILS_printf2(fp, "%s	%s%s", TAB_AS_SPACES, buffer, NEWLINE);
-		}
-		else
-			IUTILS_printf(fp, buffer);
+		IUTILS_printf(fp, buffer);
 
 	} while (true);
 

--- a/src/jrd/filters.cpp
+++ b/src/jrd/filters.cpp
@@ -1366,7 +1366,7 @@ static void string_put(BlobControl* control, const char* line)
  *
  **************************************/
 	const USHORT len = static_cast<USHORT>(strlen(line));
-	filter_tmp* string = (filter_tmp*) gds__alloc((SLONG) (sizeof(filter_tmp) + len));
+	filter_tmp* string = (filter_tmp*) gds__alloc((SLONG) (sizeof(filter_tmp) + len + 1));
 	// FREE: on isc_blob_filter_close in string_filter()
 	if (!string)
 	{
@@ -1375,8 +1375,9 @@ static void string_put(BlobControl* control, const char* line)
 		return;					// & No error handling at this level
 	}
 	string->tmp_next = NULL;
-	string->tmp_length = len;
+	string->tmp_length = len + 1;
 	memcpy(string->tmp_string, line, len);
+	string->tmp_string[len] = '\n';
 
 	filter_tmp* prior = (filter_tmp*) control->ctl_data[1];
 	if (prior)
@@ -1386,8 +1387,8 @@ static void string_put(BlobControl* control, const char* line)
 
 	control->ctl_data[1] = (IPTR) string;
 	++control->ctl_number_segments;
-	control->ctl_total_length += len;
-	control->ctl_max_segment = MAX(control->ctl_max_segment, len);
+	control->ctl_total_length += len + 1;
+	control->ctl_max_segment = MAX(control->ctl_max_segment, len + 1);
 }
 
 


### PR DESCRIPTION
When transforming a blob of an internal type (say, isc_blob_debug_info) to text, the segments are generated without new line information.

ISQL treats it segment as a line, putting some leading spaces and the new line.

I have no idea why.

But this causes problems when remote batches segments and some are split, causing the extra new line as reported in #8590.

This change is not always backward incompatible, specially when different versions of engine x ISQL is used or non-ISQL clients converting internal blobs to text.