### PR TITLE
Filters do not have schemas

### DIFF
--- a/src/dsql/DdlNodes.epp
+++ b/src/dsql/DdlNodes.epp
@@ -1612,6 +1612,7 @@ void CommentOnNode::execute(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, j
 		case obj_blob_filter:
 			tableClause = "rdb$filters";
 			columnClause = "rdb$function_name";
+			useSchemaClause = false;
 			status << Arg::Gds(isc_dyn_filter_not_found) << Arg::Str(objNameStr);
 			break;
 


### PR DESCRIPTION
If you try to add comment to filter, you will get an error:
```
SQL> connect employee user sysdba password masterkey;
Database: employee, User: SYSDBA
SQL> DECLARE FILTER ABOBA INPUT_TYPE 1 OUTPUT_TYPE -4 ENTRY_POINT 'desc_filter' MODULE_NAME 'FILTERLIB';
SQL> COMMENT ON FILTER ABOBA IS 'comment1';
Statement failed, SQLSTATE = 42S22
unsuccessful metadata update
-COMMENT ON "ABOBA" failed
-Dynamic SQL Error
-SQL error code = -206
-Column unknown
-"RDB$SCHEMA_NAME"
-At line 1, column 68
SQL> show comments;
There are no comments for objects in this database
SQL>
```

How you can see in the table, it doesn't have `RDB$SCHEMA_NAME` field:
```
Use CONNECT or CREATE DATABASE to specify a database
SQL> connect employee user sysdba password masterkey;
Database: employee, User: SYSDBA
SQL> set list on;
SQL> select * from rdb$filters;

RDB$FUNCTION_NAME               ABOBA                                                                                                                                                                                                                                                       
RDB$DESCRIPTION                 10:1e0
comment
RDB$MODULE_NAME                 FILTERLIB
RDB$ENTRYPOINT                  desc_filter                                                                                                                                                                                                                                                    
RDB$INPUT_SUB_TYPE              1
RDB$OUTPUT_SUB_TYPE             -4
RDB$SYSTEM_FLAG                 0
RDB$SECURITY_CLASS              SQL$570                                                                                                                                                                                                                                                     
RDB$OWNER_NAME                  SYSDBA                                                                                                                                                                                                                                                      


SQL>
```

I found a list of tables that use schemas, and there are no filters:
```
The following fields have been added to system tables. It is essential for applications and tools that read metadata 
to utilize these fields where appropriate. For example, consider using `RDB$SCHEMA_NAME` when joining tables.

| Table                    | Column                          |
|--------------------------|---------------------------------|
| MON$ATTACHMENTS          | MON$SEARCH_PATH                 |
| MON$CALL_STACK           | MON$SCHEMA_NAME                 |
| MON$COMPILED_STATEMENTS  | MON$SCHEMA_NAME                 |
| MON$TABLE_STATS          | MON$SCHEMA_NAME                 |
| RDB$CHARACTER_SETS       | RDB$DEFAULT_COLLATE_SCHEMA_NAME |
| RDB$CHARACTER_SETS       | RDB$SCHEMA_NAME                 |
| RDB$CHECK_CONSTRAINTS    | RDB$SCHEMA_NAME                 |
| RDB$COLLATIONS           | RDB$SCHEMA_NAME                 |
| RDB$DATABASE             | RDB$CHARACTER_SET_SCHEMA_NAME   |
| RDB$DEPENDENCIES         | RDB$DEPENDED_ON_SCHEMA_NAME     |
| RDB$DEPENDENCIES         | RDB$DEPENDENT_SCHEMA_NAME       |
| RDB$EXCEPTIONS           | RDB$SCHEMA_NAME                 |
| RDB$FIELDS               | RDB$SCHEMA_NAME                 |
| RDB$FIELD_DIMENSIONS     | RDB$SCHEMA_NAME                 |
| RDB$FUNCTIONS            | RDB$SCHEMA_NAME                 |
| RDB$FUNCTION_ARGUMENTS   | RDB$FIELD_SOURCE_SCHEMA_NAME    |
| RDB$FUNCTION_ARGUMENTS   | RDB$RELATION_SCHEMA_NAME        |
| RDB$FUNCTION_ARGUMENTS   | RDB$SCHEMA_NAME                 |
| RDB$GENERATORS           | RDB$SCHEMA_NAME                 |
| RDB$INDEX_SEGMENTS       | RDB$SCHEMA_NAME                 |
| RDB$INDICES              | RDB$FOREIGN_KEY_SCHEMA_NAME     |
| RDB$INDICES              | RDB$SCHEMA_NAME                 |
| RDB$PACKAGES             | RDB$SCHEMA_NAME                 |
| RDB$PROCEDURES           | RDB$SCHEMA_NAME                 |
| RDB$PROCEDURE_PARAMETERS | RDB$FIELD_SOURCE_SCHEMA_NAME    |
| RDB$PROCEDURE_PARAMETERS | RDB$RELATION_SCHEMA_NAME        |
| RDB$PROCEDURE_PARAMETERS | RDB$SCHEMA_NAME                 |
| RDB$PUBLICATION_TABLES   | RDB$TABLE_SCHEMA_NAME           |
| RDB$REF_CONSTRAINTS      | RDB$CONST_SCHEMA_NAME_UQ        |
| RDB$REF_CONSTRAINTS      | RDB$SCHEMA_NAME                 |
| RDB$RELATIONS            | RDB$SCHEMA_NAME                 |
| RDB$RELATION_CONSTRAINTS | RDB$SCHEMA_NAME                 |
| RDB$RELATION_FIELDS      | RDB$FIELD_SOURCE_SCHEMA_NAME    |
| RDB$RELATION_FIELDS      | RDB$SCHEMA_NAME                 |
| RDB$SCHEMAS              | RDB$CHARACTER_SET_NAME          |
| RDB$SCHEMAS              | RDB$CHARACTER_SET_SCHEMA_NAME   |
| RDB$SCHEMAS              | RDB$SQL_SECURITY                |
| RDB$SCHEMAS              | RDB$DESCRIPTION                 |
| RDB$SCHEMAS              | RDB$OWNER_NAME                  |
| RDB$SCHEMAS              | RDB$SCHEMA_NAME                 |
| RDB$SCHEMAS              | RDB$SECURITY_CLASS              |
| RDB$SCHEMAS              | RDB$SYSTEM_FLAG                 |
| RDB$TRIGGERS             | RDB$SCHEMA_NAME                 |
| RDB$TRIGGER_MESSAGES     | RDB$SCHEMA_NAME                 |
| RDB$USER_PRIVILEGES      | RDB$RELATION_SCHEMA_NAME        |
| RDB$USER_PRIVILEGES      | RDB$USER_SCHEMA_NAME            |
| RDB$VIEW_RELATIONS       | RDB$RELATION_SCHEMA_NAME        |
| RDB$VIEW_RELATIONS       | RDB$SCHEMA_NAME                 |
```

So i decided someone forgot to set a flag. Now it works:
```
Use CONNECT or CREATE DATABASE to specify a database
SQL> connect employee user sysdba password masterkey;
Database: employee, User: SYSDBA
SQL> DECLARE FILTER ABOBA INPUT_TYPE 1 OUTPUT_TYPE -4 ENTRY_POINT 'desc_filter' MODULE_NAME 'FILTERLIB';
SQL> COMMENT ON FILTER ABOBA IS 'comment1';
SQL> show comments;
COMMENT ON FILTER       ABOBA IS comment1;
SQL>
```