### PR TITLE
Prevent past-EOF access to uni-directional cursors

### DIFF
--- a/src/dsql/DsqlCursor.cpp
+++ b/src/dsql/DsqlCursor.cpp
@@ -135,6 +135,14 @@ int DsqlCursor::fetchNext(thread_db* tdbb, UCHAR* buffer)
 {
 	if (!(m_flags & IStatement::CURSOR_TYPE_SCROLLABLE))
 	{
+		if (m_state == EOS)
+		{
+			fb_assert(m_eof);
+			return 1;
+		}
+
+		fb_assert(!m_eof);
+
 		m_eof = !m_dsqlRequest->fetch(tdbb, buffer);
 
 		if (m_eof)


### PR DESCRIPTION
This code is more secure than the stub in https://github.com/FirebirdSQL/firebird/blob/master/src/dsql/DsqlRequests.cpp#L383

> ```c++
> // Fetch from already finished request should not produce error
> if (!(request->req_flags & req_active))
> {
> 	if (req_timer)
> 		req_timer->stop();
> 
> 	trace.fetch(true, ITracePlugin::RESULT_SUCCESS);
> 	return false;
> }
> ```

It can be used as a second level of cursor status checking.