### PR TITLE
Fix -T[RUSTED] key description for tracemgr

### DIFF
--- a/doc/README.trace_services
+++ b/doc/README.trace_services
@@ -87,7 +87,7 @@ Connection parameters switches :
   -U[SER]     <string>                  User name
   -P[ASSWORD] <string>                  Password
   -FE[TCH]    <string>                  Fetch password from file
-  -T[RUSTED]  <string>                  Force trusted authentication
+  -T[RUSTED]                            Force trusted authentication
 
 Also, it prints usage screen if run without parameters.
 

--- a/src/include/firebird/impl/msg/fbtracemgr.h
+++ b/src/include/firebird/impl/msg/fbtracemgr.h
@@ -18,7 +18,7 @@ FB_IMPL_MSG_NO_SYMBOL(FBTRACEMGR, 17, "  -SE[RVICE]  <string>                  S
 FB_IMPL_MSG_NO_SYMBOL(FBTRACEMGR, 18, "  -U[SER]     <string>                  User name")
 FB_IMPL_MSG_NO_SYMBOL(FBTRACEMGR, 19, "  -P[ASSWORD] <string>                  Password")
 FB_IMPL_MSG_NO_SYMBOL(FBTRACEMGR, 20, "  -FE[TCH]    <string>                  Fetch password from file")
-FB_IMPL_MSG_NO_SYMBOL(FBTRACEMGR, 21, "  -T[RUSTED]  <string>                  Force trusted authentication")
+FB_IMPL_MSG_NO_SYMBOL(FBTRACEMGR, 21, "  -T[RUSTED]                            Force trusted authentication")
 FB_IMPL_MSG_NO_SYMBOL(FBTRACEMGR, 22, "Examples:")
 FB_IMPL_MSG_NO_SYMBOL(FBTRACEMGR, 23, "  fbtracemgr -SE remote_host:service_mgr -USER SYSDBA -PASS masterkey -LIST")
 FB_IMPL_MSG_NO_SYMBOL(FBTRACEMGR, 24, "  fbtracemgr -SE service_mgr -START -NAME my_trace -CONFIG my_cfg.txt")


### PR DESCRIPTION
As I see in the code, the argument is just a flag