### PR TITLE
Add 16KB page size support for Android builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -479,6 +479,7 @@ jobs:
 
       - name: Build
         run: |
+          export LDFLAGS="-Wl,-z,max-page-size=16384"
           ./autogen.sh --prefix=/opt/firebird --enable-binreloc --with-cross-build=android.$FB_PREFIX --without-editline
           make -j4
           make CROSS_OUT=Y tests -j4


### PR DESCRIPTION
### What was done
- Updated build configuration to align segments to 16KB memory pages.
- This ensures compatibility with newer Android devices that use 16KB page size.

### Why
Without this change, the fbclient library fails to load on devices with 16KB memory pages.

### How it was tested
- Verified using `llvm-readelf -l libfbclient.so` on the built artifacts — alignment shows `0x4000` (16KB).
- Deployed on Android arm64 device — the application runs without crashes.