### PR TITLE
refactor(vio): Initialize schema search path statically in `VIO_store()` to remove unnecessary memory allocations

### DIFF
--- a/src/common/classes/init.h
+++ b/src/common/classes/init.h
@@ -147,10 +147,11 @@ public:
 		FB_NEW InstanceControl::InstanceLink<GlobalPtr, P>(this);
 	}
 
-	template <std::invocable TFunc>
+	template <typename TFunc>
+		requires(std::invocable<TFunc, MemoryPool&>)
 	GlobalPtr(TFunc initializationFunc)
 	{
-		instance = initializationFunc();
+		instance = initializationFunc(*getDefaultMemoryPool());
 		FB_NEW InstanceControl::InstanceLink<GlobalPtr, P>(this);
 	}
 
@@ -171,6 +172,7 @@ public:
 	{
 		return instance;
 	}
+
 	const T* get() const noexcept
 	{
 		return instance;

--- a/src/common/classes/init.h
+++ b/src/common/classes/init.h
@@ -147,6 +147,13 @@ public:
 		FB_NEW InstanceControl::InstanceLink<GlobalPtr, P>(this);
 	}
 
+	template <std::invocable TFunc>
+	GlobalPtr(TFunc initializationFunc)
+	{
+		instance = initializationFunc();
+		FB_NEW InstanceControl::InstanceLink<GlobalPtr, P>(this);
+	}
+
 	T* operator->() noexcept
 	{
 		return instance;
@@ -156,6 +163,15 @@ public:
 		return *instance;
 	}
 	T* operator&() noexcept
+	{
+		return instance;
+	}
+
+	T* get() noexcept
+	{
+		return instance;
+	}
+	const T* get() const noexcept
 	{
 		return instance;
 	}

--- a/src/common/classes/init.h
+++ b/src/common/classes/init.h
@@ -303,64 +303,6 @@ public:
 	}
 };
 
-template <typename T>
-class DefaultNonLazyInstanceAllocator
-{
-public:
-	template <typename... TArgs>
-	static T* create(TArgs&&... args)
-	{
-		return FB_NEW_POOL(*getDefaultMemoryPool()) T(std::forward<TArgs>(args)...);
-	}
-
-	static void destroy(T* inst) noexcept
-	{
-		delete inst;
-	}
-};
-
-// Best use case is for static local variable
-template <typename T, class TAllocator = DefaultNonLazyInstanceAllocator<T>, template <class I> class DestroyControl = DeleteInstance >
-class NonLazyInitInstance : private DestroyControl<NonLazyInitInstance<T, TAllocator, DestroyControl> >
-{
-public:
-	template <typename... TArgs>
-	NonLazyInitInstance(TArgs&&... args)
-	{
-		MutexLockGuard guard(*StaticMutex::mutex, "NonLazyInitInstance");
-		m_instance = TAllocator::create(std::forward<TArgs>(args)...);
-		DestroyControl<std::remove_cvref_t<decltype(*this)>>::registerInstance(this);
-	}
-
-	T& operator()() noexcept
-	{
-		return *m_instance;
-	}
-	const T& operator()() const noexcept
-	{
-		return *m_instance;
-	}
-
-	T* get() noexcept
-	{
-		return m_instance;
-	}
-	const T* get() const noexcept
-	{
-		return m_instance;
-	}
-
-	void dtor()
-	{
-		MutexLockGuard guard(*StaticMutex::mutex, "NonLazyInitInstance - dtor");
-		TAllocator::destroy(m_instance);
-		m_instance = nullptr;
-	}
-
-private:
-	T* m_instance = nullptr;
-};
-
 // Static - create instance of some class in static char[] buffer. Never destroy it.
 
 template <typename T>

--- a/src/jrd/vio.cpp
+++ b/src/jrd/vio.cpp
@@ -4223,9 +4223,10 @@ void VIO_store(thread_db* tdbb, record_param* rpb, jrd_tra* transaction)
 			}},
 		};
 
-		static const NonLazyInitInstance<ObjectsArray<MetaString>> schemaSearchPath(
-			*getDefaultMemoryPool(), std::initializer_list<MetaString>{SYSTEM_SCHEMA, PUBLIC_SCHEMA}
-		);
+		static const GlobalPtr<ObjectsArray<MetaString>> schemaSearchPath([]()
+		{
+			return FB_NEW_POOL(*getDefaultMemoryPool()) ObjectsArray<MetaString>(*getDefaultMemoryPool(), {SYSTEM_SCHEMA, PUBLIC_SCHEMA});
+		});
 
 		if (const auto relSchemaFields = schemaFields.find(relation->rel_id); relSchemaFields != schemaFields.end())
 		{

--- a/src/jrd/vio.cpp
+++ b/src/jrd/vio.cpp
@@ -4223,7 +4223,9 @@ void VIO_store(thread_db* tdbb, record_param* rpb, jrd_tra* transaction)
 			}},
 		};
 
-		ObjectsArray<MetaString> schemaSearchPath({SYSTEM_SCHEMA, PUBLIC_SCHEMA});
+		static const NonLazyInitInstance<ObjectsArray<MetaString>> schemaSearchPath(
+			*getDefaultMemoryPool(), std::initializer_list<MetaString>{SYSTEM_SCHEMA, PUBLIC_SCHEMA}
+		);
 
 		if (const auto relSchemaFields = schemaFields.find(relation->rel_id); relSchemaFields != schemaFields.end())
 		{
@@ -4242,7 +4244,7 @@ void VIO_store(thread_db* tdbb, record_param* rpb, jrd_tra* transaction)
 					{
 						MOV_get_metaname(tdbb, &desc, depName.object);
 
-						if (MET_qualify_existing_name(tdbb, depName, {dependency->objType}, &schemaSearchPath))
+						if (MET_qualify_existing_name(tdbb, depName, {dependency->objType}, schemaSearchPath.get()))
 							schemaName = depName.schema.c_str();
 					}
 

--- a/src/jrd/vio.cpp
+++ b/src/jrd/vio.cpp
@@ -4223,9 +4223,9 @@ void VIO_store(thread_db* tdbb, record_param* rpb, jrd_tra* transaction)
 			}},
 		};
 
-		static const GlobalPtr<ObjectsArray<MetaString>> schemaSearchPath([]()
+		static const GlobalPtr<ObjectsArray<MetaString>> schemaSearchPath([](MemoryPool& pool)
 		{
-			return FB_NEW_POOL(*getDefaultMemoryPool()) ObjectsArray<MetaString>(*getDefaultMemoryPool(), {SYSTEM_SCHEMA, PUBLIC_SCHEMA});
+			return FB_NEW_POOL(pool) ObjectsArray<MetaString>(pool, {SYSTEM_SCHEMA, PUBLIC_SCHEMA});
 		});
 
 		if (const auto relSchemaFields = schemaFields.find(relation->rel_id); relSchemaFields != schemaFields.end())


### PR DESCRIPTION
Recently, I have comparing flamegraphs for gbak restore v5 vs v6, found that VIO_store takes longer in v6 than in v5.
About 25% of the execution time of `VIO_store()` was taken up by `MemPool::allocate()` and `~ObjectsArray()`. As I can see these function calls related to new schema code, so they are not present in the v5 flame graph.

I have made `schemaSearchPath` static, and these calls was removed from flamegraphs, and restore speed for my test table (`create table tab1(v1 varchar(25), v2 varchar(25), v3 varchar(25), v4 varchar(25));`) increased by ~5%.