### PR TITLE
Cloop constexpr

### DIFF
--- a/extern/cloop/src/cloop/Generator.cpp
+++ b/extern/cloop/src/cloop/Generator.cpp
@@ -191,7 +191,9 @@ void CppGenerator::generate()
 	fprintf(out, "#endif\n\n\n");
 
 	fprintf(out, "#ifndef CLOOP_CONSTEXPR\n");
-	fprintf(out, "#if __cplusplus >= 201103L\n");
+	fprintf(out, "#if __cplusplus >= 201703L\n");
+	fprintf(out, "#define CLOOP_CONSTEXPR inline constexpr\n");
+	fprintf(out, "#elif __cplusplus >= 201103L\n");
 	fprintf(out, "#define CLOOP_CONSTEXPR constexpr\n");
 	fprintf(out, "#else\n");
 	fprintf(out, "#define CLOOP_CONSTEXPR const\n");

--- a/extern/cloop/src/cloop/cloop.vcxproj
+++ b/extern/cloop/src/cloop/cloop.vcxproj
@@ -119,6 +119,8 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -146,6 +148,8 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/extern/cloop/src/tests/test1/test1-cpp-dll.vcxproj
+++ b/extern/cloop/src/tests/test1/test1-cpp-dll.vcxproj
@@ -129,6 +129,8 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -158,6 +160,8 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/extern/cloop/src/tests/test1/test1-cpp-exe.vcxproj
+++ b/extern/cloop/src/tests/test1/test1-cpp-exe.vcxproj
@@ -129,6 +129,8 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -161,6 +163,8 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/include/firebird/IdlFbInterfaces.h
+++ b/src/include/firebird/IdlFbInterfaces.h
@@ -17,7 +17,9 @@
 
 
 #ifndef CLOOP_CONSTEXPR
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201703L
+#define CLOOP_CONSTEXPR inline constexpr
+#elif __cplusplus >= 201103L
 #define CLOOP_CONSTEXPR constexpr
 #else
 #define CLOOP_CONSTEXPR const


### PR DESCRIPTION
* Ensures header `__cplusplus` is correctly defined under Visual C++ (`/Zc:__cplusplus`)
* Sets compiler level to C++17 in Visual C++
* Defines `CLOOP_CONSTEXPR` as `inline constexpr` for C++17 and higher