### PR TITLE
Fix SQL length initialization for trace prepare event

### DIFF
--- a/src/jrd/trace/TraceDSQLHelpers.h
+++ b/src/jrd/trace/TraceDSQLHelpers.h
@@ -54,11 +54,13 @@ public:
 		m_start_clock = fb_utils::query_performance_counter();
 
 		static const char empty_string[] = "";
-		if (!m_string_len || !string)
+		if (!string)
 		{
 			m_string = empty_string;
 			m_string_len = 0;
 		}
+		else if (m_string_len == 0)
+			m_string_len = fb_strlen(m_string);
 	}
 
 	~TraceDSQLPrepare()

--- a/src/utilities/ntrace/TracePluginImpl.cpp
+++ b/src/utilities/ntrace/TracePluginImpl.cpp
@@ -525,6 +525,8 @@ void TracePluginImpl::logRecordStmt(const char* action, ITraceDatabaseConnection
 
 		if (reg)
 		{
+			fb_assert(false);
+
 			string temp;
 			temp.printf(NEWLINE "Statement %" SQUADFORMAT", <unknown, bug?>:" NEWLINE, stmt_id);
 			record.insert(0, temp);


### PR DESCRIPTION
Fix for: https://github.com/FirebirdSQL/firebird/issues/8737