### PR TITLE
Backport of fix(pio): Replace 32-bit offset calculation with 64-bit in PIO_extend

### DIFF
--- a/src/jrd/os/posix/unix.cpp
+++ b/src/jrd/os/posix/unix.cpp
@@ -333,10 +333,13 @@ void PIO_extend(thread_db* tdbb, jrd_file* main_file, const ULONG extPages, cons
 
 			const ULONG extendBy = MIN(fileMaxPages - filePages + file->fil_fudge, leftPages);
 
+			const off_t offset = static_cast<off_t>(filePages) * pageSize;
+			const off_t length = static_cast<off_t>(extendBy) * pageSize;
+
 			int r;
 			for (r = 0; r < IO_RETRY; r++)
 			{
-				int err = fallocate(file->fil_desc, 0, filePages * pageSize, extendBy * pageSize);
+				int err = fallocate(file->fil_desc, 0, offset, length);
 				if (err == 0)
 					break;
 


### PR DESCRIPTION
Backport of #8697.