### PR TITLE
Fixed string_filter (used with internal blob types) that could not report isc_segment.

### DIFF
--- a/src/jrd/filters.cpp
+++ b/src/jrd/filters.cpp
@@ -1309,7 +1309,6 @@ static ISC_STATUS string_filter(USHORT action, BlobControl* control)
  *
  **************************************/
 	filter_tmp* string;
-	USHORT length;
 
 	switch (action)
 	{
@@ -1322,10 +1321,14 @@ static ISC_STATUS string_filter(USHORT action, BlobControl* control)
 		return FB_SUCCESS;
 
 	case isc_blob_filter_get_segment:
+	{
 		if (!(string = (filter_tmp*) control->ctl_data[1]))
 			return isc_segstr_eof;
-		length = string->tmp_length - control->ctl_data[2];
-		if (length > control->ctl_buffer_length)
+
+		USHORT length = string->tmp_length - control->ctl_data[2];
+		const bool outOfBuffer = (length > control->ctl_buffer_length);
+
+		if (outOfBuffer)
 			length = control->ctl_buffer_length;
 		memcpy(control->ctl_buffer, string->tmp_string + (USHORT) control->ctl_data[2], length);
 		control->ctl_data[2] += length;
@@ -1334,7 +1337,8 @@ static ISC_STATUS string_filter(USHORT action, BlobControl* control)
 			control->ctl_data[2] = 0;
 		}
 		control->ctl_segment_length = length;
-		return (length <= control->ctl_buffer_length) ? FB_SUCCESS : isc_segment;
+		return (!outOfBuffer) ? FB_SUCCESS : isc_segment;
+	}
 
 	case isc_blob_filter_put_segment:
 	case isc_blob_filter_create:


### PR DESCRIPTION
It fixes #8590 and other similar cases.