### PR TITLE
fix(int128): Use all 16 decimal digits to represent int128 min/max in double number correctly

### DIFF
--- a/src/common/cvt.cpp
+++ b/src/common/cvt.cpp
@@ -3169,10 +3169,10 @@ Int128 CVT_get_int128(const dsc* desc, SSHORT scale, DecimalStatus decSt, ErrorF
 	Decimal128 tmp;
 	double d, eps;
 
-	static const double I128_MIN_dbl = -1.701411834604692e+38;
-	static const double I128_MAX_dbl =  1.701411834604692e+38;
+	static const double I128_MIN_dbl = -1.7014118346046923e+38;
+	static const double I128_MAX_dbl =  1.7014118346046921e+38;
 	static const CDecimal128 I128_MIN_dcft("-1.701411834604692317316873037158841E+38", decSt);
-	static const CDecimal128 I128_MAX_dcft("1.701411834604692317316873037158841E+38", decSt);
+	static const CDecimal128 I128_MAX_dcft( "1.701411834604692317316873037158841E+38", decSt);
 	static const CDecimal128 DecFlt_05("0.5", decSt);
 
 	// adjust exact numeric values to same scaling


### PR DESCRIPTION
The value `I128_MIN_dbl` was not represented precisely, as it didn't utilize all 16 decimal digits (52 bits of mantissa) available in a double-precision number. As a result, the value was rounded down to the closest representable number in the double format.

This inaccuracy led to an error in the following query:
```
SELECT CAST(-POWER(2, 127) AS INT128) FROM RDB$DATABASE;
=======================
Statement failed, SQLSTATE = 22003
arithmetic exception, numeric overflow, or string truncation
-numeric value is out of range
```
