### PR TITLE
Fixed crash after calling incorrectly parametrized request

### DIFF
--- a/src/jrd/extds/ExtDS.cpp
+++ b/src/jrd/extds/ExtDS.cpp
@@ -2273,13 +2273,16 @@ void Statement::setInParams(thread_db* tdbb, const MetaName* const* names,
 			const MetaString* sqlName = m_sqlParamsMap[sqlNum];
 
 			unsigned int num = 0;
-			for (; num < count; num++)
+			if (names)
 			{
-				if (*names[num] == *sqlName)
-					break;
+				for (; num < count; num++)
+				{
+					if (*names[num] == *sqlName)
+						break;
+				}
 			}
 
-			if (num == count)
+			if (!names || (num == count))
 			{
 				m_error = true;
 				// Input parameter ''@1'' have no value set

--- a/src/jrd/extds/ExtDS.cpp
+++ b/src/jrd/extds/ExtDS.cpp
@@ -2237,6 +2237,12 @@ void Statement::setInParams(thread_db* tdbb, const MetaName* const* names,
 	const FB_SIZE_T excCount = in_excess ? in_excess->getCount() : 0;
 	const FB_SIZE_T sqlCount = m_sqlParamNames.getCount();
 
+	if (m_error = (!names && sqlCount))
+	{
+		// Parameter name expected
+		ERR_post(Arg::Gds(isc_eds_prm_name_expected));
+	}
+
 	// OK : count - excCount <= sqlCount <= count
 
 	// Check if all passed named parameters, not marked as excess, are present in query text
@@ -2273,16 +2279,13 @@ void Statement::setInParams(thread_db* tdbb, const MetaName* const* names,
 			const MetaString* sqlName = m_sqlParamsMap[sqlNum];
 
 			unsigned int num = 0;
-			if (names)
+			for (; num < count; num++)
 			{
-				for (; num < count; num++)
-				{
-					if (*names[num] == *sqlName)
-						break;
-				}
+				if (*names[num] == *sqlName)
+					break;
 			}
 
-			if (!names || (num == count))
+			if (num == count)
 			{
 				m_error = true;
 				// Input parameter ''@1'' have no value set


### PR DESCRIPTION
Init table:
```
CREATE TABLE dept (id NUMERIC(2), name VARCHAR(14), location VARCHAR(13));
```

If we execute procedure with incorrectrly paramerized request, we have an error (as expected):
```
EXECUTE BLOCK 
AS 
     DECLARE sql_stmt    VARCHAR(200);
     DECLARE dept_id     NUMERIC(2) = 50;
     DECLARE dept_name   TYPE OF COLUMN dept.name  = 'PERSONNEL';
     DECLARE location    TYPE OF COLUMN dept.location default 'DALLAS';
BEGIN
    sql_stmt = 'INSERT INTO dept VALUES (:A, :B, :C)';
    EXECUTE STATEMENT (:sql_stmt) (:dept_id, :dept_name, :location);
END;
```

> Statement failed, SQLSTATE = 42S22
> Dynamic SQL Error
> -SQL error code = -206
> -Column unknown
> -A
> -At line 1, column 26
> -At block line: 9, col: 5

But when we make it correctly and try incorrectly request again, we have a crash. Correctly request:
```
EXECUTE BLOCK 
AS 
     DECLARE sql_stmt    VARCHAR(200);
     DECLARE dept_id     NUMERIC(2) = 50;
     DECLARE dept_name   TYPE OF COLUMN dept.name  = 'PERSONNEL';
     DECLARE location    TYPE OF COLUMN dept.location default 'DALLAS';
BEGIN
    sql_stmt = 'INSERT INTO dept VALUES (:A, :B, :C)';
    EXECUTE STATEMENT (:sql_stmt) (A := :dept_id, B :=  :dept_name, C :=  :location);
END;
```

I added 2 conditions to check if names is not a nullptr.
Now it throws an exception:

> Statement failed, SQLSTATE = 42000
> Input parameter 'A' have no value set
> -At block line: 9, col: 5