### PR TITLE
fix(pio): Replace 32-bit offset calculation with 64-bit in `PIO_extend`

### DIFF
--- a/src/jrd/os/posix/unix.cpp
+++ b/src/jrd/os/posix/unix.cpp
@@ -320,13 +320,16 @@ void PIO_extend(thread_db* tdbb, jrd_file* file, const ULONG extPages, const USH
 	if (file->fil_flags & FIL_no_fast_extend)
 		return;
 
-	const off_t filePages = PIO_get_number_of_pages(file, pageSize);
-	const off_t extendBy = MIN(MAX_ULONG - filePages, extPages);
+	const ULONG filePages = PIO_get_number_of_pages(file, pageSize);
+	const ULONG extendBy = MIN(MAX_ULONG - filePages, extPages);
+
+	const off_t offset = static_cast<off_t>(filePages) * pageSize;
+	const off_t length = static_cast<off_t>(extendBy) * pageSize;
 
 	int r;
 	for (r = 0; r < IO_RETRY; r++)
 	{
-		int err = fallocate(file->fil_desc, 0, filePages * pageSize, extendBy * pageSize);
+		int err = fallocate(file->fil_desc, 0, offset, length);
 		if (err == 0)
 			break;
 

--- a/src/jrd/os/posix/unix.cpp
+++ b/src/jrd/os/posix/unix.cpp
@@ -320,8 +320,8 @@ void PIO_extend(thread_db* tdbb, jrd_file* file, const ULONG extPages, const USH
 	if (file->fil_flags & FIL_no_fast_extend)
 		return;
 
-	const ULONG filePages = PIO_get_number_of_pages(file, pageSize);
-	const ULONG extendBy = MIN(MAX_ULONG - filePages, extPages);
+	const off_t filePages = PIO_get_number_of_pages(file, pageSize);
+	const off_t extendBy = MIN(MAX_ULONG - filePages, extPages);
 
 	int r;
 	for (r = 0; r < IO_RETRY; r++)


### PR DESCRIPTION
Replace 32-bit arguments with 64-bit ones to prevent overflow when handling large files (>4GB).
The original implementation incorrectly calculated offsets as 32-bit values, which made it impossible to extend the file via `fallocate` after it reached 4GB in size.

As I can see, every version with `PIO_extend` is affected.