### PR TITLE
Add optional COLUMN to ALTER TABLE ... ADD and DROP

### DIFF
--- a/src/dsql/parse.y
+++ b/src/dsql/parse.y
@@ -4448,14 +4448,19 @@ alter_ops($relationNode)
 	| alter_ops ',' alter_op($relationNode)
 	;
 
+col_noise
+	:
+	| COLUMN
+	;
+
 %type alter_op(<relationNode>)
 alter_op($relationNode)
-	: DROP if_exists_opt symbol_column_name drop_behaviour
+	: DROP col_noise if_exists_opt symbol_column_name drop_behaviour
 		{
 			RelationNode::DropColumnClause* clause = newNode<RelationNode::DropColumnClause>();
-			clause->silent = $2;
-			clause->name = *$3;
-			clause->cascade = $4;
+			clause->silent = $3;
+			clause->name = *$4;
+			clause->cascade = $5;
 			$relationNode->clauses.add(clause);
 		}
 	| DROP CONSTRAINT if_exists_opt symbol_constraint_name
@@ -4465,10 +4470,10 @@ alter_op($relationNode)
 			clause->name = *$4;
 			$relationNode->clauses.add(clause);
 		}
-	| ADD if_not_exists_opt column_def($relationNode)
+	| ADD col_noise if_not_exists_opt column_def($relationNode)
 		{
-			const auto node = $3;
-			node->createIfNotExistsOnly = $2;
+			const auto node = $4;
+			node->createIfNotExistsOnly = $3;
 		}
 	| ADD table_constraint($relationNode)
 	| ADD CONSTRAINT if_not_exists_opt symbol_constraint_name table_constraint($relationNode)


### PR DESCRIPTION
The SQL:2023 syntax for the `ALTER TABLE` actions \<add column definition> and \<drop column definition> are defined as:

```
<add column definition> ::=
  ADD [ COLUMN ] <column definition>

<drop column definition> ::=
  DROP [ COLUMN ] <column name> <drop behavior>
```

Firebird already allows an optional `COLUMN` in \<alter column definition>.

This PR adds support for optional `COLUMN` for `ADD` and `DROP` as well.