### PR TITLE
Fix crash during shutdown after unsuccessful ping()

### DIFF
--- a/src/yvalve/why.cpp
+++ b/src/yvalve/why.cpp
@@ -5582,6 +5582,13 @@ isc_db_handle& YAttachment::getHandle()
 
 YAttachment::~YAttachment()
 {
+	if (handle)
+	{
+		// Currently it may be possible after ping() disconnected from the next
+		fb_assert(!next);
+		removeHandle(&attachments, handle);
+	}
+
 	if (provider)
 		PluginManagerInterfacePtr()->releasePlugin(provider);
 }
@@ -6035,10 +6042,8 @@ void YAttachment::ping(CheckStatusWrapper* status)
 			if (!savedStatus.getError())
 				savedStatus.save(status);
 
-			StatusVector temp(NULL);
-			CheckStatusWrapper tempCheckStatusWrapper(&temp);
-			entry.next()->detach(&tempCheckStatusWrapper);
-			next = NULL;
+			entry.next()->release();
+			next = nullptr;
 
 			status_exception::raise(savedStatus.value());
 		}


### PR DESCRIPTION
If Y-valve's `ping()` gets an error from the underlying provider, it disconnects immediately and clears the `next` pointer. `YHelper::release()` calls `destroy()` only if `next != nullptr`. Thus the attachment handle remains uncleared from the `attachments` array. When shutdown is performed afterwards, it iterates through this array and tries to shutdown/release the already destroyed attachment.