### PR TITLE
fix(windows build): Use correct variable to specify target architecture when calling `vcvarsall.bat`

### DIFF
--- a/builds/win32/setenvvar.bat
+++ b/builds/win32/setenvvar.bat
@@ -83,10 +83,10 @@
 :: Run vsvarsall just once during the build...
 @if DEFINED FB_VSCOMNTOOLS (
   @if not defined VCToolsVersion (
-    call "%FB_VSCOMNTOOLS%\..\..\VC\Auxiliary\Build\vcvarsall.bat" %PROCESSOR_ARCHITECTURE%
+    call "%FB_VSCOMNTOOLS%\..\..\VC\Auxiliary\Build\vcvarsall.bat" %FB_PROCESSOR_ARCHITECTURE%
   ) else (
     @echo    The file:
-    @echo      "%FB_VSCOMNTOOLS%\..\..\VC\Auxiliary\Build\vcvarsall.bat" %PROCESSOR_ARCHITECTURE%
+    @echo      "%FB_VSCOMNTOOLS%\..\..\VC\Auxiliary\Build\vcvarsall.bat" %FB_PROCESSOR_ARCHITECTURE%
     @echo    has already been executed.
   )
 )


### PR DESCRIPTION
As I can see, in order to build a server for `x32` on `x64` machine, the variable `FB_PROCESSOR_ARCHITECTURE` is set to `x32` before calling `run_all.bat`, but `PROCESSOR_ARCHITECTURE` is used in the call to `vcvarsall.bat` (to set environment variables).
Currently, this does not cause any problems. However, if a third-party library uses, for example, `cl.exe` to build itself, incorrect environment variables will cause problems.