### PR TITLE
Fix #8799: BUGCHECK "decompression overran buffer (179)" when WITH LOCK clause is used

### DIFF
--- a/src/jrd/vio.cpp
+++ b/src/jrd/vio.cpp
@@ -6557,6 +6557,8 @@ static PrepareResult prepare_update(thread_db* tdbb, jrd_tra* transaction, TraNu
 
 	if (new_rpb)
 	{
+		new_rpb->rpb_flags &= ~rpb_delta;
+
 		// If both descriptors share the same record, there cannot be any difference.
 		// This trick is used by VIO_writelock(), but can be a regular practice as well.
 		if (new_rpb->rpb_address == temp->rpb_address)


### PR DESCRIPTION
`VIO_writelock` creates `new_rpb` by copying from `org_rpb` which has `rpb_delta` flag set. `new_rpb` is passed to `prepare_update`. It creates a delta but its size exceeds the limit (1024) so the current version is stored as a regular record. The problem is that `rpb_delta` flag remains set for `new_rpb`, and then `replace_record` sets it in the header of the primary version. From this moment any attempt to get data of older versions fails.
The fix is to let `prepare_update` clear `rpb_delta` flag from `new_rpb` just before an attempt to generate a delta.