### PR TITLE
Refactor RuntimeStatistics to make it more extendable for future counters

### DIFF
--- a/src/jrd/Attachment.cpp
+++ b/src/jrd/Attachment.cpp
@@ -632,10 +632,12 @@ void Jrd::Attachment::signalShutdown(ISC_STATUS code)
 void Jrd::Attachment::mergeStats(bool pageStatsOnly)
 {
 	MutexLockGuard guard(att_database->dbb_stats_mutex, FB_FUNCTION);
-	att_database->dbb_stats.adjustPageStats(att_base_stats, att_stats);
-	if (!pageStatsOnly)
+
+	if (pageStatsOnly)
+		att_database->dbb_stats.adjustPageStats(att_base_stats, att_stats);
+	else
 	{
-		att_database->dbb_stats.adjust(att_base_stats, att_stats, true);
+		att_database->dbb_stats.adjust(att_base_stats, att_stats);
 		att_base_stats.assign(att_stats);
 	}
 }

--- a/src/jrd/Monitoring.cpp
+++ b/src/jrd/Monitoring.cpp
@@ -1422,36 +1422,36 @@ void Monitoring::putStatistics(SnapshotData::DumpRecord& record, const RuntimeSt
 	record.reset(rel_mon_io_stats);
 	record.storeGlobalId(f_mon_io_stat_id, id);
 	record.storeInteger(f_mon_io_stat_group, stat_group);
-	record.storeInteger(f_mon_io_page_reads, statistics.getValue(RuntimeStatistics::PAGE_READS));
-	record.storeInteger(f_mon_io_page_writes, statistics.getValue(RuntimeStatistics::PAGE_WRITES));
-	record.storeInteger(f_mon_io_page_fetches, statistics.getValue(RuntimeStatistics::PAGE_FETCHES));
-	record.storeInteger(f_mon_io_page_marks, statistics.getValue(RuntimeStatistics::PAGE_MARKS));
+	record.storeInteger(f_mon_io_page_reads, statistics[PageStatType::READS]);
+	record.storeInteger(f_mon_io_page_writes, statistics[PageStatType::WRITES]);
+	record.storeInteger(f_mon_io_page_fetches, statistics[PageStatType::FETCHES]);
+	record.storeInteger(f_mon_io_page_marks, statistics[PageStatType::MARKS]);
 	record.write();
 
 	// logical I/O statistics (global)
 	record.reset(rel_mon_rec_stats);
 	record.storeGlobalId(f_mon_rec_stat_id, id);
 	record.storeInteger(f_mon_rec_stat_group, stat_group);
-	record.storeInteger(f_mon_rec_seq_reads, statistics.getValue(RuntimeStatistics::RECORD_SEQ_READS));
-	record.storeInteger(f_mon_rec_idx_reads, statistics.getValue(RuntimeStatistics::RECORD_IDX_READS));
-	record.storeInteger(f_mon_rec_inserts, statistics.getValue(RuntimeStatistics::RECORD_INSERTS));
-	record.storeInteger(f_mon_rec_updates, statistics.getValue(RuntimeStatistics::RECORD_UPDATES));
-	record.storeInteger(f_mon_rec_deletes, statistics.getValue(RuntimeStatistics::RECORD_DELETES));
-	record.storeInteger(f_mon_rec_backouts, statistics.getValue(RuntimeStatistics::RECORD_BACKOUTS));
-	record.storeInteger(f_mon_rec_purges, statistics.getValue(RuntimeStatistics::RECORD_PURGES));
-	record.storeInteger(f_mon_rec_expunges, statistics.getValue(RuntimeStatistics::RECORD_EXPUNGES));
-	record.storeInteger(f_mon_rec_locks, statistics.getValue(RuntimeStatistics::RECORD_LOCKS));
-	record.storeInteger(f_mon_rec_waits, statistics.getValue(RuntimeStatistics::RECORD_WAITS));
-	record.storeInteger(f_mon_rec_conflicts, statistics.getValue(RuntimeStatistics::RECORD_CONFLICTS));
-	record.storeInteger(f_mon_rec_bkver_reads, statistics.getValue(RuntimeStatistics::RECORD_BACKVERSION_READS));
-	record.storeInteger(f_mon_rec_frg_reads, statistics.getValue(RuntimeStatistics::RECORD_FRAGMENT_READS));
-	record.storeInteger(f_mon_rec_rpt_reads, statistics.getValue(RuntimeStatistics::RECORD_RPT_READS));
-	record.storeInteger(f_mon_rec_imgc, statistics.getValue(RuntimeStatistics::RECORD_IMGC));
+	record.storeInteger(f_mon_rec_seq_reads, statistics[RecordStatType::SEQ_READS]);
+	record.storeInteger(f_mon_rec_idx_reads, statistics[RecordStatType::IDX_READS]);
+	record.storeInteger(f_mon_rec_inserts, statistics[RecordStatType::INSERTS]);
+	record.storeInteger(f_mon_rec_updates, statistics[RecordStatType::UPDATES]);
+	record.storeInteger(f_mon_rec_deletes, statistics[RecordStatType::DELETES]);
+	record.storeInteger(f_mon_rec_backouts, statistics[RecordStatType::BACKOUTS]);
+	record.storeInteger(f_mon_rec_purges, statistics[RecordStatType::PURGES]);
+	record.storeInteger(f_mon_rec_expunges, statistics[RecordStatType::EXPUNGES]);
+	record.storeInteger(f_mon_rec_locks, statistics[RecordStatType::LOCKS]);
+	record.storeInteger(f_mon_rec_waits, statistics[RecordStatType::WAITS]);
+	record.storeInteger(f_mon_rec_conflicts, statistics[RecordStatType::CONFLICTS]);
+	record.storeInteger(f_mon_rec_bkver_reads, statistics[RecordStatType::BACK_READS]);
+	record.storeInteger(f_mon_rec_frg_reads, statistics[RecordStatType::FRAGMENT_READS]);
+	record.storeInteger(f_mon_rec_rpt_reads, statistics[RecordStatType::RPT_READS]);
+	record.storeInteger(f_mon_rec_imgc, statistics[RecordStatType::IMGC]);
 	record.write();
 
 	// logical I/O statistics (table wise)
 
-	for (RuntimeStatistics::Iterator iter = statistics.begin(); iter != statistics.end(); ++iter)
+	for (auto iter(statistics.getRelCounters()); iter; ++iter)
 	{
 		const auto rec_stat_id = getGlobalId(fb_utils::genUniqueId());
 
@@ -1466,21 +1466,21 @@ void Monitoring::putStatistics(SnapshotData::DumpRecord& record, const RuntimeSt
 		record.reset(rel_mon_rec_stats);
 		record.storeGlobalId(f_mon_rec_stat_id, rec_stat_id);
 		record.storeInteger(f_mon_rec_stat_group, stat_group);
-		record.storeInteger(f_mon_rec_seq_reads, (*iter).getCounter(RuntimeStatistics::RECORD_SEQ_READS));
-		record.storeInteger(f_mon_rec_idx_reads, (*iter).getCounter(RuntimeStatistics::RECORD_IDX_READS));
-		record.storeInteger(f_mon_rec_inserts, (*iter).getCounter(RuntimeStatistics::RECORD_INSERTS));
-		record.storeInteger(f_mon_rec_updates, (*iter).getCounter(RuntimeStatistics::RECORD_UPDATES));
-		record.storeInteger(f_mon_rec_deletes, (*iter).getCounter(RuntimeStatistics::RECORD_DELETES));
-		record.storeInteger(f_mon_rec_backouts, (*iter).getCounter(RuntimeStatistics::RECORD_BACKOUTS));
-		record.storeInteger(f_mon_rec_purges, (*iter).getCounter(RuntimeStatistics::RECORD_PURGES));
-		record.storeInteger(f_mon_rec_expunges, (*iter).getCounter(RuntimeStatistics::RECORD_EXPUNGES));
-		record.storeInteger(f_mon_rec_locks, (*iter).getCounter(RuntimeStatistics::RECORD_LOCKS));
-		record.storeInteger(f_mon_rec_waits, (*iter).getCounter(RuntimeStatistics::RECORD_WAITS));
-		record.storeInteger(f_mon_rec_conflicts, (*iter).getCounter(RuntimeStatistics::RECORD_CONFLICTS));
-		record.storeInteger(f_mon_rec_bkver_reads, (*iter).getCounter(RuntimeStatistics::RECORD_BACKVERSION_READS));
-		record.storeInteger(f_mon_rec_frg_reads, (*iter).getCounter(RuntimeStatistics::RECORD_FRAGMENT_READS));
-		record.storeInteger(f_mon_rec_rpt_reads, (*iter).getCounter(RuntimeStatistics::RECORD_RPT_READS));
-		record.storeInteger(f_mon_rec_imgc, (*iter).getCounter(RuntimeStatistics::RECORD_IMGC));
+		record.storeInteger(f_mon_rec_seq_reads, (*iter)[RecordStatType::SEQ_READS]);
+		record.storeInteger(f_mon_rec_idx_reads, (*iter)[RecordStatType::IDX_READS]);
+		record.storeInteger(f_mon_rec_inserts, (*iter)[RecordStatType::INSERTS]);
+		record.storeInteger(f_mon_rec_updates, (*iter)[RecordStatType::UPDATES]);
+		record.storeInteger(f_mon_rec_deletes, (*iter)[RecordStatType::DELETES]);
+		record.storeInteger(f_mon_rec_backouts, (*iter)[RecordStatType::BACKOUTS]);
+		record.storeInteger(f_mon_rec_purges, (*iter)[RecordStatType::PURGES]);
+		record.storeInteger(f_mon_rec_expunges, (*iter)[RecordStatType::EXPUNGES]);
+		record.storeInteger(f_mon_rec_locks, (*iter)[RecordStatType::LOCKS]);
+		record.storeInteger(f_mon_rec_waits, (*iter)[RecordStatType::WAITS]);
+		record.storeInteger(f_mon_rec_conflicts, (*iter)[RecordStatType::CONFLICTS]);
+		record.storeInteger(f_mon_rec_bkver_reads, (*iter)[RecordStatType::BACK_READS]);
+		record.storeInteger(f_mon_rec_frg_reads, (*iter)[RecordStatType::FRAGMENT_READS]);
+		record.storeInteger(f_mon_rec_rpt_reads, (*iter)[RecordStatType::RPT_READS]);
+		record.storeInteger(f_mon_rec_imgc, (*iter)[RecordStatType::IMGC]);
 		record.write();
 	}
 }

--- a/src/jrd/cch.cpp
+++ b/src/jrd/cch.cpp
@@ -930,7 +930,7 @@ void CCH_fetch_page(thread_db* tdbb, WIN* window, const bool read_shadow)
 	pag* page = bdb->bdb_buffer;
 	bdb->bdb_incarnation = ++bcb->bcb_page_incarnation;
 
-	tdbb->bumpStats(RuntimeStatistics::PAGE_READS);
+	tdbb->bumpStats(PageStatType::READS);
 
 	PageSpace* pageSpace = dbb->dbb_page_manager.findPageSpace(bdb->bdb_page.getPageSpaceID());
 	fb_assert(pageSpace);
@@ -1701,7 +1701,7 @@ void CCH_mark(thread_db* tdbb, WIN* window, bool mark_system, bool must_write)
 
 	SET_TDBB(tdbb);
 	Database* dbb = tdbb->getDatabase();
-	tdbb->bumpStats(RuntimeStatistics::PAGE_MARKS);
+	tdbb->bumpStats(PageStatType::MARKS);
 
 	BufferControl* bcb = dbb->dbb_bcb;
 
@@ -3640,7 +3640,7 @@ static BufferDesc* get_dirty_buffer(thread_db* tdbb)
 
 		if (bdb->bdb_flags & BDB_db_dirty)
 		{
-			//tdbb->bumpStats(RuntimeStatistics::PAGE_FETCHES); shouldn't it be here?
+			//tdbb->bumpStats(PageStatType::FETCHES); shouldn't it be here?
 			return bdb;
 		}
 
@@ -3814,7 +3814,7 @@ static BufferDesc* get_buffer(thread_db* tdbb, const PageNumber page, SyncType s
 				if (bdb->bdb_page == page)
 				{
 					recentlyUsed(bdb);
-					tdbb->bumpStats(RuntimeStatistics::PAGE_FETCHES);
+					tdbb->bumpStats(PageStatType::FETCHES);
 					return bdb;
 				}
 
@@ -3857,7 +3857,7 @@ static BufferDesc* get_buffer(thread_db* tdbb, const PageNumber page, SyncType s
 				if (bdb->bdb_page == page)
 				{
 					recentlyUsed(bdb);
-					tdbb->bumpStats(RuntimeStatistics::PAGE_FETCHES);
+					tdbb->bumpStats(PageStatType::FETCHES);
 					cacheBuffer(att, bdb);
 					return bdb;
 				}
@@ -3897,7 +3897,7 @@ static BufferDesc* get_buffer(thread_db* tdbb, const PageNumber page, SyncType s
 				{
 					bdb->downgrade(syncType);
 					recentlyUsed(bdb);
-					tdbb->bumpStats(RuntimeStatistics::PAGE_FETCHES);
+					tdbb->bumpStats(PageStatType::FETCHES);
 					cacheBuffer(att, bdb);
 					return bdb;
 				}
@@ -3941,7 +3941,7 @@ static BufferDesc* get_buffer(thread_db* tdbb, const PageNumber page, SyncType s
 						else
 							recentlyUsed(bdb);
 					}
-					tdbb->bumpStats(RuntimeStatistics::PAGE_FETCHES);
+					tdbb->bumpStats(PageStatType::FETCHES);
 					cacheBuffer(att, bdb);
 					return bdb;
 				}
@@ -3959,7 +3959,7 @@ static BufferDesc* get_buffer(thread_db* tdbb, const PageNumber page, SyncType s
 					continue;
 				}
 				recentlyUsed(bdb2);
-				tdbb->bumpStats(RuntimeStatistics::PAGE_FETCHES);
+				tdbb->bumpStats(PageStatType::FETCHES);
 				cacheBuffer(att, bdb2);
 			}
 			else
@@ -4914,7 +4914,7 @@ static bool write_page(thread_db* tdbb, BufferDesc* bdb, FbStatusVector* const s
 	// I won't wipe out the if() itself to allow my changes be verified easily by others
 	if (true)
 	{
-		tdbb->bumpStats(RuntimeStatistics::PAGE_WRITES);
+		tdbb->bumpStats(PageStatType::WRITES);
 
 		// write out page to main database file, and to any
 		// shadows, making a special case of the header page

--- a/src/jrd/inf.cpp
+++ b/src/jrd/inf.cpp
@@ -125,20 +125,19 @@ namespace
 
 	typedef HalfStaticArray<UCHAR, BUFFER_SMALL> CountsBuffer;
 
-	ULONG getCounts(thread_db* tdbb, RuntimeStatistics::StatType type, CountsBuffer& buffer)
+	ULONG getCounts(thread_db* tdbb, RecordStatType type, CountsBuffer& buffer)
 	{
-		const Attachment* const attachment = tdbb->getAttachment();
-		const RuntimeStatistics& stats = attachment->att_stats;
+		const auto attachment = tdbb->getAttachment();
 
 		UCHAR num_buffer[BUFFER_TINY];
 
 		buffer.clear();
 		FB_SIZE_T buffer_length = 0;
 
-		for (RuntimeStatistics::Iterator iter = stats.begin(); iter != stats.end(); ++iter)
+		for (auto iter(attachment->att_stats.getRelCounters()); iter; ++iter)
 		{
 			const USHORT relation_id = (*iter).getRelationId();
-			const SINT64 n = (*iter).getCounter(type);
+			const SINT64 n = (*iter)[type];
 
 			if (n)
 			{
@@ -313,19 +312,19 @@ void INF_database_info(thread_db* tdbb,
 			break;
 
 		case isc_info_reads:
-			length = INF_convert(dbb->dbb_stats.getValue(RuntimeStatistics::PAGE_READS), buffer);
+			length = INF_convert(dbb->dbb_stats[PageStatType::READS], buffer);
 			break;
 
 		case isc_info_writes:
-			length = INF_convert(dbb->dbb_stats.getValue(RuntimeStatistics::PAGE_WRITES), buffer);
+			length = INF_convert(dbb->dbb_stats[PageStatType::WRITES], buffer);
 			break;
 
 		case isc_info_fetches:
-			length = INF_convert(dbb->dbb_stats.getValue(RuntimeStatistics::PAGE_FETCHES), buffer);
+			length = INF_convert(dbb->dbb_stats[PageStatType::FETCHES], buffer);
 			break;
 
 		case isc_info_marks:
-			length = INF_convert(dbb->dbb_stats.getValue(RuntimeStatistics::PAGE_MARKS), buffer);
+			length = INF_convert(dbb->dbb_stats[PageStatType::MARKS], buffer);
 			break;
 
 		case isc_info_page_size:
@@ -407,42 +406,42 @@ void INF_database_info(thread_db* tdbb,
 			break;
 
 		case isc_info_read_seq_count:
-			length = getCounts(tdbb, RuntimeStatistics::RECORD_SEQ_READS, counts_buffer);
+			length = getCounts(tdbb, RecordStatType::SEQ_READS, counts_buffer);
 			buffer = counts_buffer.begin();
 			break;
 
 		case isc_info_read_idx_count:
-			length = getCounts(tdbb, RuntimeStatistics::RECORD_IDX_READS, counts_buffer);
+			length = getCounts(tdbb, RecordStatType::IDX_READS, counts_buffer);
 			buffer = counts_buffer.begin();
 			break;
 
 		case isc_info_update_count:
-			length = getCounts(tdbb, RuntimeStatistics::RECORD_UPDATES, counts_buffer);
+			length = getCounts(tdbb, RecordStatType::UPDATES, counts_buffer);
 			buffer = counts_buffer.begin();
 			break;
 
 		case isc_info_insert_count:
-			length = getCounts(tdbb, RuntimeStatistics::RECORD_INSERTS, counts_buffer);
+			length = getCounts(tdbb, RecordStatType::INSERTS, counts_buffer);
 			buffer = counts_buffer.begin();
 			break;
 
 		case isc_info_delete_count:
-			length = getCounts(tdbb, RuntimeStatistics::RECORD_DELETES, counts_buffer);
+			length = getCounts(tdbb, RecordStatType::DELETES, counts_buffer);
 			buffer = counts_buffer.begin();
 			break;
 
 		case isc_info_backout_count:
-			length = getCounts(tdbb, RuntimeStatistics::RECORD_BACKOUTS, counts_buffer);
+			length = getCounts(tdbb, RecordStatType::BACKOUTS, counts_buffer);
 			buffer = counts_buffer.begin();
 			break;
 
 		case isc_info_purge_count:
-			length = getCounts(tdbb, RuntimeStatistics::RECORD_PURGES, counts_buffer);
+			length = getCounts(tdbb, RecordStatType::PURGES, counts_buffer);
 			buffer = counts_buffer.begin();
 			break;
 
 		case isc_info_expunge_count:
-			length = getCounts(tdbb, RuntimeStatistics::RECORD_EXPUNGES, counts_buffer);
+			length = getCounts(tdbb, RecordStatType::EXPUNGES, counts_buffer);
 			buffer = counts_buffer.begin();
 			break;
 

--- a/src/jrd/jrd.h
+++ b/src/jrd/jrd.h
@@ -612,25 +612,25 @@ public:
 		tdbb_flags |= TDBB_sweeper;
 	}
 
-	void bumpStats(const RuntimeStatistics::StatType index, SINT64 delta = 1)
+	void bumpStats(const PageStatType type, SINT64 delta = 1)
 	{
-		reqStat->bumpValue(index, delta);
-		traStat->bumpValue(index, delta);
-		attStat->bumpValue(index, delta);
+		reqStat->bumpValue(type, delta);
+		traStat->bumpValue(type, delta);
+		attStat->bumpValue(type, delta);
 
 		if ((tdbb_flags & TDBB_async) && !attachment)
-			dbbStat->bumpValue(index, delta);
+			dbbStat->bumpValue(type, delta);
 
 		// else dbbStat is adjusted from attStat, see Attachment::mergeAsyncStats()
 	}
 
-	void bumpRelStats(const RuntimeStatistics::StatType index, SLONG relation_id, SINT64 delta = 1)
+	void bumpStats(const RecordStatType type, SLONG relation_id, SINT64 delta = 1)
 	{
 		// We don't bump counters for dbbStat here, they're merged from attStats on demand
 
-		reqStat->bumpValue(index, delta);
-		traStat->bumpValue(index, delta);
-		attStat->bumpValue(index, delta);
+		reqStat->bumpValue(type, delta);
+		traStat->bumpValue(type, delta);
+		attStat->bumpValue(type, delta);
 
 		const RuntimeStatistics* const dummyStat = RuntimeStatistics::getDummy();
 
@@ -643,13 +643,13 @@ public:
 		// dummy object concurrently.
 
 		if (reqStat != dummyStat)
-			reqStat->bumpRelValue(index, relation_id, delta);
+			reqStat->bumpValue(type, relation_id, delta);
 
 		if (traStat != dummyStat)
-			traStat->bumpRelValue(index, relation_id, delta);
+			traStat->bumpValue(type, relation_id, delta);
 
 		if (attStat != dummyStat)
-			attStat->bumpRelValue(index, relation_id, delta);
+			attStat->bumpValue(type, relation_id, delta);
 	}
 
 	ISC_STATUS getCancelState(ISC_STATUS* secondary = NULL);

--- a/src/jrd/recsrc/SortedStream.cpp
+++ b/src/jrd/recsrc/SortedStream.cpp
@@ -487,7 +487,7 @@ void SortedStream::mapData(thread_db* tdbb, Request* request, UCHAR* data) const
 		if (!DPM_get(tdbb, &temp, LCK_read))
 			Arg::Gds(isc_no_cur_rec).raise();
 
-		tdbb->bumpRelStats(RuntimeStatistics::RECORD_RPT_READS, relation->rel_id);
+		tdbb->bumpStats(RecordStatType::RPT_READS, relation->rel_id);
 
 		if (VIO_chase_record_version(tdbb, &temp, transaction, tdbb->getDefaultPool(), false, false))
 		{
@@ -591,8 +591,7 @@ void SortedStream::mapData(thread_db* tdbb, Request* request, UCHAR* data) const
 		// We have to find the original record version, sigh.
 		// Scan version chain backwards until it's done.
 
-		RuntimeStatistics::Accumulator backversions(tdbb, relation,
-													RuntimeStatistics::RECORD_BACKVERSION_READS);
+		RuntimeStatistics::Accumulator backversions(tdbb, relation, RecordStatType::BACK_READS);
 
 		while (temp.rpb_transaction_nr != orgTraNum)
 		{

--- a/src/jrd/tra.cpp
+++ b/src/jrd/tra.cpp
@@ -4295,17 +4295,10 @@ void TraceSweepEvent::endSweepRelation(jrd_rel* relation)
 	jrd_tra* tran = m_tdbb->getTransaction();
 
 	// don't report empty relation
-	if (m_base_stats.getValue(RuntimeStatistics::RECORD_SEQ_READS) ==
-		tran->tra_stats.getValue(RuntimeStatistics::RECORD_SEQ_READS) &&
-
-		m_base_stats.getValue(RuntimeStatistics::RECORD_BACKOUTS) ==
-		tran->tra_stats.getValue(RuntimeStatistics::RECORD_BACKOUTS) &&
-
-		m_base_stats.getValue(RuntimeStatistics::RECORD_PURGES) ==
-		tran->tra_stats.getValue(RuntimeStatistics::RECORD_PURGES) &&
-
-		m_base_stats.getValue(RuntimeStatistics::RECORD_EXPUNGES) ==
-		tran->tra_stats.getValue(RuntimeStatistics::RECORD_EXPUNGES) )
+	if (m_base_stats[RecordStatType::SEQ_READS] == tran->tra_stats[RecordStatType::SEQ_READS] &&
+		m_base_stats[RecordStatType::BACKOUTS] == tran->tra_stats[RecordStatType::BACKOUTS] &&
+		m_base_stats[RecordStatType::PURGES] == tran->tra_stats[RecordStatType::PURGES] &&
+		m_base_stats[RecordStatType::EXPUNGES] == tran->tra_stats[RecordStatType::EXPUNGES] )
 	{
 		return;
 	}

--- a/src/jrd/trace/TraceObjects.cpp
+++ b/src/jrd/trace/TraceObjects.cpp
@@ -655,7 +655,7 @@ TraceRuntimeStats::TraceRuntimeStats(Attachment* att, RuntimeStatistics* baselin
 	}
 }
 
-SINT64 TraceRuntimeStats::m_dummy_counts[RuntimeStatistics::TOTAL_ITEMS] = {0};
+SINT64 TraceRuntimeStats::m_dummy_counts[RuntimeStatistics::GLOBAL_ITEMS] = {0};
 
 
 /// TraceStatusVectorImpl

--- a/src/jrd/trace/TraceObjects.h
+++ b/src/jrd/trace/TraceObjects.h
@@ -674,7 +674,7 @@ private:
 	Firebird::PerformanceInfo m_info;
 	TraceCountsArray m_counts;
 	Firebird::ObjectsArray<Firebird::string> m_tempNames;
-	static SINT64 m_dummy_counts[RuntimeStatistics::TOTAL_ITEMS];	// Zero-initialized array with zero counts
+	static SINT64 m_dummy_counts[RuntimeStatistics::GLOBAL_ITEMS];	// Zero-initialized array with zero counts
 };
 
 


### PR DESCRIPTION
- Improve bounds checking (make it compile-time using `class enum`)
- Simplify retrieval of the counters (using `operator[]`)
- Make it easier to extend internally, especially adding grouped counters (per-tablespace page I/O counters, temp I/O counters, etc)