### PR TITLE
refactor(pag): Use `fallocate` as the primary method for extending a file

### DIFF
--- a/src/jrd/nbak.cpp
+++ b/src/jrd/nbak.cpp
@@ -389,10 +389,12 @@ bool BackupManager::extendDatabase(thread_db* tdbb)
 	if (maxAllocPage >= maxPage)
 		return true;
 
-	const auto allocatedPages = pgSpace->extend(tdbb, maxPage, true);
-	maxAllocPage = pgSpace->maxAlloc();
-	if (allocatedPages.has_value() && maxAllocPage > maxPage)
-		return true;
+	if (pgSpace->extend(tdbb, maxPage, true))
+	{
+		maxAllocPage = pgSpace->maxAlloc();
+		if (maxAllocPage >= maxPage)
+			return true;
+	}
 
 	// Fast file extension not succeeded for some reason, try file extension via direct file writes.
 	while (maxAllocPage < maxPage)

--- a/src/jrd/nbak.cpp
+++ b/src/jrd/nbak.cpp
@@ -389,9 +389,9 @@ bool BackupManager::extendDatabase(thread_db* tdbb)
 	if (maxAllocPage >= maxPage)
 		return true;
 
-	const auto extension_result = pgSpace->extend(tdbb, maxPage, true);
+	const auto extensionResult = pgSpace->extend(tdbb, maxPage, true);
 	maxAllocPage = pgSpace->maxAlloc();
-	if (extension_result.success && maxAllocPage > maxPage)
+	if (extensionResult.success && maxAllocPage > maxPage)
 		return true;
 
 	// Fast file extension not succeeded for some reason, try file extension via direct file writes.

--- a/src/jrd/nbak.cpp
+++ b/src/jrd/nbak.cpp
@@ -389,9 +389,9 @@ bool BackupManager::extendDatabase(thread_db* tdbb)
 	if (maxAllocPage >= maxPage)
 		return true;
 
-	const auto extensionResult = pgSpace->extend(tdbb, maxPage, true);
+	const auto allocatedPages = pgSpace->extend(tdbb, maxPage, true);
 	maxAllocPage = pgSpace->maxAlloc();
-	if (extensionResult.success && maxAllocPage > maxPage)
+	if (allocatedPages.has_value() && maxAllocPage > maxPage)
 		return true;
 
 	// Fast file extension not succeeded for some reason, try file extension via direct file writes.

--- a/src/jrd/os/pio_proto.h
+++ b/src/jrd/os/pio_proto.h
@@ -40,12 +40,13 @@ void	PIO_close(Jrd::jrd_file*);
 Jrd::jrd_file*	PIO_create(Jrd::thread_db*, const Firebird::PathName&,
 							const bool, const bool);
 bool	PIO_expand(const TEXT*, USHORT, TEXT*, FB_SIZE_T);
-void	PIO_extend(Jrd::thread_db*, Jrd::jrd_file*, const ULONG, const USHORT);
+bool	PIO_fast_extension_is_supported(const Jrd::jrd_file& file) noexcept;
+bool	PIO_extend(Jrd::thread_db* tdbb, Jrd::jrd_file* file, ULONG extPages, USHORT pageSize);
 void	PIO_flush(Jrd::thread_db*, Jrd::jrd_file*);
 void	PIO_force_write(Jrd::jrd_file*, const bool);
 ULONG	PIO_get_number_of_pages(const Jrd::jrd_file*, const USHORT);
 bool	PIO_header(Jrd::thread_db*, UCHAR*, unsigned);
-USHORT	PIO_init_data(Jrd::thread_db*, Jrd::jrd_file*, Jrd::FbStatusVector*, ULONG, USHORT);
+USHORT	PIO_init_data(Jrd::thread_db* tdbb, Jrd::jrd_file* file, Jrd::FbStatusVector* status_vector, ULONG startPage, USHORT initPages);
 Jrd::jrd_file*	PIO_open(Jrd::thread_db*, const Firebird::PathName&,
 						 const Firebird::PathName&);
 bool	PIO_read(Jrd::thread_db*, Jrd::jrd_file*, Jrd::BufferDesc*, Ods::pag*, Jrd::FbStatusVector*);

--- a/src/jrd/os/posix/unix.cpp
+++ b/src/jrd/os/posix/unix.cpp
@@ -302,9 +302,7 @@ bool PIO_expand(const TEXT* file_name, USHORT file_length, TEXT* expanded_name, 
 bool PIO_fast_extension_is_supported(const Jrd::jrd_file& file) noexcept
 {
 #if defined(HAVE_LINUX_FALLOC_H) && defined(HAVE_FALLOCATE)
-	return file.fil_flags & FIL_no_fast_extend
-		? false
-		: true;
+	return !(file.fil_flags & FIL_no_fast_extend);
 #else
 	return false;
 #endif

--- a/src/jrd/os/posix/unix.cpp
+++ b/src/jrd/os/posix/unix.cpp
@@ -299,7 +299,19 @@ bool PIO_expand(const TEXT* file_name, USHORT file_length, TEXT* expanded_name, 
 }
 
 
-void PIO_extend(thread_db* tdbb, jrd_file* file, const ULONG extPages, const USHORT pageSize)
+bool PIO_fast_extension_is_supported(const Jrd::jrd_file& file) noexcept
+{
+#if defined(HAVE_LINUX_FALLOC_H) && defined(HAVE_FALLOCATE)
+	return file.fil_flags & FIL_no_fast_extend
+		? false
+		: true;
+#else
+	return false;
+#endif
+}
+
+
+bool PIO_extend(thread_db* tdbb, jrd_file* file, const ULONG extPages, const USHORT pageSize)
 {
 /**************************************
  *
@@ -317,8 +329,8 @@ void PIO_extend(thread_db* tdbb, jrd_file* file, const ULONG extPages, const USH
 
 	EngineCheckout cout(tdbb, FB_FUNCTION, EngineCheckout::UNNECESSARY);
 
-	if (file->fil_flags & FIL_no_fast_extend)
-		return;
+	if (!PIO_fast_extension_is_supported(*file))
+		return false;
 
 	const ULONG filePages = PIO_get_number_of_pages(file, pageSize);
 	const ULONG extendBy = MIN(MAX_ULONG - filePages, extPages);
@@ -341,7 +353,7 @@ void PIO_extend(thread_db* tdbb, jrd_file* file, const ULONG extPages, const USH
 			unix_error("fallocate", file, isc_io_write_err);
 
 		file->fil_flags |= FIL_no_fast_extend;
-		return;
+		return false;
 	}
 
 	if (r == IO_RETRY)
@@ -352,12 +364,12 @@ void PIO_extend(thread_db* tdbb, jrd_file* file, const ULONG extPages, const USH
 #endif
 		unix_error("fallocate_retry", file, isc_io_write_err);
 	}
+
+	return true;
 #else
 	file->fil_flags |= FIL_no_fast_extend;
+	return false;
 #endif // fallocate present
-
-	// not implemented
-	return;
 }
 
 

--- a/src/jrd/os/win32/winnt.cpp
+++ b/src/jrd/os/win32/winnt.cpp
@@ -215,7 +215,13 @@ bool PIO_expand(const TEXT* file_name, USHORT file_length, TEXT* expanded_name, 
 }
 
 
-void PIO_extend(thread_db* tdbb, jrd_file* file, const ULONG extPages, const USHORT pageSize)
+bool PIO_fast_extension_is_supported(const Jrd::jrd_file& file) noexcept
+{
+	return true;
+}
+
+
+bool PIO_extend(thread_db* tdbb, jrd_file* file, const ULONG extPages, const USHORT pageSize)
 {
 /**************************************
  *
@@ -238,7 +244,7 @@ void PIO_extend(thread_db* tdbb, jrd_file* file, const ULONG extPages, const USH
 
 	// if file have no extend lock it is better to not extend file than corrupt it
 	if (!file->fil_ext_lock)
-		return;
+		return false;
 
 	EngineCheckout cout(tdbb, FB_FUNCTION, EngineCheckout::UNNECESSARY);
 	FileExtendLockGuard extLock(file->fil_ext_lock, true);
@@ -257,6 +263,8 @@ void PIO_extend(thread_db* tdbb, jrd_file* file, const ULONG extPages, const USH
 
 	if (!SetEndOfFile(hFile))
 		nt_error("SetEndOfFile", file, isc_io_write_err, NULL);
+
+	return true;
 }
 
 

--- a/src/jrd/pag.cpp
+++ b/src/jrd/pag.cpp
@@ -275,9 +275,8 @@ namespace
 		const ULONG sequence = pageNum.getPageNum() / pageMgr.pagesPerPIP;
 		const ULONG relativeBit = pageNum.getPageNum() - sequence * pageMgr.pagesPerPIP;
 
-		if (relativeBit + 1 <= pipUsed)
+		if (relativeBit < pipUsed)
 			return pipUsed;
-		fb_assert(relativeBit >= pipUsed);
 
 		BackupManager::StateReadGuard stateGuard(tdbb);
 

--- a/src/jrd/pag.cpp
+++ b/src/jrd/pag.cpp
@@ -1947,12 +1947,12 @@ PageSpace::ExtendResult PageSpace::extend(thread_db* tdbb, const ULONG pageNum, 
  *	extend can't be less than hardcoded value MIN_EXTEND_BYTES and more than
  *	configured value "DatabaseGrowthIncrement" (both values in bytes).
  *
- *	If "DatabaseGrowthIncrement" is less than MIN_EXTEND_BYTES then don't
- *	extend file(s)
- *
- *  If forceSize is true, extend file up to pageNum pages (despite of value
+ *  If `forceSize` is true, extend file up to pageNum pages (despite of value
  *  of "DatabaseGrowthIncrement") and don't make attempts to extend by less
  *	pages.
+ *
+ *	If "DatabaseGrowthIncrement" is less than MIN_EXTEND_BYTES, then treat
+ *	it as if `forceSize` is true.
  *
  **************************************/
 	fb_assert(dbb == tdbb->getDatabase());

--- a/src/jrd/pag.cpp
+++ b/src/jrd/pag.cpp
@@ -1990,7 +1990,8 @@ ULONG PageSpace::extend(thread_db* tdbb, const ULONG pageNum, bool forceSize)
 			if (!PIO_extend(tdbb, file, extPages, dbb->dbb_page_size))
 				return 0;
 
-			maxPageNumber += extPages;
+			// File was extended, reset the cached value
+			maxPageNumber = 0;
 
 			return extPages;
 		}

--- a/src/jrd/pag.h
+++ b/src/jrd/pag.h
@@ -132,7 +132,7 @@ public:
 	struct ExtendResult
 	{
 		bool success = false;
-		ULONG pages_allocated = 0;
+		ULONG pagesAllocated = 0;
 	};
 	// extend page space
 	ExtendResult extend(thread_db* tdbb, ULONG pageNum, bool forceSize);

--- a/src/jrd/pag.h
+++ b/src/jrd/pag.h
@@ -130,7 +130,7 @@ public:
 	static ULONG usedPages(const Database* dbb);
 
 	// extend page space
-	std::optional<ULONG> extend(thread_db* tdbb, ULONG pageNum, bool forceSize);
+	ULONG extend(thread_db* tdbb, ULONG pageNum, bool forceSize);
 
 	// get SCN's page number
 	ULONG getSCNPageNum(ULONG sequence) noexcept;

--- a/src/jrd/pag.h
+++ b/src/jrd/pag.h
@@ -129,8 +129,13 @@ public:
 	ULONG usedPages();
 	static ULONG usedPages(const Database* dbb);
 
+	struct ExtendResult
+	{
+		bool success = false;
+		ULONG pages_allocated = 0;
+	};
 	// extend page space
-	bool extend(thread_db*, const ULONG, const bool);
+	ExtendResult extend(thread_db* tdbb, ULONG pageNum, bool forceSize);
 
 	// get SCN's page number
 	ULONG getSCNPageNum(ULONG sequence) noexcept;

--- a/src/jrd/pag.h
+++ b/src/jrd/pag.h
@@ -129,13 +129,8 @@ public:
 	ULONG usedPages();
 	static ULONG usedPages(const Database* dbb);
 
-	struct ExtendResult
-	{
-		bool success = false;
-		ULONG pagesAllocated = 0;
-	};
 	// extend page space
-	ExtendResult extend(thread_db* tdbb, ULONG pageNum, bool forceSize);
+	std::optional<ULONG> extend(thread_db* tdbb, ULONG pageNum, bool forceSize);
 
 	// get SCN's page number
 	ULONG getSCNPageNum(ULONG sequence) noexcept;


### PR DESCRIPTION
- This should eliminate double writes of pages when file is extended.
- If fallocate is not supported by filesystem fallback to the old method of writing zeroes to the file.

Restore gets the biggest performance boost from this patch. I tested restore on a database with one table `CREATE TABLE TAB1(V1 VARCHAR(25), V2 VARCHAR(25), V3 VARCHAR(25), V4 VARCHAR(25))`, with a file size of about 16 GB. The testing was done on two different PCs with the same OS (Ubuntu 24.04):
`Intel Core i5-10400 + WD Red SN700 1000 GB (111150WD)`: +10% speedup with `-par 8`;
`Ryzen 7 7700 + KINGSTON SKC3000S1024G (EIFK31.6)`: +18% speedup with `-par 8`;
On Windows, the performance improvement is small (about 3-5%), so the real target of this patch is Linux.