### PR TITLE
Change gbak output of errors and warnings to stderr instead of stdout

### DIFF
--- a/src/burp/BurpTasks.cpp
+++ b/src/burp/BurpTasks.cpp
@@ -220,7 +220,7 @@ bool BackupRelationTask::handler(WorkItem& _item)
 
 		{ // scope
 			SimpleGblHolder gbl(m_masterGbl);
-			BURP_print_status(true, &st);
+			BURP_print_status(&st, true);
 		}
 
 		m_stop = true;
@@ -743,7 +743,7 @@ bool RestoreRelationTask::handler(WorkItem& _item)
 
 		{ // scope
 			SimpleGblHolder gbl(m_masterGbl);
-			BURP_print_status(true, &st);
+			BURP_print_status(&st, true);
 		}
 
 		m_stop = true;
@@ -957,7 +957,7 @@ bool RestoreRelationTask::freeItem(Item& item, bool commit)
 				ret = false;
 
 				// more detailed message required ?
-				BURP_print_status(false, &status);
+				BURP_print_status(&status);
 			}
 			item.m_tra = nullptr;
 		}

--- a/src/burp/backup.epp
+++ b/src/burp/backup.epp
@@ -1130,7 +1130,7 @@ void put_array( burp_fld* field, burp_rel* relation, ISC_QUAD* blob_id)
 	if (!status_vector.isSuccess())
 	{
 		BurpMaster master;
-		BURP_print(false, 81, field->fld_name);
+		BURP_print(true, 81, field->fld_name);
 		// msg 81 error accessing blob field %s -- continuing
 		BURP_print_status(false, &status_vector);
 #ifdef DEBUG
@@ -1235,7 +1235,7 @@ void put_asciz( const att_type attribute, const TEXT* string)
 	// We can't honor operating systems that allow longer file names.
 	if (len >= MAX_FILE_NAME_SIZE)
 	{
-		BURP_print(false, 343, SafeArg() << int(attribute) << "put_asciz()" << (MAX_FILE_NAME_SIZE - 1));
+		BURP_print(true, 343, SafeArg() << int(attribute) << "put_asciz()" << (MAX_FILE_NAME_SIZE - 1));
 		// msg 343: text for attribute @1 is too large in @2, truncating to @3 bytes
 		len = MAX_FILE_NAME_SIZE - 1;
 	}
@@ -1276,7 +1276,7 @@ void put_blob( burp_fld* field, ISC_QUAD& blob_id)
 	if (!blob.open(DB, gds_trans, blob_id))
 	{
 		BurpMaster master;
-		BURP_print(false, 81, field->fld_name);
+		BURP_print(true, 81, field->fld_name);
 		// msg 81 error accessing blob field %s -- continuing
 		BURP_print_status(false, &status_vector);
 		return;

--- a/src/burp/backup.epp
+++ b/src/burp/backup.epp
@@ -295,7 +295,7 @@ int BACKUP_backup(const TEXT* dbb_file, const TEXT* file_name)
 		IStatement* stmt = DB->prepare(fbStatus, gds_trans, 0, sql, 3, 0);
 		if (fbStatus->getState() & IStatus::RESULT_ERROR)
 		{
-			// BURP_print_status(false, isc_status);
+			// BURP_print_status(isc_status);
 			tdgbl->gbl_sw_par_workers = 1;
 		}
 		if (stmt)
@@ -736,10 +736,11 @@ burp_fld* get_fields( burp_rel* relation)
 			{
 				field->fld_flags |= FLD_array;
 				field->fld_dimensions = Y.RDB$DIMENSIONS;
-				if (field->fld_dimensions < 0) {
-					BURP_error_redirect (NULL, 52, SafeArg() << field->fld_name);
+				if (field->fld_dimensions < 0)
+				{
+					BURP_error(52, true, SafeArg() << field->fld_name);
+					// msg 52 array dimension for field %s is invalid
 				}
-				// msg 52 array dimension for field %s is invalid
 				get_ranges (field);
 			}
 
@@ -855,10 +856,11 @@ burp_fld* get_fields( burp_rel* relation)
 			{
 				field->fld_flags |= FLD_array;
 				field->fld_dimensions = Y.RDB$DIMENSIONS;
-				if (field->fld_dimensions < 0) {
-					BURP_error_redirect (NULL, 52, SafeArg() << field->fld_name);
+				if (field->fld_dimensions < 0)
+				{
+					BURP_error(52, true, SafeArg() << field->fld_name);
+					// msg 52 array dimension for field %s is invalid
 				}
-				// msg 52 array dimension for field %s is invalid
 				get_ranges (field);
 			}
 
@@ -989,8 +991,10 @@ void get_ranges( burp_fld* field)
 		SORTED BY X.RDB$DIMENSION
 	{
 		if (count != X.RDB$DIMENSION)
-			BURP_error_redirect (NULL, 52, SafeArg() << field->fld_name);
+		{
+			BURP_error(52, true, SafeArg() << field->fld_name);
 			// msg 52 array dimension for field %s is invalid
+		}
 		*rp++ = X.RDB$LOWER_BOUND;
 		*rp++ = X.RDB$UPPER_BOUND;
 		count++;
@@ -1001,8 +1005,10 @@ void get_ranges( burp_fld* field)
 	END_ERROR
 
 	if (count != field->fld_dimensions)
-		BURP_error_redirect(NULL, 52, SafeArg() << field->fld_name);
+	{
+		BURP_error(52, true, SafeArg() << field->fld_name);
 		// msg 52 array dimension for field %s is invalid
+	}
 }
 
 
@@ -1130,9 +1136,9 @@ void put_array( burp_fld* field, burp_rel* relation, ISC_QUAD* blob_id)
 	if (!status_vector.isSuccess())
 	{
 		BurpMaster master;
-		BURP_print(true, 81, field->fld_name);
+		BURP_print(81, field->fld_name);
 		// msg 81 error accessing blob field %s -- continuing
-		BURP_print_status(false, &status_vector);
+		BURP_print_status(&status_vector);
 #ifdef DEBUG
 		PRETTY_print_sdl(blr_buffer, NULL, NULL, 0);
 #endif
@@ -1235,7 +1241,7 @@ void put_asciz( const att_type attribute, const TEXT* string)
 	// We can't honor operating systems that allow longer file names.
 	if (len >= MAX_FILE_NAME_SIZE)
 	{
-		BURP_print(true, 343, SafeArg() << int(attribute) << "put_asciz()" << (MAX_FILE_NAME_SIZE - 1));
+		BURP_print(343, SafeArg() << int(attribute) << "put_asciz()" << (MAX_FILE_NAME_SIZE - 1));
 		// msg 343: text for attribute @1 is too large in @2, truncating to @3 bytes
 		len = MAX_FILE_NAME_SIZE - 1;
 	}
@@ -1276,9 +1282,9 @@ void put_blob( burp_fld* field, ISC_QUAD& blob_id)
 	if (!blob.open(DB, gds_trans, blob_id))
 	{
 		BurpMaster master;
-		BURP_print(true, 81, field->fld_name);
+		BURP_print(81, field->fld_name);
 		// msg 81 error accessing blob field %s -- continuing
-		BURP_print_status(false, &status_vector);
+		BURP_print_status(&status_vector);
 		return;
 	}
 
@@ -1325,7 +1331,7 @@ void put_blob( burp_fld* field, ISC_QUAD& blob_id)
 			break;
 
 		default:
-			BURP_error_redirect(NULL, 21, SafeArg() << int(item));
+			BURP_error(21, true, SafeArg() << int(item));
 			// msg 21 don't understand blob info item %ld
 		}
 	}
@@ -1372,8 +1378,10 @@ void put_blob( burp_fld* field, ISC_QUAD& blob_id)
 	}
 
 	if (!blob.close())
+	{
 		BURP_error_redirect(&status_vector, 23);
 		// msg 23 isc_close_blob failed
+	}
 
 	if (buffer != static_buffer)
 		BURP_free(buffer);
@@ -1441,11 +1449,13 @@ bool put_blr_blob( att_type attribute, ISC_QUAD& blob_id)
 			break;
 
 		default:
-			BURP_print(true, 79, SafeArg() << int(item));
+			BURP_print(79, SafeArg() << int(item));
 			// msg 79 don't understand blob info item %ld
 			if (!blob.close())
+			{
 				BURP_error_redirect(&status_vector, 23);
 				// msg 23 isc_close_blob failed
+			}
 			return false;
 		}
 	}
@@ -1453,8 +1463,10 @@ bool put_blr_blob( att_type attribute, ISC_QUAD& blob_id)
 	if (!length || length > MAX_ULONG)
 	{
 		if (!blob.close())
+		{
 			BURP_error_redirect(&status_vector, 23);
 			// msg 23 isc_close_blob failed
+		}
 		return false;
 	}
 
@@ -1668,7 +1680,7 @@ void put_index( burp_rel* relation)
 
 			if (count != (ULONG) X.RDB$SEGMENT_COUNT)
 			{
-				BURP_print(true, 180, SafeArg() << X.RDB$INDEX_NAME << count << X.RDB$SEGMENT_COUNT);
+				BURP_print(180, SafeArg() << X.RDB$INDEX_NAME << count << X.RDB$SEGMENT_COUNT);
 				continue;
 			}
 
@@ -1749,7 +1761,7 @@ void put_index( burp_rel* relation)
 
 			if (count != (ULONG) X.RDB$SEGMENT_COUNT)
 			{
-				BURP_print(true, 180, SafeArg() << X.RDB$INDEX_NAME << count << X.RDB$SEGMENT_COUNT);
+				BURP_print(180, SafeArg() << X.RDB$INDEX_NAME << count << X.RDB$SEGMENT_COUNT);
 				continue;
 			}
 
@@ -2211,7 +2223,7 @@ bool put_source_blob(att_type attribute, att_type old_attribute, ISC_QUAD& blob_
 			break;
 
 		default:
-			BURP_print(true, 79, SafeArg() << int(item));
+			BURP_print(79, SafeArg() << int(item));
 			// msg 79 don't understand blob info item %ld
 			if (!blob.close())
 			{
@@ -2261,8 +2273,10 @@ bool put_source_blob(att_type attribute, att_type old_attribute, ISC_QUAD& blob_
 	}
 
 	if (!blob.close())
+	{
 		BURP_error_redirect(&status_vector, 23);
-	// msg 23 isc_close_blob failed
+		// msg 23 isc_close_blob failed
+	}
 
 	if (buffer != static_buffer)
 		BURP_free(buffer);
@@ -2294,7 +2308,7 @@ int put_text(att_type attribute, const TEXT* text, SSHORT size_len)
 	fb_assert(l <= MAX_UCHAR);
 	if (l > MAX_UCHAR)
 	{
-		BURP_print(true, 343, SafeArg() << int(attribute) << "put_text()" << MAX_UCHAR);
+		BURP_print(343, SafeArg() << int(attribute) << "put_text()" << MAX_UCHAR);
 		// msg 343: text for attribute @1 is too large in @2, truncating to @3 bytes
 		l = MAX_UCHAR;
 	}
@@ -4991,7 +5005,7 @@ void ReadRelationMeta::setRelation(const burp_rel* relation, bool partition)
 			break;
 
 		default:
-			BURP_error_redirect(NULL, 26, SafeArg() << field->fld_type);
+			BURP_error(26, true, SafeArg() << field->fld_type);
 			// msg 26 datatype %ld not understood
 			break;
 		}

--- a/src/burp/burp.cpp
+++ b/src/burp/burp.cpp
@@ -1795,19 +1795,19 @@ void BURP_print_status(bool err, const Firebird::IStatus* status_vector, USHORT 
         SCHAR s[1024];
 		if (fb_interpret(s, sizeof(s), &vector))
 		{
-			BURP_msg_partial(err, 256); // msg 256: gbak: ERROR:
-			burp_output(err, "%s\n", s);
+			BURP_msg_partial(true, 256); // msg 256: gbak: ERROR:
+			burp_output(true, "%s\n", s);
 
 			while (fb_interpret(s, sizeof(s), &vector))
 			{
-				BURP_msg_partial(err, 256); // msg 256: gbak: ERROR:
-				burp_output(err, "    %s\n", s);
+				BURP_msg_partial(true, 256); // msg 256: gbak: ERROR:
+				burp_output(true, "    %s\n", s);
 			}
 		}
 
 		if (secondNumber)
 		{
-			BURP_msg_partial(err, 169);	// msg 169: gbak:
+			BURP_msg_partial(true, 169);	// msg 169: gbak:
 			BURP_msg_put(true, secondNumber, SafeArg());
 		}
 	}
@@ -1850,13 +1850,13 @@ void BURP_print_warning(const Firebird::IStatus* status, bool printErrorAsWarnin
 
 	if (fb_interpret(s, sizeof(s), &vector))
 	{
-		BURP_msg_partial(false, 255); // msg 255: gbak: WARNING:
-		burp_output(false, "%s\n", s);
+		BURP_msg_partial(true, 255); // msg 255: gbak: WARNING:
+		burp_output(true, "%s\n", s);
 
 		while (fb_interpret(s, sizeof(s), &vector))
 		{
-			BURP_msg_partial(false, 255); // msg 255: gbak: WARNING:
-			burp_output(false, "    %s\n", s);
+			BURP_msg_partial(true, 255); // msg 255: gbak: WARNING:
+			burp_output(true, "    %s\n", s);
 		}
 	}
 }

--- a/src/burp/burp.cpp
+++ b/src/burp/burp.cpp
@@ -372,8 +372,8 @@ static int svc_api_gbak(Firebird::UtilSvc* uSvc, const Switches& switches)
 			spb.getBufferLength(), spb.getBuffer());
 		if (!status.isSuccess())
 		{
-			BURP_print_status(true, &status, 83);
-				// msg 83 Exiting before completion due to errors
+			BURP_print_status(&status, true, 83);
+			// msg 83 Exiting before completion due to errors
 			return FINI_ERROR;
 		}
 
@@ -406,8 +406,8 @@ static int svc_api_gbak(Firebird::UtilSvc* uSvc, const Switches& switches)
 		svc_handle->start(&status, thdlen, thd);
 		if (!status.isSuccess())
 		{
-			BURP_print_status(true, &status, 83);
-				// msg 83 Exiting before completion due to errors
+			BURP_print_status(&status, true, 83);
+			// msg 83 Exiting before completion due to errors
 			svc_handle->release();
 			return FINI_ERROR;
 		}
@@ -437,8 +437,8 @@ static int svc_api_gbak(Firebird::UtilSvc* uSvc, const Switches& switches)
 							  sizeof(respbuf), respbuf);
 			if (!status.isSuccess())
 			{
-				BURP_print_status(true, &status, 83);
-					// msg 83 Exiting before completion due to errors
+				BURP_print_status(&status, true, 83);
+				// msg 83 Exiting before completion due to errors
 				svc_handle->release();
 				return FINI_ERROR;
 			}
@@ -487,8 +487,8 @@ static int svc_api_gbak(Firebird::UtilSvc* uSvc, const Switches& switches)
 	{
 		FbLocalStatus s;
 		e.stuffException(&s);
-		BURP_print_status(true, &s, 83);
-			// msg 83 Exiting before completion due to errors
+		BURP_print_status(&s, true, 83);
+		// msg 83 Exiting before completion due to errors
 		if (svc_handle)
 			svc_handle->release();
 		return FINI_ERROR;
@@ -519,7 +519,7 @@ static Switches::in_sw_tab_t* findSwitchOrThrow(Firebird::UtilSvc* uSvc, Switche
 	{
 		if (! uSvc->isService())
 		{
-			BURP_print(true, 137, sw.c_str());
+			BURP_print(137, sw.c_str());
 			// msg 137  unknown switch %s
 			burp_usage(switches);
 			BURP_error(1, true);
@@ -1265,7 +1265,7 @@ int gbak(Firebird::UtilSvc* uSvc)
 #endif
 
 		case IN_SW_BURP_Z:
-			BURP_print(false, 91, FB_VERSION);
+			BURP_message(91, SafeArg() << FB_VERSION);
 			// msg 91 gbak version %s
 			tdgbl->gbl_sw_version = true;
 			break;
@@ -1310,7 +1310,7 @@ int gbak(Firebird::UtilSvc* uSvc)
 		}
 		if (temp != tdgbl->gbl_sw_page_size)
 		{
-			BURP_print(false, 103, SafeArg() << tdgbl->gbl_sw_page_size << temp);
+			BURP_print(103, SafeArg() << tdgbl->gbl_sw_page_size << temp);
 			// msg 103 page size specified (%ld bytes) rounded up to %ld bytes
 			tdgbl->gbl_sw_page_size = temp;
 		}
@@ -1467,10 +1467,11 @@ int gbak(Firebird::UtilSvc* uSvc)
 		// Non-burp exception was caught
 		tdgbl->burp_throw = false;
 		e.stuffException(&tdgbl->status_vector);
-		BURP_print_status(true, &tdgbl->status_vector);
+		BURP_print_status(&tdgbl->status_vector, true);
 		if (! tdgbl->uSvc->isService())
 		{
-			BURP_print(true, 83);	// msg 83 Exiting before completion due to errors
+			BURP_print(83);
+			// msg 83 Exiting before completion due to errors
 		}
 		exit_code = FINI_ERROR;
 	}
@@ -1502,7 +1503,7 @@ int gbak(Firebird::UtilSvc* uSvc)
 		tdgbl->db_handle->detach(&tdgbl->status_vector);
 
 		if (tdgbl->status_vector->getState() & Firebird::IStatus::STATE_ERRORS)
-			BURP_print_status(true, &tdgbl->status_vector);
+			BURP_print_status(&tdgbl->status_vector, true);
 		else
 			tdgbl->db_handle = NULL;
 	}
@@ -1544,13 +1545,13 @@ void BURP_abort(const Firebird::IStatus* status)
 	UtilSvc::StatusAccessor sa = tdgbl->uSvc->getStatusAccessor();
 
 	if (status)
-		BURP_print_status(true, status, code);
+		BURP_print_status(status, true, code);
 	else
 	{
 		sa.setServiceStatus(burp_msg_fac, code, SafeArg());
 
 		if (!tdgbl->uSvc->isService())
-			BURP_print(true, code);
+			BURP_print(code);
 	}
 
 	tdgbl->uSvc->started();
@@ -1566,6 +1567,7 @@ void BURP_error(USHORT errcode, bool abort, const SafeArg& arg)
  **************************************
  *
  * Functional description
+ *	Format and print an error message, then punt.
  *
  **************************************/
 	BurpMaster master;
@@ -1598,7 +1600,7 @@ void BURP_error(USHORT errcode, bool abort, const char* str)
  **************************************
  *
  * Functional description
- *	Format and print an error message, then punt.
+ *	Shortcut for text argument
  *
  **************************************/
 
@@ -1623,7 +1625,7 @@ void BURP_error_redirect(const Firebird::IStatus* status_vector, USHORT errcode,
 	// StatusAccessor is used only as RAII holder here
 	UtilSvc::StatusAccessor sa = master.get()->uSvc->getStatusAccessor();
 
-	BURP_print_status(true, status_vector);
+	BURP_print_status(status_vector, true);
 	BURP_error(errcode, true, arg);
 }
 
@@ -1716,28 +1718,32 @@ void OutputVersion::callback(Firebird::CheckStatusWrapper* status, const char* t
 	burp_output(false, format, text);
 }
 
-void BURP_print(bool err, USHORT number, const SafeArg& arg)
+
+void BURP_message(USHORT number, const SafeArg& arg, bool totals)
 {
 /**************************************
  *
- *	B U R P _ p r i n t
+ *	B U R P _ m e s s a g e
  *
  **************************************
  *
  * Functional description
- *	Display a formatted error message
- *	in a way that civilized systems
- *	will accept.
+ *	Calls BURP_msg for formatting & displaying a message.
  *
  **************************************/
 	BurpMaster master;
+	BurpGlobals* tdgbl = master.get();
 
-	BURP_msg_partial(err, 169);	// msg 169: gbak:
-	BURP_msg_put(err, number, arg);
+	if (totals)
+		tdgbl->print_stats_header();
+	BURP_msg_partial(false, 169);	// msg 169: gbak:
+	if (totals)
+		tdgbl->print_stats(number);
+	BURP_msg_put(false, number, arg);
 }
 
 
-void BURP_print(bool err, USHORT number, const char* str)
+void BURP_print(USHORT number, const SafeArg& arg)
 {
 /**************************************
  *
@@ -1754,12 +1760,28 @@ void BURP_print(bool err, USHORT number, const char* str)
 	BurpMaster master;
 
 	static const SafeArg dummy;
-	BURP_msg_partial(err, 169, dummy);	// msg 169: gbak:
-	BURP_msg_put(err, number, SafeArg() << str);
+	BURP_msg_partial(true, 169, dummy);	// msg 169: gbak:
+	BURP_msg_put(true, number, arg);
 }
 
 
-void BURP_print_status(bool err, const Firebird::IStatus* status_vector, USHORT secondNumber)
+void BURP_print(USHORT number, const char* str)
+{
+/**************************************
+ *
+ *	B U R P _ p r i n t
+ *
+ **************************************
+ *
+ * Functional description
+ *	Shortcut for text argument
+ *
+ **************************************/
+	BURP_print(number, SafeArg() << str);
+}
+
+
+void BURP_print_status(const Firebird::IStatus* status_vector, bool serviceFlag, USHORT secondNumber)
 {
 /**************************************
  *
@@ -1778,7 +1800,7 @@ void BURP_print_status(bool err, const Firebird::IStatus* status_vector, USHORT 
 		BurpGlobals* tdgbl = master.get();
 
 		const ISC_STATUS* vector = status_vector->getErrors();
-		if (err)
+		if (serviceFlag)
 		{
 			UtilSvc::StatusAccessor sa = tdgbl->uSvc->getStatusAccessor();
 			sa.setServiceStatus(vector);
@@ -1885,30 +1907,6 @@ void BURP_verbose(USHORT number, const SafeArg& arg)
 }
 
 
-void BURP_message(USHORT number, const MsgFormat::SafeArg& arg, bool totals)
-{
-/**************************************
- *
- *	B U R P _ m e s s a g e
- *
- **************************************
- *
- * Functional description
- *	Calls BURP_msg for formatting & displaying a message.
- *
- **************************************/
-	BurpMaster master;
-	BurpGlobals* tdgbl = master.get();
-
-	if (totals)
-		tdgbl->print_stats_header();
-	BURP_msg_partial(false, 169);	// msg 169: gbak:
-	if (totals)
-		tdgbl->print_stats(number);
-	BURP_msg_put(false, number, arg);
-}
-
-
 void BURP_verbose(USHORT number, const string& str)
 {
 /**************************************
@@ -1955,7 +1953,7 @@ static void close_out_transaction(gbak_action action, Firebird::ITransaction** t
 				// we can detach from the database.
 				(*tPtr)->rollback(&status_vector);
 				if (!status_vector.isSuccess())
-					BURP_print_status(false, &status_vector);
+					BURP_print_status(&status_vector);
 				else
 					*tPtr = nullptr;
 			}
@@ -1969,7 +1967,7 @@ static void close_out_transaction(gbak_action action, Firebird::ITransaction** t
 			// ensure it by doing a rollback
 			(*tPtr)->rollback(&status_vector);
 			if (!status_vector.isSuccess())
-				BURP_print_status(false, &status_vector);
+				BURP_print_status(&status_vector);
 			else
 				*tPtr = nullptr;
 		}
@@ -2040,7 +2038,7 @@ static gbak_action open_files(const TEXT* file1,
 
 			if (!status_vector.isSuccess())
 			{
-				BURP_print_status(true, &status_vector);
+				BURP_print_status(&status_vector, true);
 				return QUIT;
 			}
 		}
@@ -2057,7 +2055,7 @@ static gbak_action open_files(const TEXT* file1,
 				tdgbl->db_handle->detach(&status_vector);
 
 				if (status_vector->getState() & Firebird::IStatus::STATE_ERRORS)
-					BURP_print_status(true, &status_vector);
+					BURP_print_status(&status_vector, true);
 				else
 					tdgbl->db_handle = NULL;
 
@@ -2065,8 +2063,8 @@ static gbak_action open_files(const TEXT* file1,
 			}
 			if (tdgbl->gbl_sw_version)
 			{
+				BURP_message(139, SafeArg() << file1);
 				// msg 139 Version(s) for database "%s"
-				BURP_print(false, 139, file1);
 				OutputVersion outputVersion("\t%s\n");
 				Firebird::UtilInterfacePtr()->getFbVersion(&status_vector, tdgbl->db_handle, &outputVersion);
 			}
@@ -2120,7 +2118,7 @@ static gbak_action open_files(const TEXT* file1,
 		else if (sw_replace == IN_SW_BURP_B ||
 			(status_vector->getErrors()[1] != isc_io_error && status_vector->getErrors()[1] != isc_bad_db_format))
 		{
-			BURP_print_status(true, &status_vector);
+			BURP_print_status(&status_vector, true);
 			return QUIT;
 		}
 	}
@@ -2246,7 +2244,7 @@ static gbak_action open_files(const TEXT* file1,
 			tdgbl->db_handle->detach(&status_vector);
 
 			if (status_vector->getState() & Firebird::IStatus::STATE_ERRORS)
-				BURP_print_status(true, &status_vector);
+				BURP_print_status(&status_vector, true);
 			else
 				tdgbl->db_handle = NULL;
 		}
@@ -2431,7 +2429,7 @@ static gbak_action open_files(const TEXT* file1,
 			provider->setDbCryptCallback(&status_vector, MVOL_get_crypt(tdgbl));
 			if (!status_vector.isSuccess())
 			{
-				BURP_print_status(true, &status_vector);
+				BURP_print_status(&status_vector, true);
 				return QUIT;
 			}
 		}
@@ -2446,7 +2444,7 @@ static gbak_action open_files(const TEXT* file1,
 				tdgbl->db_handle->detach(&status_vector);
 
 				if (status_vector->getState() & Firebird::IStatus::STATE_ERRORS)
-					BURP_print_status(true, &status_vector);
+					BURP_print_status(&status_vector, true);
 				else
 					tdgbl->db_handle = NULL;
 
@@ -2463,7 +2461,7 @@ static gbak_action open_files(const TEXT* file1,
 					tdgbl->db_handle->detach(&status2);
 
 					if (status2->getState() & Firebird::IStatus::STATE_ERRORS)
-						BURP_print_status(true, &status2);
+						BURP_print_status(&status2, true);
 					else
 						tdgbl->db_handle = NULL;
 
@@ -2553,11 +2551,11 @@ static void burp_usage(const Switches& switches)
 	const SafeArg sa(SafeArg() << switch_char);
 	const SafeArg dummy;
 
-	BURP_print(true, 317); // usage
+	BURP_print(317); // usage
 	for (int i = 318; i < 323; ++i)
 		BURP_msg_put(true, i, dummy); // usage
 
-	BURP_print(true, 95); // msg 95  legal switches are
+	BURP_print(95); // msg 95  legal switches are
 	const Switches::in_sw_tab_t* const base = switches.getTable();
 	for (const Switches::in_sw_tab_t* p = base; p->in_sw; ++p)
 	{
@@ -2565,28 +2563,28 @@ static void burp_usage(const Switches& switches)
 			BURP_msg_put(true, p->in_sw_msg, sa);
 	}
 
-	BURP_print(true, 323); // backup options are
+	BURP_print(323); // backup options are
 	for (const Switches::in_sw_tab_t* p = base; p->in_sw; ++p)
 	{
 		if (p->in_sw_msg && p->in_sw_optype == boBackup)
 			BURP_msg_put(true, p->in_sw_msg, sa);
 	}
 
-	BURP_print(true, 324); // restore options are
+	BURP_print(324); // restore options are
 	for (const Switches::in_sw_tab_t* p = base; p->in_sw; ++p)
 	{
 		if (p->in_sw_msg && p->in_sw_optype == boRestore)
 			BURP_msg_put(true, p->in_sw_msg, sa);
 	}
 
-	BURP_print(true, 325); // general options are
+	BURP_print(325); // general options are
 	for (const Switches::in_sw_tab_t* p = base; p->in_sw; ++p)
 	{
 		if (p->in_sw_msg && p->in_sw_optype == boGeneral)
 			BURP_msg_put(true, p->in_sw_msg, sa);
 	}
 
-	BURP_print(true, 132); // msg 132 switches can be abbreviated to the unparenthesized characters
+	BURP_print(132); // msg 132 switches can be abbreviated to the unparenthesized characters
 }
 
 

--- a/src/burp/burp_proto.h
+++ b/src/burp/burp_proto.h
@@ -38,16 +38,16 @@ void	BURP_abort(const Firebird::IStatus* status = nullptr);
 void	BURP_error(USHORT, bool, const MsgFormat::SafeArg& arg = MsgFormat::SafeArg());
 void	BURP_error(USHORT, bool, const char* str);
 void	BURP_error_redirect(const Firebird::IStatus*, USHORT, const MsgFormat::SafeArg& arg = MsgFormat::SafeArg());
+void	BURP_message(USHORT, const MsgFormat::SafeArg& arg = MsgFormat::SafeArg(), bool totals = false);
 void	BURP_msg_partial(bool, USHORT, const MsgFormat::SafeArg& arg = MsgFormat::SafeArg());
 void	BURP_msg_put(bool, USHORT, const MsgFormat::SafeArg& arg);
 inline constexpr int BURP_MSG_GET_SIZE = 128; // Use it for buffers passed to this function.
 void	BURP_msg_get(USHORT, TEXT*, const MsgFormat::SafeArg& arg = MsgFormat::SafeArg());
-void	BURP_print(bool err, USHORT, const MsgFormat::SafeArg& arg = MsgFormat::SafeArg());
-void	BURP_print(bool err, USHORT, const char* str);
-void	BURP_print_status(bool err, const Firebird::IStatus* status, USHORT secondNumber = 0);
+void	BURP_print(USHORT, const MsgFormat::SafeArg& arg = MsgFormat::SafeArg());
+void	BURP_print(USHORT, const char* str);
+void	BURP_print_status(const Firebird::IStatus* status, bool serviceFlag = false, USHORT secondNumber = 0);
 void	BURP_print_warning(const Firebird::IStatus* status, bool printErrorAsWarning = false);
 void	BURP_verbose(USHORT, const MsgFormat::SafeArg& arg = MsgFormat::SafeArg());
 void	BURP_verbose(USHORT, const Firebird::string& str);
-void	BURP_message(USHORT, const MsgFormat::SafeArg& arg = MsgFormat::SafeArg(), bool totals = false);
 
 #endif	//  BURP_BURP_PROTO_H

--- a/src/burp/mvol.cpp
+++ b/src/burp/mvol.cpp
@@ -1713,7 +1713,7 @@ static void put_asciz(SCHAR attribute, const TEXT* str)
 	USHORT l = static_cast<USHORT>(strlen(str));
 	if (l > MAX_UCHAR)
 	{
-		BURP_print(false, 343, SafeArg() << int(attribute) << "put_asciz()" << USHORT(MAX_UCHAR));
+		BURP_print(true, 343, SafeArg() << int(attribute) << "put_asciz()" << USHORT(MAX_UCHAR));
 		// msg 343: text for attribute @1 is too large in @2, truncating to @3 bytes
 		l = MAX_UCHAR;
 	}

--- a/src/burp/mvol.cpp
+++ b/src/burp/mvol.cpp
@@ -859,7 +859,7 @@ int mvol_read(int* cnt, UCHAR** ptr)
 		tdgbl->mvol_io_cnt = tdgbl->uSvc->getBytes(tdgbl->mvol_io_buffer, tdgbl->mvol_io_buffer_size);
 		if (!tdgbl->mvol_io_cnt)
 		{
-			BURP_error_redirect(0, 220);
+			BURP_error(220, true);
 			// msg 220 Unexpected I/O error while reading from backup file
 		}
 		tdgbl->mvol_io_ptr = tdgbl->mvol_io_buffer;
@@ -913,12 +913,12 @@ static void os_read(int* cnt, UCHAR** ptr)
 		{
 			if (cnt)
 			{
-				BURP_error_redirect(0, 220);
+				BURP_error(220, true);
 				// msg 220 Unexpected I/O error while reading from backup file
 			}
 			else
 			{
-				BURP_error_redirect(0, 50);
+				BURP_error(50, true);
 				// msg 50 unexpected end of file on backup file
 			}
 		}
@@ -957,11 +957,15 @@ static void os_read(int* cnt, UCHAR** ptr)
 		else if (GetLastError() != ERROR_HANDLE_EOF)
 		{
 			if (cnt)
-				BURP_error_redirect(NULL, 220);
+			{
+				BURP_error(220, true);
 				// msg 220 Unexpected I/O error while reading from backup file
+			}
 			else
-				BURP_error_redirect(NULL, 50);
+			{
+				BURP_error(50, true);
 				// msg 50 unexpected end of file on backup file
+			}
 		}
 	}
 }
@@ -1241,7 +1245,7 @@ UCHAR mvol_write(const UCHAR c, int* io_cnt, UCHAR** io_ptr)
 							}
 
 							tdgbl->action->act_file->fil_fd = INVALID_HANDLE_VALUE;
-							BURP_print(true, 272, SafeArg() <<
+							BURP_print(272, SafeArg() <<
 										tdgbl->action->act_file->fil_name.c_str() <<
 										tdgbl->action->act_file->fil_length <<
 										tdgbl->action->act_file->fil_next->fil_name.c_str());
@@ -1302,7 +1306,7 @@ UCHAR mvol_write(const UCHAR c, int* io_cnt, UCHAR** io_ptr)
 				}
 				else if (!SYSCALL_INTERRUPTED(errno))
 				{
-					BURP_error_redirect(0, 221);
+					BURP_error(221, true);
 					// msg 221 Unexpected I/O error while writing to backup file
 				}
 			}
@@ -1425,7 +1429,7 @@ static void bad_attribute(int attribute, USHORT type)
 	BurpGlobals* tdgbl = BurpGlobals::getSpecific();
 	static const SafeArg dummy;
 	fb_msg_format(NULL, burp_msg_fac, type, sizeof(name), name, dummy);
-	BURP_print(true, 80, SafeArg() << name << attribute);
+	BURP_print(80, SafeArg() << name << attribute);
 	// msg 80  don't recognize %s attribute %ld -- continuing
 	for (int l = get(tdgbl); l; --l)
 		get(tdgbl);
@@ -1471,7 +1475,7 @@ static int get_text(UCHAR* text, SSHORT length)
 
 	if (length < 0)
 	{
-		BURP_error_redirect(0, 46);	// msg 46 string truncated
+		BURP_error(46, true);	// msg 46 string truncated
 	}
 
 	if (len)
@@ -1518,7 +1522,7 @@ static DESC next_volume( DESC handle, ULONG mode, bool full_buffer)
 			return tdgbl->action->act_file->fil_fd;
 		}
 
-		BURP_error_redirect(0, 50);	// msg 50 unexpected end of file on backup file
+		BURP_error(50, true);	// msg 50 unexpected end of file on backup file
 	}
 
 	// If we got here, we've got a live one... Up the volume number unless
@@ -1559,7 +1563,7 @@ static DESC next_volume( DESC handle, ULONG mode, bool full_buffer)
 		if (new_desc < 0)
 #endif // WIN_NT
 		{
-			BURP_print(true, 222, new_file);
+			BURP_print(222, new_file);
 			// msg 222 \n\nCould not open file name \"%s\"\n
 			continue;
 		}
@@ -1574,7 +1578,7 @@ static DESC next_volume( DESC handle, ULONG mode, bool full_buffer)
 		{
 			if (!write_header(new_desc, 0L, full_buffer))
 			{
-				BURP_print(true, 223, new_file);
+				BURP_print(223, new_file);
 				// msg223 \n\nCould not write to file \"%s\"\n
 				continue;
 			}
@@ -1593,7 +1597,7 @@ static DESC next_volume( DESC handle, ULONG mode, bool full_buffer)
 			USHORT format;
 			if (!read_header(new_desc, &temp_buffer_size, &format, false))
 			{
-				BURP_print(true, 224, new_file);
+				BURP_print(224, new_file);
 				continue;
 			}
 			else
@@ -1713,7 +1717,7 @@ static void put_asciz(SCHAR attribute, const TEXT* str)
 	USHORT l = static_cast<USHORT>(strlen(str));
 	if (l > MAX_UCHAR)
 	{
-		BURP_print(true, 343, SafeArg() << int(attribute) << "put_asciz()" << USHORT(MAX_UCHAR));
+		BURP_print(343, SafeArg() << int(attribute) << "put_asciz()" << USHORT(MAX_UCHAR));
 		// msg 343: text for attribute @1 is too large in @2, truncating to @3 bytes
 		l = MAX_UCHAR;
 	}
@@ -1774,13 +1778,13 @@ static bool read_header(DESC handle, ULONG* buffer_size, USHORT* format, bool in
 #endif
 	}
 	if (!tdgbl->mvol_io_cnt)
-		BURP_error_redirect(0, 45); // maybe there's a better message
+		BURP_error(45, true); // maybe there's a better message
 
 	tdgbl->mvol_io_ptr = tdgbl->mvol_io_buffer;
 
 	int attribute = get(tdgbl);
 	if (attribute != rec_burp)
-		BURP_error_redirect(0, 45);
+		BURP_error(45, true);
 		// msg 45 expected backup description record
 
 	int l, maxlen;

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -317,7 +317,7 @@ void activateIndex(BurpGlobals* tdgbl, const QualifiedMetaString& indexName)
 
 	if (fError)
 	{
-		BURP_print(false, 173, indexName.toQuotedString().c_str());
+		BURP_print(true, 173, indexName.toQuotedString().c_str());
 		BURP_print_status(false, &local_status_vector);
 		tdgbl->flag_on_line = false;
 
@@ -378,25 +378,25 @@ int RESTORE_restore (const TEXT* file_name, const TEXT* database_name)
 						MODIFY IDX USING
 							IDX.RDB$INDEX_INACTIVE = TRUE;
 						END_MODIFY;
-						BURP_print(false, 240, indexName.toQuotedString().c_str());
+						BURP_print(true, 240, indexName.toQuotedString().c_str());
 						// msg 240 Index \"%s\" failed to activate because:
 
 						if (error_code == isc_no_dup)
 						{
-							BURP_print(false, 241);
+							BURP_print(true, 241);
 							// msg 241 The unique index has duplicate values or NULLs
-							BURP_print(false, 242);
+							BURP_print(true, 242);
 							// msg 242 Delete or Update duplicate values or NULLs, and activate index with
 						}
 						else
 						{
-							BURP_print(false, 244);
+							BURP_print(true, 244);
 							// msg 244 Not enough disk space to create the sort file for an index
-							BURP_print(false, 245);
+							BURP_print(true, 245);
 							// msg 245 Set the TMP environment variable to a directory on a filesystem that does have enough space, and activate index with
 						}
 
-						BURP_print(false, 243, indexName.toQuotedString().c_str());
+						BURP_print(true, 243, indexName.toQuotedString().c_str());
 						// msg 243 ALTER INDEX \"%s\" ACTIVE;
 					}
 					END_FOR
@@ -765,7 +765,7 @@ void add_files(BurpGlobals* tdgbl, const char* file_name)
 		COMMIT
 		// existing ON_ERROR continues past error, beck
 		ON_ERROR
-			BURP_print (false, 174);
+			BURP_print (true, 174);
 			// msg 174 cannot commit files
 			BURP_print_status (false, &tdgbl->status_vector);
 			ROLLBACK;
@@ -2116,7 +2116,7 @@ void get_array(BurpGlobals* tdgbl, burp_rel* relation, UCHAR* record_buffer)
 						 elements_written * field->fld_length, (*buffer) + data_at);
 			if (status_vector->hasData())
 			{
-				BURP_print (false, 81, field->fld_name);
+				BURP_print (true, 81, field->fld_name);
 				// msg 81 error accessing blob field %s -- continuing
 				BURP_print_status (true, &status_vector);
 #ifdef DEBUG
@@ -3143,9 +3143,9 @@ static void check_data_error(BurpGlobals* tdgbl, IStatus* status_vector, const b
 	{
 		if (tdgbl->gbl_sw_incremental)
 		{
-			BURP_print(false, 138, relation->rel_name.toQuotedString().c_str());
+			BURP_print(true, 138, relation->rel_name.toQuotedString().c_str());
 			// msg 138 validation error on field in relation %s
-			BURP_print_status (false, status_vector);
+			BURP_print_status(false, status_vector);
 		}
 		else
 			BURP_error_redirect(status_vector, 47);
@@ -3155,9 +3155,8 @@ static void check_data_error(BurpGlobals* tdgbl, IStatus* status_vector, const b
 	{
 		if (tdgbl->gbl_sw_incremental)
 		{
+			BURP_print(true, 114, relation->rel_name.toQuotedString().c_str());
 			// msg 114 restore failed for record in relation %s
-			BURP_print(false, 114, relation->rel_name.toQuotedString().c_str());
-
 			BURP_print_status(false, status_vector, 342);	// isc_gbak_invalid_data
 		}
 		else
@@ -3167,7 +3166,7 @@ static void check_data_error(BurpGlobals* tdgbl, IStatus* status_vector, const b
 	{
 		if (tdgbl->gbl_sw_incremental && isc_sqlcode(status_vector->getErrors()) != -902)
 		{
-			BURP_print (false, 114, relation->rel_name.toQuotedString().c_str());
+			BURP_print(true, 114, relation->rel_name.toQuotedString().c_str());
 			// msg 114 restore failed for record in relation %s
 			BURP_print_status(false, status_vector);
 		}
@@ -3214,25 +3213,25 @@ static void commit_relation_data(BurpGlobals* tdgbl, burp_rel* relation)
 					{
 						IDX.RDB$INDEX_INACTIVE = TRUE;
 
-						BURP_print(false, 240, indexName.toQuotedString().c_str());
+						BURP_print(true, 240, indexName.toQuotedString().c_str());
 						// msg 240 Index \"%s\" failed to activate because:
 
 						if (error_code == isc_no_dup)
 						{
-							BURP_print(false, 241);
+							BURP_print(true, 241);
 							// msg 241 The unique index has duplicate values or NULLs
-							BURP_print(false, 242);
+							BURP_print(true, 242);
 							// msg 242 Delete or Update duplicate values or NULLs, and activate index with
 						}
 						else
 						{
-							BURP_print(false, 244);
+							BURP_print(true, 244);
 							// msg 244 Not enough disk space to create the sort file for an index
-							BURP_print(false, 245);
+							BURP_print(true, 245);
 							// msg 245 Set the TMP environment variable to a directory on a filesystem that does have enough space, and activate index with
 						}
 
-						BURP_print(false, 243, indexName.toQuotedString().c_str());
+						BURP_print(true, 243, indexName.toQuotedString().c_str());
 						// msg 243 ALTER INDEX \"%s\" ACTIVE
 					}
 					END_MODIFY
@@ -3246,7 +3245,7 @@ static void commit_relation_data(BurpGlobals* tdgbl, burp_rel* relation)
 				break;
 
 			default:
-				BURP_print(false, 69, relation->rel_name.toQuotedString().c_str());
+				BURP_print(true, 69, relation->rel_name.toQuotedString().c_str());
 				// msg 69 commit failed on relation %s
 				BURP_print_status(false, &tdgbl->status_vector);
 				ROLLBACK;

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -2126,7 +2126,7 @@ void get_array(BurpGlobals* tdgbl, burp_rel* relation, UCHAR* record_buffer)
 			{
 				BURP_print(81, field->fld_name);
 				// msg 81 error accessing blob field %s -- continuing
-				BURP_print_status(&status_vector, true);
+				BURP_print_status(&status_vector);
 #ifdef DEBUG
 				PRETTY_print_sdl (blr_buffer, NULL, NULL, 0);
 #endif

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -317,8 +317,8 @@ void activateIndex(BurpGlobals* tdgbl, const QualifiedMetaString& indexName)
 
 	if (fError)
 	{
-		BURP_print(true, 173, indexName.toQuotedString().c_str());
-		BURP_print_status(false, &local_status_vector);
+		BURP_print(173, indexName.toQuotedString().c_str());
+		BURP_print_status(&local_status_vector);
 		tdgbl->flag_on_line = false;
 
 		ROLLBACK activateIndexTran;
@@ -368,7 +368,7 @@ int RESTORE_restore (const TEXT* file_name, const TEXT* database_name)
 				case isc_sort_mem_err:
 				case isc_no_dup:
 					indexName = QualifiedMetaString::parseSchemaObject((TEXT*) tdgbl->status_vector[3]);
-					BURP_print_status(false, &tdgbl->status_vector);
+					BURP_print_status(&tdgbl->status_vector);
 					FOR (REQUEST_HANDLE req_handle3)
 						IDX IN RDB$INDICES
 						WITH IDX.RDB$SCHEMA_NAME EQUIV NULLIF(indexName.schema.c_str(), '') AND
@@ -378,25 +378,25 @@ int RESTORE_restore (const TEXT* file_name, const TEXT* database_name)
 						MODIFY IDX USING
 							IDX.RDB$INDEX_INACTIVE = TRUE;
 						END_MODIFY;
-						BURP_print(true, 240, indexName.toQuotedString().c_str());
+						BURP_print(240, indexName.toQuotedString().c_str());
 						// msg 240 Index \"%s\" failed to activate because:
 
 						if (error_code == isc_no_dup)
 						{
-							BURP_print(true, 241);
+							BURP_print(241);
 							// msg 241 The unique index has duplicate values or NULLs
-							BURP_print(true, 242);
+							BURP_print(242);
 							// msg 242 Delete or Update duplicate values or NULLs, and activate index with
 						}
 						else
 						{
-							BURP_print(true, 244);
+							BURP_print(244);
 							// msg 244 Not enough disk space to create the sort file for an index
-							BURP_print(true, 245);
+							BURP_print(245);
 							// msg 245 Set the TMP environment variable to a directory on a filesystem that does have enough space, and activate index with
 						}
 
-						BURP_print(true, 243, indexName.toQuotedString().c_str());
+						BURP_print(243, indexName.toQuotedString().c_str());
 						// msg 243 ALTER INDEX \"%s\" ACTIVE;
 					}
 					END_FOR
@@ -645,7 +645,7 @@ int RESTORE_restore (const TEXT* file_name, const TEXT* database_name)
 		(Arg::Gds(ENCODE_ISC_MSG(246, burp_msg_fac)) << Arg::Gds(ENCODE_ISC_MSG(247, burp_msg_fac))).copyTo(&st);
 			// msg 246 Database is not online due to failure to activate one or more indices.
 			// msg 247 Run gfix -online to bring database online without active indices.
-		BURP_print_status(true, &st);
+		BURP_print_status(&st, true);
 
 		return FINI_DB_NOT_ONLINE;
 	}
@@ -749,7 +749,7 @@ void add_files(BurpGlobals* tdgbl, const char* file_name)
 			file->fil_length -= start - 1;
 		else
 		{
-			BURP_print (false, 96, SafeArg() << file->fil_length << (start - 1));
+			BURP_print(96, SafeArg() << file->fil_length << (start - 1));
 			// msg 96  length given for initial file (%ld) is less than minimum (%ld)
 			file->fil_length = 0;
 		}
@@ -765,9 +765,9 @@ void add_files(BurpGlobals* tdgbl, const char* file_name)
 		COMMIT
 		// existing ON_ERROR continues past error, beck
 		ON_ERROR
-			BURP_print (true, 174);
+			BURP_print(174);
 			// msg 174 cannot commit files
-			BURP_print_status (false, &tdgbl->status_vector);
+			BURP_print_status(&tdgbl->status_vector);
 			ROLLBACK;
 			ON_ERROR
 				general_on_error ();
@@ -802,7 +802,7 @@ void bad_attribute(scan_attr_t scan_next_attr, att_type bad_attr, USHORT type)
 		static const SafeArg dummy;
 		TEXT t_name[128];
 		fb_msg_format(NULL, burp_msg_fac, type, sizeof(t_name), t_name, dummy);
-		BURP_print (false, 80, SafeArg() << t_name << int(bad_attr));
+		BURP_print(80, SafeArg() << t_name << int(bad_attr));
 		// msg 80  don't recognize %s attribute %ld -- continuing
 		int skip_l = get(tdgbl);
 		if (skip_l)
@@ -814,13 +814,13 @@ void bad_attribute(scan_attr_t scan_next_attr, att_type bad_attr, USHORT type)
 		{
 			skip_count = tdgbl->gbl_sw_skip_count;
 			get_skip(tdgbl, skip_count);
-			BURP_print (false, 203, SafeArg() << skip_count << int(bad_attr));
+			BURP_print(203, SafeArg() << skip_count << int(bad_attr));
 			// msg 203: skipped %d bytes after reading a bad attribute %d
 		}
 		else
 		{
 			++skip_count;
-			BURP_print (false, 205, SafeArg() << skip_count << int(bad_attr));
+			BURP_print(205, SafeArg() << skip_count << int(bad_attr));
 			// msg 205: skipped %d bytes looking for next valid attribute, encountered attribute %d
 		}
 		scan_next_attr = AFTER_SKIP;
@@ -968,14 +968,16 @@ void create_database(BurpGlobals* tdgbl, Firebird::IProvider* provider, const TE
 	}
 
 	if (record != rec_database)
-		BURP_error_redirect(NULL, 32);
+	{
+		BURP_error(32, true);
 		// msg 32 Expected database description record
+	}
 
 	if (tdgbl->gbl_sw_page_size)
 	{
 		if (tdgbl->gbl_sw_page_size < page_size)
 		{
-			BURP_print (false, 110, SafeArg() << page_size << tdgbl->gbl_sw_page_size);
+			BURP_print(110, SafeArg() << page_size << tdgbl->gbl_sw_page_size);
 			// msg 110 Reducing the database page size from %ld bytes to %ld bytes
 		}
 		page_size = tdgbl->gbl_sw_page_size;
@@ -1096,7 +1098,7 @@ void create_database(BurpGlobals* tdgbl, Firebird::IProvider* provider, const TE
 		provider->setDbCryptCallback(&status_vector, MVOL_get_crypt(tdgbl));
 		if (!status_vector.isSuccess())
 		{
-			BURP_print_status(true, &status_vector);
+			BURP_print_status(&status_vector, true);
 			BURP_exit_local(FINI_ERROR, tdgbl);
 		}
 	}
@@ -1126,7 +1128,7 @@ void create_database(BurpGlobals* tdgbl, Firebird::IProvider* provider, const TE
 
 	if (tdgbl->gbl_sw_version && !tdgbl->uSvc->isService())
 	{
-		BURP_print(false, 139, file_name);
+		BURP_message(139, SafeArg() << file_name);
 		// msg 139 Version(s) for database "%s"
 		OutputVersion outputVersion("\t%s\n");
 		Firebird::UtilInterfacePtr()->getFbVersion(&status_vector, DB, &outputVersion);
@@ -1266,7 +1268,7 @@ void decompress(BurpGlobals* tdgbl, UCHAR* buffer, ULONG length)
 		{
 			if (end - p < count)
 			{
-				BURP_print (false, 202, SafeArg() << count << (end - p));
+				BURP_print(202, SafeArg() << count << (end - p));
 				// msg 202: adjusting a decompression length error: invalid length  %d was adjusted to %d
 				count = end - p;
 			}
@@ -1276,7 +1278,7 @@ void decompress(BurpGlobals* tdgbl, UCHAR* buffer, ULONG length)
 		{
 			if (end + count < p)
 			{
-				BURP_print(false, 202, SafeArg() << count << (p - end));
+				BURP_print(202, SafeArg() << count << (p - end));
 				// msg 202: adjusting a decompression length error: invalid length %d was adjusted to %d
 				count = p - end;
 			}
@@ -1286,8 +1288,10 @@ void decompress(BurpGlobals* tdgbl, UCHAR* buffer, ULONG length)
 		}
 	}
 
-	if (p > end) {
-		BURP_error_redirect(NULL, 34); // msg 34 RESTORE: decompression length error
+	if (p > end)
+	{
+		BURP_error(34, true);
+		// msg 34 RESTORE: decompression length error
 	}
 }
 
@@ -1317,7 +1321,7 @@ SLONG get_compressed(BurpGlobals* tdgbl, UCHAR* buffer, SLONG length)
 		{
 			if (length < count)
 			{
-				//BURP_print(false, 202, SafeArg() << count << length);
+				//BURP_print(202, SafeArg() << count << length);
 				// msg 202: adjusting a decompression length error: invalid length  %d was adjusted to %d
 				count = length;
 			}
@@ -1328,7 +1332,7 @@ SLONG get_compressed(BurpGlobals* tdgbl, UCHAR* buffer, SLONG length)
 		{
 			if (length < -count)
 			{
-				//BURP_print(false, 202, SafeArg() << count << -length);
+				//BURP_print(202, SafeArg() << count << -length);
 				// msg 202: adjusting a decompression length error: invalid length %d was adjusted to %d
 				count = -length;
 			}
@@ -1338,8 +1342,10 @@ SLONG get_compressed(BurpGlobals* tdgbl, UCHAR* buffer, SLONG length)
 		}
 	}
 
-	if (length < 0) {
-		BURP_error_redirect(NULL, 34); // msg 34 RESTORE: decompression length error
+	if (length < 0)
+	{
+		BURP_error(34, true);
+		// msg 34 RESTORE: decompression length error
 	}
 
 	return p - buffer;
@@ -1409,7 +1415,7 @@ burp_rel* find_relation(BurpGlobals* tdgbl, const QualifiedMetaString& name)
 			return relation;
 	}
 
-	BURP_error_redirect(NULL, 35, SafeArg() << name.toQuotedString().c_str());
+	BURP_error(35, true, SafeArg() << name.toQuotedString().c_str());
 	// msg 35 can't find relation %s
 
 	return NULL;
@@ -1631,7 +1637,7 @@ bool get_acl(BurpGlobals* tdgbl, const TEXT* owner_nm, ISC_QUAD* blob_id, ISC_QU
 
 		default:
 			// msg 79 don't understand blob info item %ld
-			BURP_print (false, 79, SafeArg() << int(item));
+			BURP_print(79, SafeArg() << int(item));
 			// CVC: do you return, without closing the blob, dear function???
 			if (!blob.close())
 			{
@@ -1786,8 +1792,10 @@ void get_array(BurpGlobals* tdgbl, burp_rel* relation, UCHAR* record_buffer)
 				if (field->fld_number == field_number)
 					break;
 			}
-			if (!field) {
-				BURP_error_redirect(NULL, 36);	// msg 36 Can't find field for blob
+			if (!field)
+			{
+				BURP_error(36, true);
+				// msg 36 Can't find field for blob
 			}
 
 			field_length = field->fld_length;
@@ -2079,7 +2087,7 @@ void get_array(BurpGlobals* tdgbl, burp_rel* relation, UCHAR* record_buffer)
 					if (get_attribute(&attribute, tdgbl) != att_xdr_array)
 					{
 						// msg 55 Expected XDR record length
-						BURP_error_redirect(NULL, 55);
+						BURP_error(55, true);
 					}
 					else
 					{
@@ -2116,9 +2124,9 @@ void get_array(BurpGlobals* tdgbl, burp_rel* relation, UCHAR* record_buffer)
 						 elements_written * field->fld_length, (*buffer) + data_at);
 			if (status_vector->hasData())
 			{
-				BURP_print (true, 81, field->fld_name);
+				BURP_print(81, field->fld_name);
 				// msg 81 error accessing blob field %s -- continuing
-				BURP_print_status (true, &status_vector);
+				BURP_print_status(&status_vector, true);
 #ifdef DEBUG
 				PRETTY_print_sdl (blr_buffer, NULL, NULL, 0);
 #endif
@@ -2214,7 +2222,7 @@ void get_array(BurpGlobals* tdgbl, burp_rel* relation, UCHAR* record_buffer)
 		{
 			if (get_attribute(&attribute, tdgbl) != att_xdr_array)
 			{
-				BURP_error_redirect(NULL, 55);
+				BURP_error(55, true);
 				// msg 55 Expected XDR record length
 			}
 			else
@@ -2251,9 +2259,9 @@ void get_array(BurpGlobals* tdgbl, burp_rel* relation, UCHAR* record_buffer)
 					 return_length, *buffer);
 		if (status_vector->hasData())
 		{
-			BURP_print (false, 81, field->fld_name);
+			BURP_print(81, field->fld_name);
 			// msg 81 error accessing blob field %s -- continuing
-			BURP_print_status (false, &status_vector);
+			BURP_print_status(&status_vector);
 #ifdef DEBUG
 			PRETTY_print_sdl (blr_buffer, NULL, NULL, 0);
 #endif
@@ -2324,7 +2332,7 @@ void get_blob(BurpGlobals* tdgbl, IBatch* batch, const burp_fld* fields, UCHAR* 
 
 	if (!field)
 	{
-		BURP_error_redirect(NULL, 36);
+		BURP_error(36, true);
 		// msg 36 Can't find field for blob
 	}
 
@@ -3143,9 +3151,9 @@ static void check_data_error(BurpGlobals* tdgbl, IStatus* status_vector, const b
 	{
 		if (tdgbl->gbl_sw_incremental)
 		{
-			BURP_print(true, 138, relation->rel_name.toQuotedString().c_str());
+			BURP_print(138, relation->rel_name.toQuotedString().c_str());
 			// msg 138 validation error on field in relation %s
-			BURP_print_status(false, status_vector);
+			BURP_print_status(status_vector);
 		}
 		else
 			BURP_error_redirect(status_vector, 47);
@@ -3155,9 +3163,9 @@ static void check_data_error(BurpGlobals* tdgbl, IStatus* status_vector, const b
 	{
 		if (tdgbl->gbl_sw_incremental)
 		{
-			BURP_print(true, 114, relation->rel_name.toQuotedString().c_str());
+			BURP_print(114, relation->rel_name.toQuotedString().c_str());
 			// msg 114 restore failed for record in relation %s
-			BURP_print_status(false, status_vector, 342);	// isc_gbak_invalid_data
+			BURP_print_status(status_vector, false, 342);	// isc_gbak_invalid_data
 		}
 		else
 			BURP_error_redirect(status_vector, 342);	// isc_gbak_invalid_data
@@ -3166,9 +3174,9 @@ static void check_data_error(BurpGlobals* tdgbl, IStatus* status_vector, const b
 	{
 		if (tdgbl->gbl_sw_incremental && isc_sqlcode(status_vector->getErrors()) != -902)
 		{
-			BURP_print(true, 114, relation->rel_name.toQuotedString().c_str());
+			BURP_print(114, relation->rel_name.toQuotedString().c_str());
 			// msg 114 restore failed for record in relation %s
-			BURP_print_status(false, status_vector);
+			BURP_print_status(status_vector);
 		}
 		else
 			BURP_error_redirect(status_vector, 48);
@@ -3202,7 +3210,7 @@ static void commit_relation_data(BurpGlobals* tdgbl, burp_rel* relation)
 			case isc_sort_mem_err:
 			case isc_no_dup:
 				indexName = QualifiedMetaString::parseSchemaObject((TEXT*) tdgbl->status_vector[3]);
-				BURP_print_status(false, &tdgbl->status_vector);
+				BURP_print_status(&tdgbl->status_vector);
 
 				FOR(REQUEST_HANDLE req_handle)
 					IDX IN RDB$INDICES
@@ -3213,25 +3221,25 @@ static void commit_relation_data(BurpGlobals* tdgbl, burp_rel* relation)
 					{
 						IDX.RDB$INDEX_INACTIVE = TRUE;
 
-						BURP_print(true, 240, indexName.toQuotedString().c_str());
+						BURP_print(240, indexName.toQuotedString().c_str());
 						// msg 240 Index \"%s\" failed to activate because:
 
 						if (error_code == isc_no_dup)
 						{
-							BURP_print(true, 241);
+							BURP_print(241);
 							// msg 241 The unique index has duplicate values or NULLs
-							BURP_print(true, 242);
+							BURP_print(242);
 							// msg 242 Delete or Update duplicate values or NULLs, and activate index with
 						}
 						else
 						{
-							BURP_print(true, 244);
+							BURP_print(244);
 							// msg 244 Not enough disk space to create the sort file for an index
-							BURP_print(true, 245);
+							BURP_print(245);
 							// msg 245 Set the TMP environment variable to a directory on a filesystem that does have enough space, and activate index with
 						}
 
-						BURP_print(true, 243, indexName.toQuotedString().c_str());
+						BURP_print(243, indexName.toQuotedString().c_str());
 						// msg 243 ALTER INDEX \"%s\" ACTIVE
 					}
 					END_MODIFY
@@ -3245,9 +3253,9 @@ static void commit_relation_data(BurpGlobals* tdgbl, burp_rel* relation)
 				break;
 
 			default:
-				BURP_print(true, 69, relation->rel_name.toQuotedString().c_str());
+				BURP_print(69, relation->rel_name.toQuotedString().c_str());
 				// msg 69 commit failed on relation %s
-				BURP_print_status(false, &tdgbl->status_vector);
+				BURP_print_status(&tdgbl->status_vector);
 				ROLLBACK;
 				ON_ERROR
 					general_on_error();
@@ -3270,7 +3278,8 @@ void fix_exception(BurpGlobals* tdgbl, const QualifiedMetaString& name, scan_att
 		if (!failed_attrib)
 		{
 			failed_attrib = attribute;
-			BURP_print(false, 313, SafeArg() << failed_attrib << name.toQuotedString().c_str());
+			BURP_print(313, SafeArg() << failed_attrib << name.toQuotedString().c_str());
+			// msg 313 Trying to recover from unexpected attribute @1 due to wrong message length for exception @2
 		}
 
 		// Notice we use 1021 instead of 1023 because this is the maximum length
@@ -3351,7 +3360,10 @@ void get_data(BurpGlobals* tdgbl, burp_rel* relation, WriteRelationReq* req)
 			while (!task->isStopped())
 			{
 				if (get(tdgbl) != att_data_length)
-					BURP_error_redirect(NULL, 39); // msg 39 expected record length
+				{
+					BURP_error(39, true);
+					// msg 39 expected record length
+				}
 
 				RCRD_LENGTH len = get_int32(tdgbl);
 
@@ -3373,7 +3385,7 @@ void get_data(BurpGlobals* tdgbl, burp_rel* relation, WriteRelationReq* req)
 				{
 					if (get(tdgbl) != att_xdr_length)
 					{
-						BURP_error_redirect(NULL, 55);
+						BURP_error(55, true);
 						// msg 55 Expected XDR record length
 					}
 					else
@@ -3393,7 +3405,10 @@ void get_data(BurpGlobals* tdgbl, burp_rel* relation, WriteRelationReq* req)
 					p = buffer;
 
 				if (get(tdgbl) != att_data_data)
-					BURP_error_redirect(NULL, 41); // msg 41 expected data attribute
+				{
+					BURP_error(41, true);
+					// msg 41 expected data attribute
+				}
 
 				if (tdgbl->gbl_sw_compress)
 					decompress(tdgbl, p, len);
@@ -3568,7 +3583,7 @@ bool get_exception(BurpGlobals* tdgbl)
 					else if (!X.RDB$MESSAGE.NULL)
 					{
 						msg_seen = true;
-						BURP_print(false, 312, SafeArg() << attribute << name.toQuotedString().c_str());
+						BURP_print(312, SafeArg() << attribute << name.toQuotedString().c_str());
 						eat_text(tdgbl);
 					}
 					else
@@ -3585,7 +3600,7 @@ bool get_exception(BurpGlobals* tdgbl)
 						BURP_error(311, true, SafeArg() << attribute << name.toQuotedString().c_str());
 					else if (!X.RDB$MESSAGE.NULL)
 					{
-						BURP_print(false, 312, SafeArg() << attribute << name.toQuotedString().c_str());
+						BURP_print(312, SafeArg() << attribute << name.toQuotedString().c_str());
 						eat_text2(tdgbl);
 					}
 					else
@@ -3717,7 +3732,7 @@ bool get_exception(BurpGlobals* tdgbl)
 					else if (!X.RDB$MESSAGE.NULL)
 					{
 						msg_seen = true;
-						BURP_print(false, 312, SafeArg() << attribute << name.toQuotedString().c_str());
+						BURP_print(312, SafeArg() << attribute << name.toQuotedString().c_str());
 						eat_text(tdgbl);
 					}
 					else
@@ -3734,7 +3749,7 @@ bool get_exception(BurpGlobals* tdgbl)
 						BURP_error(311, true, SafeArg() << attribute << name.toQuotedString().c_str());
 					else if (!X.RDB$MESSAGE.NULL)
 					{
-						BURP_print(false, 312, SafeArg() << attribute << name.toQuotedString().c_str());
+						BURP_print(312, SafeArg() << attribute << name.toQuotedString().c_str());
 						eat_text2(tdgbl);
 					}
 					else
@@ -8262,9 +8277,9 @@ bool get_relation(BurpGlobals* tdgbl, Coordinator* coord, RestoreRelationTask* t
 				COMMIT
 				// existing ON_ERROR continues past error, beck
 				ON_ERROR
-					BURP_print(false, 171, relation->rel_name.toQuotedString().c_str());
+					BURP_print(171, relation->rel_name.toQuotedString().c_str());
 					// msg 171: error committing metadata for relation %s
-					BURP_print_status (false, &tdgbl->status_vector);
+					BURP_print_status(&tdgbl->status_vector);
 					ROLLBACK;
 					ON_ERROR
 						general_on_error ();
@@ -8453,8 +8468,10 @@ bool get_relation_data(BurpGlobals* tdgbl, Coordinator* coord, RestoreRelationTa
 	}
 
 	if (!relation)
-		BURP_error_redirect(NULL, 49);
-	// msg 49 no relation name for data
+	{
+		BURP_error(49, true);
+		// msg 49 no relation name for data
+	}
 
 	// Eat up misc. records
 	rec_type record;
@@ -8699,7 +8716,10 @@ bool get_sql_roles(BurpGlobals* tdgbl)
 					{
 						const ULONG l = get(tdgbl);
 						if (l > sizeof(X.RDB$SYSTEM_PRIVILEGES))
-							BURP_error_redirect(NULL, 46);	// msg 46 string truncated
+						{
+							BURP_error(46, true);
+							// msg 46 string truncated
+						}
 
 						if (l)
 							get_block(tdgbl, (UCHAR*) (X.RDB$SYSTEM_PRIVILEGES), l);
@@ -9106,7 +9126,7 @@ bool get_db_creator(BurpGlobals* tdgbl)
 
 			BURP_verbose(393, MetaString(usr).toQuotedString());
 			if (strlen(usr) > sizeof(C.RDB$USER))
-				BURP_error_redirect(NULL, 46);
+				BURP_error(46, true);
 
 			C.RDB$USER.NULL = userSet ? FALSE : TRUE;
 			if (userSet)
@@ -9190,7 +9210,7 @@ bool get_security_class(BurpGlobals* tdgbl)
 				is_valid_sec_class = is_ascii_name(X.RDB$SECURITY_CLASS, name.length());
 				if (!is_valid_sec_class)
 				{
-					BURP_print(false, 234, name.toQuotedString().c_str());
+					BURP_print(234, name.toQuotedString().c_str());
 					// msg 234   Skipped bad security class entry: %s
 					break;
 				}
@@ -9335,8 +9355,10 @@ USHORT get_text(BurpGlobals* tdgbl, TEXT* text, ULONG length)
 	const ULONG l = get(tdgbl);
 
 	if (length <= l)
-		BURP_error_redirect(NULL, 46);
+	{
+		BURP_error(46, true);
 		// msg 46 string truncated
+	}
 
 	if (l)
 		text = (TEXT*) get_block(tdgbl, (UCHAR*) text, l);
@@ -9364,7 +9386,7 @@ USHORT get_text2(BurpGlobals* tdgbl, TEXT* text, ULONG length)
 
 	if (length <= len)
 	{
-		BURP_error_redirect(NULL, 46);
+		BURP_error(46, true);
 		// msg 46 string truncated
 	}
 
@@ -9482,9 +9504,9 @@ bool get_trigger_old (BurpGlobals* tdgbl, burp_rel* relation)
 		COMMIT
 		// existing ON_ERROR continues past error, beck
 		ON_ERROR
-			BURP_print (false, 94, name);
+			BURP_print(94, name);
 			// msg 94 trigger %s is invalid
-			BURP_print_status(false, &tdgbl->status_vector);
+			BURP_print_status(&tdgbl->status_vector);
 			ROLLBACK;
 			ON_ERROR
 				general_on_error ();
@@ -9861,9 +9883,9 @@ bool get_trigger(BurpGlobals* tdgbl)
 		COMMIT
 		// existing ON_ERROR continues past error, beck
 		ON_ERROR
-			BURP_print(false, 94, name.toQuotedString().c_str());
+			BURP_print(94, name.toQuotedString().c_str());
 			// msg 94 trigger %s is invalid
-			BURP_print_status(false, &tdgbl->status_vector);
+			BURP_print_status(&tdgbl->status_vector);
 			ROLLBACK;
 			ON_ERROR
 				general_on_error ();
@@ -9979,9 +10001,9 @@ bool get_trigger_message(BurpGlobals* tdgbl)
 		COMMIT
 		// existing ON_ERROR continues past error, beck
 		ON_ERROR
-			BURP_print(false, 94, name.toQuotedString().c_str());
+			BURP_print(94, name.toQuotedString().c_str());
 			// msg 94 trigger %s is invalid
-			BURP_print_status(false, &tdgbl->status_vector);
+			BURP_print_status(&tdgbl->status_vector);
 			ROLLBACK;
 			ON_ERROR
 				general_on_error ();
@@ -10353,7 +10375,7 @@ bool get_user_privilege(BurpGlobals* tdgbl)
 		ON_ERROR
 			if (tdgbl->status_vector->getErrors()[1] == isc_integ_fail)
 			{
-				BURP_print_status(false, &tdgbl->status_vector);
+				BURP_print_status(&tdgbl->status_vector);
 				tdgbl->flag_on_line = false;
 				return true;
 			}
@@ -10556,8 +10578,10 @@ void ignore_array(BurpGlobals* tdgbl, burp_rel* relation)
 					break;
 			}
 			if (!field)
-				BURP_error_redirect(NULL, 36);
+			{
+				BURP_error(36, true);
 				// msg 36 Can't find field for blob
+			}
 			break;
 
 		case att_array_dimensions:
@@ -10594,8 +10618,10 @@ void ignore_array(BurpGlobals* tdgbl, burp_rel* relation)
 	if (tdgbl->gbl_sw_transportable)
 	{
 		if (get_attribute(&attribute, tdgbl) != att_xdr_array)
-			BURP_error_redirect(NULL, 55);
+		{
+			BURP_error(55, true);
 			// msg 55 Expected XDR record length
+		}
 		else
 		{
 			lcount = get(tdgbl);
@@ -10691,20 +10717,26 @@ rec_type ignore_data(BurpGlobals* tdgbl, burp_rel* relation)
 		while (true)
 		{
 			if (get(tdgbl) != att_data_length)
-				BURP_error_redirect(NULL, 39);
+			{
+				BURP_error(39, true);
 				// msg 39 expected record length
+			}
 			USHORT len = (USHORT) get_int32(tdgbl);
 			if (tdgbl->gbl_sw_transportable)
 			{
 				if (get(tdgbl) != att_xdr_length)
-					BURP_error_redirect(NULL, 55);
+				{
+					BURP_error(55, true);
 					// msg 55 Expected XDR record length
+				}
 				else
 					len = (USHORT) get_int32(tdgbl);
 			}
 			if (get(tdgbl) != att_data_data)
-				BURP_error_redirect(NULL, 41);
+			{
+				BURP_error(41, true);
 				// msg 41 expected data attribute
+			}
 			if (len)
 			{
 				if (tdgbl->gbl_sw_compress)
@@ -11754,14 +11786,16 @@ void store_blr_gen_id(BurpGlobals* tdgbl, const QualifiedMetaString& gen_name, S
 	if (status_vector->hasData())
 	{
 		fb_print_blr(blr_buffer, blr_length, NULL, NULL, 0);
-		BURP_error_redirect(&status_vector, 42); // msg 42 Failed in store_blr_gen_id
+		BURP_error_redirect(&status_vector, 42);
+		// msg 42 Failed in store_blr_gen_id
 	}
 
 	gen_id_reqh->start(&status_vector, gds_trans, 0);
 	if (status_vector->hasData())
 	{
 		fb_print_blr(blr_buffer, blr_length, NULL, NULL, 0);
-		BURP_error_redirect(&status_vector, 42); // msg 42 Failed in store_blr_gen_id
+		BURP_error_redirect(&status_vector, 42);
+		// msg 42 Failed in store_blr_gen_id
 	}
 
 	BURP_verbose (185, SafeArg() << gen_name.toQuotedString().c_str() << value);
@@ -12167,7 +12201,7 @@ void fix_generator(BurpGlobals* tdgbl, const FixGenerator* g)
 
 		if (tdgbl->status_vector->getErrors()[1] == isc_dsql_error)
 		{
-			BURP_print_status(false, &tdgbl->status_vector);
+			BURP_print_status(&tdgbl->status_vector);
 			tdgbl->flag_on_line = false;
 		}
 		else
@@ -13236,7 +13270,7 @@ IBatch* WriteRelationMeta::createBatch(BurpGlobals* tdgbl, IAttachment* att)
 	if (fbStatus->hasData())
 	{
 		if (m_batchOk)
-			BURP_print_status(true, fbStatus);
+			BURP_print_status(fbStatus, true);
 	}
 	else if (!m_batchOk)
 	{
@@ -13309,7 +13343,7 @@ IBatch* WriteRelationMeta::createBatch(BurpGlobals* tdgbl, IAttachment* att)
 	BURP_verbose(371, m_relation->rel_name.toQuotedString());
 	// msg 371 could not start batch when restoring table @1, trying old way
 
-	//BURP_print_status(false, fbStatus);
+	//BURP_print_status(fbStatus);
 
 	// Possible reason of fail - use of keywords as fields in old backup of dialect1 DB
 	// Try to roll back to use of old version (fieldnames independent)
@@ -13843,7 +13877,7 @@ bool RestoreRelationTask::fileReader(Item& item)
 		//	<att_data_data> <data>
 
 		if (get(tdgbl) != att_data_length)
-			BURP_error_redirect(NULL, 39); // msg 39 expected record length
+			BURP_error(39, true); // msg 39 expected record length
 
 		RCRD_LENGTH len = get_int32(tdgbl);
 
@@ -13856,14 +13890,16 @@ bool RestoreRelationTask::fileReader(Item& item)
 		if (tdgbl->gbl_sw_transportable)
 		{
 			if (get(tdgbl) != att_xdr_length)
-				BURP_error_redirect(NULL, 55);
+			{
+				BURP_error(55, true);
 				// msg 55 Expected XDR record length
+			}
 			else
 				len = get_int32(tdgbl);
 		}
 
 		if (get(tdgbl) != att_data_data)
-			BURP_error_redirect(NULL, 41); // msg 41 expected data attribute
+			BURP_error(41, true); // msg 41 expected data attribute
 
 		// check if record fits into current buffer and get a new one if needed
 		// note, non-compressible record takes 1 additional byte per every 127 bytes
@@ -14171,7 +14207,7 @@ IOBuffer* RestoreRelationTask::read_array(BurpGlobals* tdgbl, IOBuffer* ioBuf)
 		if (get_attribute(&attribute, tdgbl) != att_xdr_array)
 		{
 			// msg 55 Expected XDR record length
-			BURP_error_redirect(NULL, 55);
+			BURP_error(55, true);
 		}
 		else
 		{


### PR DESCRIPTION
Currently in standalone application mode when redirect to the standard stream, for example:
`gbak ... > /path/to/stdout.log`
some error and warning messages may be missed, which may cause inconvenience.

For example, during when restore we may see an error message:
```
gbak: ERROR:Database is not online due to failure to activate one or more indices.
gbak: ERROR:    Run gfix -online to bring database online without active indices.
```
but in order to find out which index remains inactive, we need to look at the entire log, and in it we can already find:
```
gbak:cannot commit index TEST_INDEX
gbak: ERROR:attempt to store duplicate value (visible to active transactions) in unique index "TEST_INDEX"
gbak: ERROR:    Problematic key value is ("ID" = 1)
```

Although in the global community it is accepted to output all errors and warnings to stderr.

This patch fixes this bug. I tried to cover all the cases found, but may have missed something.
I believe `BURP_print_status` should always output to stderr, regardless of whether the `err` argument is set to true or not. The `err` argument is now only responsible for setting status in service mode. Also `BURP_print_warning` should always output to stderr.