### PR TITLE
Per pagespace I/O statistics and new trace API interfaces to allow extendable statistics

### DIFF
--- a/doc/Using_OO_API.md
+++ b/doc/Using_OO_API.md
@@ -2136,9 +2136,9 @@ If `getCounters()` is called with a counter group not supported by the implement
 <a name="PerformanceCounters"></a> PerformanceCounters interface:
 
 - unsigned getObjectCount() - returns number of objects (e.g. tables) containing non-zero performance counters
-- unsigned getCountersCapacity() - returns total number of performance counters supported by the implementation (it's the same for all objects of the same type)
+- unsigned getMaxCounterIndex() - returns maximum index number of the performance counters supported by the implementation (it's the same for all objects of the same group)
 - unsigned getObjectId(unsigned index) - returns ID of the specified object
 - const char* getObjectName(unsigned index) - returns name of the specified object
-- const ISC_INT64* getObjectCounters(unsigned index) - returns pointer to the vector of performance counters (containing getCountersCapacity() elements) of the specified object
+- const ISC_INT64* getObjectCounters(unsigned index) - returns pointer to the vector of performance counters (containing getMaxCounterIndex() + 1 elements) of the specified object
 
 The returned pointer to the vector (as well as the whole instance of `PerformanceStats`) is valid until the object used to obtain the statistics (using the `getPerfStats()` method) is destroyed.

--- a/doc/Using_OO_API.md
+++ b/doc/Using_OO_API.md
@@ -2124,8 +2124,14 @@ The returned pointer may be `nullptr` if the corresponding trace object is not i
 
 - ISC_UINT64 getElapsedTime() - returns the elapsed time, in milliseconds
 - ISC_UINT64 getFetchedRecords() - returns number of records fetched during execution
-- IPerformanceCounters* getPageCounters() - returns per-pagespace performance counters
-- IPerformanceCounters* getTableCounters() - returns per-table performance counters
+- IPerformanceCounters* getCounters(unsigned group) - returns the requested performance counters group
+
+The following groups of performance counters are currently supported:
+
+- COUNTER_GROUP_PAGES - per-pagespace counters
+- COUNTER_GROUP_TABLES - per-table counters
+
+If `getCounters()` is called with a counter group not supported by the implementation, `nullptr` is returned.
 
 <a name="PerformanceCounters"></a> PerformanceCounters interface:
 

--- a/doc/Using_OO_API.md
+++ b/doc/Using_OO_API.md
@@ -2101,3 +2101,38 @@ struct FbVarChar
 
 This document is currently missing 2 types of plugins – ExternalEngine and Trace. Information about them will be made
 available in next release of it.
+
+# Trace plugin
+
+_TODO_
+
+# Trace objects
+
+_TODO_
+
+# Trace performance statistics
+
+Trace plugin may retrieve various performance statistics available using the `getPerfStats()` method of the trace object, which returns a pointer to the `IPerformanceStats` interface.
+
+```cpp
+IPerformanceStats* stats = statement->getPerfStats();
+```
+
+The returned pointer may be `nullptr` if the corresponding trace object is not in the terminate state yet (i.e. still active / being executed).
+
+<a name="PerformanceStats"></a> PerformanceStats interface:
+
+- ISC_UINT64 getElapsedTime() - returns the elapsed time, in milliseconds
+- ISC_UINT64 getFetchedRecords() - returns number of records fetched during execution
+- IPerformanceCounters* getPageCounters() - returns per-pagespace performance counters
+- IPerformanceCounters* getTableCounters() - returns per-table performance counters
+
+<a name="PerformanceCounters"></a> PerformanceCounters interface:
+
+- unsigned getObjectCount() - returns number of objects (e.g. tables) containing non-zero performance counters
+- unsigned getCountersCapacity() - returns total number of performance counters supported by the implementation (it's the same for all objects of the same type)
+- unsigned getObjectId(unsigned index) - returns ID of the specified object
+- const char* getObjectName(unsigned index) - returns name of the specified object
+- const ISC_INT64* getObjectCounters(unsigned index) - returns pointer to the vector of performance counters (containing getCountersCapacity() elements) of the specified object
+
+The returned pointer to the vector (as well as the whole instance of `PerformanceStats`) is valid until the object used to obtain the statistics (using the `getPerfStats()` method) is destroyed.

--- a/src/include/firebird/FirebirdInterface.idl
+++ b/src/include/firebird/FirebirdInterface.idl
@@ -1899,12 +1899,35 @@ interface ProfilerStats : Versioned
 
 interface PerformanceCounters : Versioned
 {
-	uint getCount();
-	uint getVectorCapacity();
+	// Page-level performance counters (grouped per tablespace)
+	const uint PAGE_FETCHES = 0;
+	const uint PAGE_READS = 1;
+	const uint PAGE_MARKS = 2;
+	const uint PAGE_WRITES = 3;
 
-	uint getId(uint index);
-	const string getName(uint index);
-	const int64* getCounterVector(uint index);
+	// Record-level performance counters (grouped per table)
+	const uint RECORD_SEQ_READS = 0;
+	const uint RECORD_IDX_READS = 1;
+	const uint RECORD_UPDATES = 2;
+	const uint RECORD_INSERTS = 3;
+	const uint RECORD_DELETES = 4;
+	const uint RECORD_BACKOUTS = 5;
+	const uint RECORD_PURGES = 6;
+	const uint RECORD_EXPUNGES = 7;
+	const uint RECORD_LOCKS = 8;
+	const uint RECORD_WAITS = 9;
+	const uint RECORD_CONFLICTS = 10;
+	const uint RECORD_BACK_READS = 11;
+	const uint RECORD_FRAGMENT_READS = 12;
+	const uint RECORD_RPT_READS = 13;
+	const uint RECORD_IMGC = 14;
+
+	uint getObjectCount();
+	uint getCountersCapacity();
+
+	uint getObjectId(uint index);
+	const string getObjectName(uint index);
+	const int64* getObjectCounters(uint index);
 }
 
 interface PerformanceStats : Versioned
@@ -1912,8 +1935,7 @@ interface PerformanceStats : Versioned
 	uint64 getElapsedTime();	// in milliseconds
 	uint64 getFetchedRecords();
 
-	PerformanceCounters getGlobalCounters();
 	PerformanceCounters getPageCounters();
-	PerformanceCounters getRelationCounters();
+	PerformanceCounters getTableCounters();
 }
 

--- a/src/include/firebird/FirebirdInterface.idl
+++ b/src/include/firebird/FirebirdInterface.idl
@@ -1923,7 +1923,7 @@ interface PerformanceCounters : Versioned
 	const uint RECORD_IMGC = 14;
 
 	uint getObjectCount();
-	uint getCountersCapacity();
+	uint getMaxCounterIndex();
 
 	uint getObjectId(uint index);
 	const string getObjectName(uint index);

--- a/src/include/firebird/FirebirdInterface.idl
+++ b/src/include/firebird/FirebirdInterface.idl
@@ -1932,10 +1932,12 @@ interface PerformanceCounters : Versioned
 
 interface PerformanceStats : Versioned
 {
+	const uint COUNTER_GROUP_PAGES = 0;
+	const uint COUNTER_GROUP_TABLES = 1;
+
 	uint64 getElapsedTime();	// in milliseconds
 	uint64 getFetchedRecords();
 
-	PerformanceCounters getPageCounters();
-	PerformanceCounters getTableCounters();
+	PerformanceCounters getCounters(uint group);
 }
 

--- a/src/include/firebird/FirebirdInterface.idl
+++ b/src/include/firebird/FirebirdInterface.idl
@@ -1364,6 +1364,9 @@ interface TraceTransaction : Versioned
 version: // 3.0.4 -> 3.0.5
 	int64 getInitialID();
 	int64 getPreviousID();
+
+version: // 5.0 -> 6.0
+	PerformanceStats getPerfStats();
 }
 
 interface TraceParams : Versioned
@@ -1379,6 +1382,9 @@ interface TraceStatement : Versioned
 {
 	int64 getStmtID();
 	PerformanceInfo* getPerf();
+
+version: // 5.0 -> 6.0
+	PerformanceStats getPerfStats();
 }
 
 interface TraceSQLStatement : TraceStatement
@@ -1421,6 +1427,9 @@ version: // 4.0 -> 5.0
 	int64 getStmtID();
 	const string getPlan();
 	const string getExplainedPlan();
+
+version: // 5.0 -> 6.0
+	PerformanceStats getPerfStats();
 }
 
 interface TraceFunction : Versioned
@@ -1434,6 +1443,9 @@ version: // 4.0 -> 5.0
 	int64 getStmtID();
 	const string getPlan();
 	const string getExplainedPlan();
+
+version: // 5.0 -> 6.0
+	PerformanceStats getPerfStats();
 }
 
 interface TraceTrigger : Versioned
@@ -1456,6 +1468,9 @@ version: // 4.0 -> 5.0
 	int64 getStmtID();
 	const string getPlan();
 	const string getExplainedPlan();
+
+version: // 5.0 -> 6.0
+	PerformanceStats getPerfStats();
 }
 
 interface TraceServiceConnection : TraceConnection
@@ -1480,6 +1495,9 @@ interface TraceSweepInfo : Versioned
 	int64 getOAT();
 	int64 getNext();
 	PerformanceInfo* getPerf();
+
+version: // 5.0 -> 6.0
+	PerformanceStats getPerfStats();
 }
 
 interface TraceLogWriter : ReferenceCounted
@@ -1876,3 +1894,26 @@ interface ProfilerStats : Versioned
 {
 	uint64 getElapsedTicks();
 }
+
+// Extendable replacement for struct PerformanceInfo
+
+interface PerformanceCounters : Versioned
+{
+	uint getCount();
+	uint getVectorCapacity();
+
+	uint getId(uint index);
+	const string getName(uint index);
+	const int64* getCounterVector(uint index);
+}
+
+interface PerformanceStats : Versioned
+{
+	uint64 getElapsedTime();	// in milliseconds
+	uint64 getFetchedRecords();
+
+	PerformanceCounters getGlobalCounters();
+	PerformanceCounters getPageCounters();
+	PerformanceCounters getRelationCounters();
+}
+

--- a/src/include/firebird/IdlFbInterfaces.h
+++ b/src/include/firebird/IdlFbInterfaces.h
@@ -143,6 +143,8 @@ namespace Firebird
 	class IProfilerPlugin;
 	class IProfilerSession;
 	class IProfilerStats;
+	class IPerformanceCounters;
+	class IPerformanceStats;
 
 	// Interfaces declarations
 
@@ -5458,7 +5460,7 @@ namespace Firebird
 		}
 	};
 
-#define FIREBIRD_ITRACE_TRANSACTION_VERSION 3u
+#define FIREBIRD_ITRACE_TRANSACTION_VERSION 4u
 
 	class ITraceTransaction : public IVersioned
 	{
@@ -5472,6 +5474,7 @@ namespace Firebird
 			PerformanceInfo* (CLOOP_CARG *getPerf)(ITraceTransaction* self) CLOOP_NOEXCEPT;
 			ISC_INT64 (CLOOP_CARG *getInitialID)(ITraceTransaction* self) CLOOP_NOEXCEPT;
 			ISC_INT64 (CLOOP_CARG *getPreviousID)(ITraceTransaction* self) CLOOP_NOEXCEPT;
+			IPerformanceStats* (CLOOP_CARG *getPerfStats)(ITraceTransaction* self) CLOOP_NOEXCEPT;
 		};
 
 	protected:
@@ -5542,6 +5545,16 @@ namespace Firebird
 			ISC_INT64 ret = static_cast<VTable*>(this->cloopVTable)->getPreviousID(this);
 			return ret;
 		}
+
+		IPerformanceStats* getPerfStats()
+		{
+			if (cloopVTable->version < 4)
+			{
+				return 0;
+			}
+			IPerformanceStats* ret = static_cast<VTable*>(this->cloopVTable)->getPerfStats(this);
+			return ret;
+		}
 	};
 
 #define FIREBIRD_ITRACE_PARAMS_VERSION 3u
@@ -5596,7 +5609,7 @@ namespace Firebird
 		}
 	};
 
-#define FIREBIRD_ITRACE_STATEMENT_VERSION 2u
+#define FIREBIRD_ITRACE_STATEMENT_VERSION 3u
 
 	class ITraceStatement : public IVersioned
 	{
@@ -5605,6 +5618,7 @@ namespace Firebird
 		{
 			ISC_INT64 (CLOOP_CARG *getStmtID)(ITraceStatement* self) CLOOP_NOEXCEPT;
 			PerformanceInfo* (CLOOP_CARG *getPerf)(ITraceStatement* self) CLOOP_NOEXCEPT;
+			IPerformanceStats* (CLOOP_CARG *getPerfStats)(ITraceStatement* self) CLOOP_NOEXCEPT;
 		};
 
 	protected:
@@ -5631,9 +5645,19 @@ namespace Firebird
 			PerformanceInfo* ret = static_cast<VTable*>(this->cloopVTable)->getPerf(this);
 			return ret;
 		}
+
+		IPerformanceStats* getPerfStats()
+		{
+			if (cloopVTable->version < 3)
+			{
+				return 0;
+			}
+			IPerformanceStats* ret = static_cast<VTable*>(this->cloopVTable)->getPerfStats(this);
+			return ret;
+		}
 	};
 
-#define FIREBIRD_ITRACE_SQLSTATEMENT_VERSION 3u
+#define FIREBIRD_ITRACE_SQLSTATEMENT_VERSION 4u
 
 	class ITraceSQLStatement : public ITraceStatement
 	{
@@ -5691,7 +5715,7 @@ namespace Firebird
 		}
 	};
 
-#define FIREBIRD_ITRACE_BLRSTATEMENT_VERSION 3u
+#define FIREBIRD_ITRACE_BLRSTATEMENT_VERSION 4u
 
 	class ITraceBLRStatement : public ITraceStatement
 	{
@@ -5823,7 +5847,7 @@ namespace Firebird
 		}
 	};
 
-#define FIREBIRD_ITRACE_PROCEDURE_VERSION 3u
+#define FIREBIRD_ITRACE_PROCEDURE_VERSION 4u
 
 	class ITraceProcedure : public IVersioned
 	{
@@ -5836,6 +5860,7 @@ namespace Firebird
 			ISC_INT64 (CLOOP_CARG *getStmtID)(ITraceProcedure* self) CLOOP_NOEXCEPT;
 			const char* (CLOOP_CARG *getPlan)(ITraceProcedure* self) CLOOP_NOEXCEPT;
 			const char* (CLOOP_CARG *getExplainedPlan)(ITraceProcedure* self) CLOOP_NOEXCEPT;
+			IPerformanceStats* (CLOOP_CARG *getPerfStats)(ITraceProcedure* self) CLOOP_NOEXCEPT;
 		};
 
 	protected:
@@ -5898,9 +5923,19 @@ namespace Firebird
 			const char* ret = static_cast<VTable*>(this->cloopVTable)->getExplainedPlan(this);
 			return ret;
 		}
+
+		IPerformanceStats* getPerfStats()
+		{
+			if (cloopVTable->version < 4)
+			{
+				return 0;
+			}
+			IPerformanceStats* ret = static_cast<VTable*>(this->cloopVTable)->getPerfStats(this);
+			return ret;
+		}
 	};
 
-#define FIREBIRD_ITRACE_FUNCTION_VERSION 3u
+#define FIREBIRD_ITRACE_FUNCTION_VERSION 4u
 
 	class ITraceFunction : public IVersioned
 	{
@@ -5914,6 +5949,7 @@ namespace Firebird
 			ISC_INT64 (CLOOP_CARG *getStmtID)(ITraceFunction* self) CLOOP_NOEXCEPT;
 			const char* (CLOOP_CARG *getPlan)(ITraceFunction* self) CLOOP_NOEXCEPT;
 			const char* (CLOOP_CARG *getExplainedPlan)(ITraceFunction* self) CLOOP_NOEXCEPT;
+			IPerformanceStats* (CLOOP_CARG *getPerfStats)(ITraceFunction* self) CLOOP_NOEXCEPT;
 		};
 
 	protected:
@@ -5982,9 +6018,19 @@ namespace Firebird
 			const char* ret = static_cast<VTable*>(this->cloopVTable)->getExplainedPlan(this);
 			return ret;
 		}
+
+		IPerformanceStats* getPerfStats()
+		{
+			if (cloopVTable->version < 4)
+			{
+				return 0;
+			}
+			IPerformanceStats* ret = static_cast<VTable*>(this->cloopVTable)->getPerfStats(this);
+			return ret;
+		}
 	};
 
-#define FIREBIRD_ITRACE_TRIGGER_VERSION 3u
+#define FIREBIRD_ITRACE_TRIGGER_VERSION 4u
 
 	class ITraceTrigger : public IVersioned
 	{
@@ -5999,6 +6045,7 @@ namespace Firebird
 			ISC_INT64 (CLOOP_CARG *getStmtID)(ITraceTrigger* self) CLOOP_NOEXCEPT;
 			const char* (CLOOP_CARG *getPlan)(ITraceTrigger* self) CLOOP_NOEXCEPT;
 			const char* (CLOOP_CARG *getExplainedPlan)(ITraceTrigger* self) CLOOP_NOEXCEPT;
+			IPerformanceStats* (CLOOP_CARG *getPerfStats)(ITraceTrigger* self) CLOOP_NOEXCEPT;
 		};
 
 	protected:
@@ -6075,6 +6122,16 @@ namespace Firebird
 				return 0;
 			}
 			const char* ret = static_cast<VTable*>(this->cloopVTable)->getExplainedPlan(this);
+			return ret;
+		}
+
+		IPerformanceStats* getPerfStats()
+		{
+			if (cloopVTable->version < 4)
+			{
+				return 0;
+			}
+			IPerformanceStats* ret = static_cast<VTable*>(this->cloopVTable)->getPerfStats(this);
 			return ret;
 		}
 	};
@@ -6174,7 +6231,7 @@ namespace Firebird
 		}
 	};
 
-#define FIREBIRD_ITRACE_SWEEP_INFO_VERSION 2u
+#define FIREBIRD_ITRACE_SWEEP_INFO_VERSION 3u
 
 	class ITraceSweepInfo : public IVersioned
 	{
@@ -6186,6 +6243,7 @@ namespace Firebird
 			ISC_INT64 (CLOOP_CARG *getOAT)(ITraceSweepInfo* self) CLOOP_NOEXCEPT;
 			ISC_INT64 (CLOOP_CARG *getNext)(ITraceSweepInfo* self) CLOOP_NOEXCEPT;
 			PerformanceInfo* (CLOOP_CARG *getPerf)(ITraceSweepInfo* self) CLOOP_NOEXCEPT;
+			IPerformanceStats* (CLOOP_CARG *getPerfStats)(ITraceSweepInfo* self) CLOOP_NOEXCEPT;
 		};
 
 	protected:
@@ -6228,6 +6286,16 @@ namespace Firebird
 		PerformanceInfo* getPerf()
 		{
 			PerformanceInfo* ret = static_cast<VTable*>(this->cloopVTable)->getPerf(this);
+			return ret;
+		}
+
+		IPerformanceStats* getPerfStats()
+		{
+			if (cloopVTable->version < 3)
+			{
+				return 0;
+			}
+			IPerformanceStats* ret = static_cast<VTable*>(this->cloopVTable)->getPerfStats(this);
 			return ret;
 		}
 	};
@@ -7534,6 +7602,122 @@ namespace Firebird
 		ISC_UINT64 getElapsedTicks()
 		{
 			ISC_UINT64 ret = static_cast<VTable*>(this->cloopVTable)->getElapsedTicks(this);
+			return ret;
+		}
+	};
+
+#define FIREBIRD_IPERFORMANCE_COUNTERS_VERSION 2u
+
+	class IPerformanceCounters : public IVersioned
+	{
+	public:
+		struct VTable : public IVersioned::VTable
+		{
+			unsigned (CLOOP_CARG *getCount)(IPerformanceCounters* self) CLOOP_NOEXCEPT;
+			unsigned (CLOOP_CARG *getVectorCapacity)(IPerformanceCounters* self) CLOOP_NOEXCEPT;
+			unsigned (CLOOP_CARG *getId)(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT;
+			const char* (CLOOP_CARG *getName)(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT;
+			const ISC_INT64* (CLOOP_CARG *getCounterVector)(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT;
+		};
+
+	protected:
+		IPerformanceCounters(DoNotInherit)
+			: IVersioned(DoNotInherit())
+		{
+		}
+
+		~IPerformanceCounters()
+		{
+		}
+
+	public:
+		static CLOOP_CONSTEXPR unsigned VERSION = FIREBIRD_IPERFORMANCE_COUNTERS_VERSION;
+
+		unsigned getCount()
+		{
+			unsigned ret = static_cast<VTable*>(this->cloopVTable)->getCount(this);
+			return ret;
+		}
+
+		unsigned getVectorCapacity()
+		{
+			unsigned ret = static_cast<VTable*>(this->cloopVTable)->getVectorCapacity(this);
+			return ret;
+		}
+
+		unsigned getId(unsigned index)
+		{
+			unsigned ret = static_cast<VTable*>(this->cloopVTable)->getId(this, index);
+			return ret;
+		}
+
+		const char* getName(unsigned index)
+		{
+			const char* ret = static_cast<VTable*>(this->cloopVTable)->getName(this, index);
+			return ret;
+		}
+
+		const ISC_INT64* getCounterVector(unsigned index)
+		{
+			const ISC_INT64* ret = static_cast<VTable*>(this->cloopVTable)->getCounterVector(this, index);
+			return ret;
+		}
+	};
+
+#define FIREBIRD_IPERFORMANCE_STATS_VERSION 2u
+
+	class IPerformanceStats : public IVersioned
+	{
+	public:
+		struct VTable : public IVersioned::VTable
+		{
+			ISC_UINT64 (CLOOP_CARG *getElapsedTime)(IPerformanceStats* self) CLOOP_NOEXCEPT;
+			ISC_UINT64 (CLOOP_CARG *getFetchedRecords)(IPerformanceStats* self) CLOOP_NOEXCEPT;
+			IPerformanceCounters* (CLOOP_CARG *getGlobalCounters)(IPerformanceStats* self) CLOOP_NOEXCEPT;
+			IPerformanceCounters* (CLOOP_CARG *getPageCounters)(IPerformanceStats* self) CLOOP_NOEXCEPT;
+			IPerformanceCounters* (CLOOP_CARG *getRelationCounters)(IPerformanceStats* self) CLOOP_NOEXCEPT;
+		};
+
+	protected:
+		IPerformanceStats(DoNotInherit)
+			: IVersioned(DoNotInherit())
+		{
+		}
+
+		~IPerformanceStats()
+		{
+		}
+
+	public:
+		static CLOOP_CONSTEXPR unsigned VERSION = FIREBIRD_IPERFORMANCE_STATS_VERSION;
+
+		ISC_UINT64 getElapsedTime()
+		{
+			ISC_UINT64 ret = static_cast<VTable*>(this->cloopVTable)->getElapsedTime(this);
+			return ret;
+		}
+
+		ISC_UINT64 getFetchedRecords()
+		{
+			ISC_UINT64 ret = static_cast<VTable*>(this->cloopVTable)->getFetchedRecords(this);
+			return ret;
+		}
+
+		IPerformanceCounters* getGlobalCounters()
+		{
+			IPerformanceCounters* ret = static_cast<VTable*>(this->cloopVTable)->getGlobalCounters(this);
+			return ret;
+		}
+
+		IPerformanceCounters* getPageCounters()
+		{
+			IPerformanceCounters* ret = static_cast<VTable*>(this->cloopVTable)->getPageCounters(this);
+			return ret;
+		}
+
+		IPerformanceCounters* getRelationCounters()
+		{
+			IPerformanceCounters* ret = static_cast<VTable*>(this->cloopVTable)->getRelationCounters(this);
 			return ret;
 		}
 	};
@@ -17637,6 +17821,7 @@ namespace Firebird
 					this->getPerf = &Name::cloopgetPerfDispatcher;
 					this->getInitialID = &Name::cloopgetInitialIDDispatcher;
 					this->getPreviousID = &Name::cloopgetPreviousIDDispatcher;
+					this->getPerfStats = &Name::cloopgetPerfStatsDispatcher;
 				}
 			} vTable;
 
@@ -17733,6 +17918,19 @@ namespace Firebird
 				return static_cast<ISC_INT64>(0);
 			}
 		}
+
+		static IPerformanceStats* CLOOP_CARG cloopgetPerfStatsDispatcher(ITraceTransaction* self) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getPerfStats();
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<IPerformanceStats*>(0);
+			}
+		}
 	};
 
 	template <typename Name, typename StatusType, typename Base = IVersionedImpl<Name, StatusType, Inherit<ITraceTransaction> > >
@@ -17755,6 +17953,7 @@ namespace Firebird
 		virtual PerformanceInfo* getPerf() = 0;
 		virtual ISC_INT64 getInitialID() = 0;
 		virtual ISC_INT64 getPreviousID() = 0;
+		virtual IPerformanceStats* getPerfStats() = 0;
 	};
 
 	template <typename Name, typename StatusType, typename Base>
@@ -17854,6 +18053,7 @@ namespace Firebird
 					this->version = Base::VERSION;
 					this->getStmtID = &Name::cloopgetStmtIDDispatcher;
 					this->getPerf = &Name::cloopgetPerfDispatcher;
+					this->getPerfStats = &Name::cloopgetPerfStatsDispatcher;
 				}
 			} vTable;
 
@@ -17885,6 +18085,19 @@ namespace Firebird
 				return static_cast<PerformanceInfo*>(0);
 			}
 		}
+
+		static IPerformanceStats* CLOOP_CARG cloopgetPerfStatsDispatcher(ITraceStatement* self) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getPerfStats();
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<IPerformanceStats*>(0);
+			}
+		}
 	};
 
 	template <typename Name, typename StatusType, typename Base = IVersionedImpl<Name, StatusType, Inherit<ITraceStatement> > >
@@ -17902,6 +18115,7 @@ namespace Firebird
 
 		virtual ISC_INT64 getStmtID() = 0;
 		virtual PerformanceInfo* getPerf() = 0;
+		virtual IPerformanceStats* getPerfStats() = 0;
 	};
 
 	template <typename Name, typename StatusType, typename Base>
@@ -17919,6 +18133,7 @@ namespace Firebird
 					this->version = Base::VERSION;
 					this->getStmtID = &Name::cloopgetStmtIDDispatcher;
 					this->getPerf = &Name::cloopgetPerfDispatcher;
+					this->getPerfStats = &Name::cloopgetPerfStatsDispatcher;
 					this->getText = &Name::cloopgetTextDispatcher;
 					this->getPlan = &Name::cloopgetPlanDispatcher;
 					this->getInputs = &Name::cloopgetInputsDispatcher;
@@ -18020,6 +18235,19 @@ namespace Firebird
 				return static_cast<PerformanceInfo*>(0);
 			}
 		}
+
+		static IPerformanceStats* CLOOP_CARG cloopgetPerfStatsDispatcher(ITraceStatement* self) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getPerfStats();
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<IPerformanceStats*>(0);
+			}
+		}
 	};
 
 	template <typename Name, typename StatusType, typename Base = ITraceStatementImpl<Name, StatusType, Inherit<IVersionedImpl<Name, StatusType, Inherit<ITraceSQLStatement> > > > >
@@ -18057,6 +18285,7 @@ namespace Firebird
 					this->version = Base::VERSION;
 					this->getStmtID = &Name::cloopgetStmtIDDispatcher;
 					this->getPerf = &Name::cloopgetPerfDispatcher;
+					this->getPerfStats = &Name::cloopgetPerfStatsDispatcher;
 					this->getData = &Name::cloopgetDataDispatcher;
 					this->getDataLength = &Name::cloopgetDataLengthDispatcher;
 					this->getText = &Name::cloopgetTextDispatcher;
@@ -18128,6 +18357,19 @@ namespace Firebird
 			{
 				StatusType::catchException(0);
 				return static_cast<PerformanceInfo*>(0);
+			}
+		}
+
+		static IPerformanceStats* CLOOP_CARG cloopgetPerfStatsDispatcher(ITraceStatement* self) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getPerfStats();
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<IPerformanceStats*>(0);
 			}
 		}
 	};
@@ -18329,6 +18571,7 @@ namespace Firebird
 					this->getStmtID = &Name::cloopgetStmtIDDispatcher;
 					this->getPlan = &Name::cloopgetPlanDispatcher;
 					this->getExplainedPlan = &Name::cloopgetExplainedPlanDispatcher;
+					this->getPerfStats = &Name::cloopgetPerfStatsDispatcher;
 				}
 			} vTable;
 
@@ -18412,6 +18655,19 @@ namespace Firebird
 				return static_cast<const char*>(0);
 			}
 		}
+
+		static IPerformanceStats* CLOOP_CARG cloopgetPerfStatsDispatcher(ITraceProcedure* self) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getPerfStats();
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<IPerformanceStats*>(0);
+			}
+		}
 	};
 
 	template <typename Name, typename StatusType, typename Base = IVersionedImpl<Name, StatusType, Inherit<ITraceProcedure> > >
@@ -18433,6 +18689,7 @@ namespace Firebird
 		virtual ISC_INT64 getStmtID() = 0;
 		virtual const char* getPlan() = 0;
 		virtual const char* getExplainedPlan() = 0;
+		virtual IPerformanceStats* getPerfStats() = 0;
 	};
 
 	template <typename Name, typename StatusType, typename Base>
@@ -18455,6 +18712,7 @@ namespace Firebird
 					this->getStmtID = &Name::cloopgetStmtIDDispatcher;
 					this->getPlan = &Name::cloopgetPlanDispatcher;
 					this->getExplainedPlan = &Name::cloopgetExplainedPlanDispatcher;
+					this->getPerfStats = &Name::cloopgetPerfStatsDispatcher;
 				}
 			} vTable;
 
@@ -18551,6 +18809,19 @@ namespace Firebird
 				return static_cast<const char*>(0);
 			}
 		}
+
+		static IPerformanceStats* CLOOP_CARG cloopgetPerfStatsDispatcher(ITraceFunction* self) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getPerfStats();
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<IPerformanceStats*>(0);
+			}
+		}
 	};
 
 	template <typename Name, typename StatusType, typename Base = IVersionedImpl<Name, StatusType, Inherit<ITraceFunction> > >
@@ -18573,6 +18844,7 @@ namespace Firebird
 		virtual ISC_INT64 getStmtID() = 0;
 		virtual const char* getPlan() = 0;
 		virtual const char* getExplainedPlan() = 0;
+		virtual IPerformanceStats* getPerfStats() = 0;
 	};
 
 	template <typename Name, typename StatusType, typename Base>
@@ -18596,6 +18868,7 @@ namespace Firebird
 					this->getStmtID = &Name::cloopgetStmtIDDispatcher;
 					this->getPlan = &Name::cloopgetPlanDispatcher;
 					this->getExplainedPlan = &Name::cloopgetExplainedPlanDispatcher;
+					this->getPerfStats = &Name::cloopgetPerfStatsDispatcher;
 				}
 			} vTable;
 
@@ -18705,6 +18978,19 @@ namespace Firebird
 				return static_cast<const char*>(0);
 			}
 		}
+
+		static IPerformanceStats* CLOOP_CARG cloopgetPerfStatsDispatcher(ITraceTrigger* self) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getPerfStats();
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<IPerformanceStats*>(0);
+			}
+		}
 	};
 
 	template <typename Name, typename StatusType, typename Base = IVersionedImpl<Name, StatusType, Inherit<ITraceTrigger> > >
@@ -18728,6 +19014,7 @@ namespace Firebird
 		virtual ISC_INT64 getStmtID() = 0;
 		virtual const char* getPlan() = 0;
 		virtual const char* getExplainedPlan() = 0;
+		virtual IPerformanceStats* getPerfStats() = 0;
 	};
 
 	template <typename Name, typename StatusType, typename Base>
@@ -19049,6 +19336,7 @@ namespace Firebird
 					this->getOAT = &Name::cloopgetOATDispatcher;
 					this->getNext = &Name::cloopgetNextDispatcher;
 					this->getPerf = &Name::cloopgetPerfDispatcher;
+					this->getPerfStats = &Name::cloopgetPerfStatsDispatcher;
 				}
 			} vTable;
 
@@ -19119,6 +19407,19 @@ namespace Firebird
 				return static_cast<PerformanceInfo*>(0);
 			}
 		}
+
+		static IPerformanceStats* CLOOP_CARG cloopgetPerfStatsDispatcher(ITraceSweepInfo* self) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getPerfStats();
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<IPerformanceStats*>(0);
+			}
+		}
 	};
 
 	template <typename Name, typename StatusType, typename Base = IVersionedImpl<Name, StatusType, Inherit<ITraceSweepInfo> > >
@@ -19139,6 +19440,7 @@ namespace Firebird
 		virtual ISC_INT64 getOAT() = 0;
 		virtual ISC_INT64 getNext() = 0;
 		virtual PerformanceInfo* getPerf() = 0;
+		virtual IPerformanceStats* getPerfStats() = 0;
 	};
 
 	template <typename Name, typename StatusType, typename Base>
@@ -21697,6 +21999,226 @@ namespace Firebird
 		}
 
 		virtual ISC_UINT64 getElapsedTicks() = 0;
+	};
+
+	template <typename Name, typename StatusType, typename Base>
+	class IPerformanceCountersBaseImpl : public Base
+	{
+	public:
+		typedef IPerformanceCounters Declaration;
+
+		IPerformanceCountersBaseImpl(DoNotInherit = DoNotInherit())
+		{
+			static struct VTableImpl : Base::VTable
+			{
+				VTableImpl()
+				{
+					this->version = Base::VERSION;
+					this->getCount = &Name::cloopgetCountDispatcher;
+					this->getVectorCapacity = &Name::cloopgetVectorCapacityDispatcher;
+					this->getId = &Name::cloopgetIdDispatcher;
+					this->getName = &Name::cloopgetNameDispatcher;
+					this->getCounterVector = &Name::cloopgetCounterVectorDispatcher;
+				}
+			} vTable;
+
+			this->cloopVTable = &vTable;
+		}
+
+		static unsigned CLOOP_CARG cloopgetCountDispatcher(IPerformanceCounters* self) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getCount();
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<unsigned>(0);
+			}
+		}
+
+		static unsigned CLOOP_CARG cloopgetVectorCapacityDispatcher(IPerformanceCounters* self) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getVectorCapacity();
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<unsigned>(0);
+			}
+		}
+
+		static unsigned CLOOP_CARG cloopgetIdDispatcher(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getId(index);
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<unsigned>(0);
+			}
+		}
+
+		static const char* CLOOP_CARG cloopgetNameDispatcher(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getName(index);
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<const char*>(0);
+			}
+		}
+
+		static const ISC_INT64* CLOOP_CARG cloopgetCounterVectorDispatcher(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getCounterVector(index);
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<const ISC_INT64*>(0);
+			}
+		}
+	};
+
+	template <typename Name, typename StatusType, typename Base = IVersionedImpl<Name, StatusType, Inherit<IPerformanceCounters> > >
+	class IPerformanceCountersImpl : public IPerformanceCountersBaseImpl<Name, StatusType, Base>
+	{
+	protected:
+		IPerformanceCountersImpl(DoNotInherit = DoNotInherit())
+		{
+		}
+
+	public:
+		virtual ~IPerformanceCountersImpl()
+		{
+		}
+
+		virtual unsigned getCount() = 0;
+		virtual unsigned getVectorCapacity() = 0;
+		virtual unsigned getId(unsigned index) = 0;
+		virtual const char* getName(unsigned index) = 0;
+		virtual const ISC_INT64* getCounterVector(unsigned index) = 0;
+	};
+
+	template <typename Name, typename StatusType, typename Base>
+	class IPerformanceStatsBaseImpl : public Base
+	{
+	public:
+		typedef IPerformanceStats Declaration;
+
+		IPerformanceStatsBaseImpl(DoNotInherit = DoNotInherit())
+		{
+			static struct VTableImpl : Base::VTable
+			{
+				VTableImpl()
+				{
+					this->version = Base::VERSION;
+					this->getElapsedTime = &Name::cloopgetElapsedTimeDispatcher;
+					this->getFetchedRecords = &Name::cloopgetFetchedRecordsDispatcher;
+					this->getGlobalCounters = &Name::cloopgetGlobalCountersDispatcher;
+					this->getPageCounters = &Name::cloopgetPageCountersDispatcher;
+					this->getRelationCounters = &Name::cloopgetRelationCountersDispatcher;
+				}
+			} vTable;
+
+			this->cloopVTable = &vTable;
+		}
+
+		static ISC_UINT64 CLOOP_CARG cloopgetElapsedTimeDispatcher(IPerformanceStats* self) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getElapsedTime();
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<ISC_UINT64>(0);
+			}
+		}
+
+		static ISC_UINT64 CLOOP_CARG cloopgetFetchedRecordsDispatcher(IPerformanceStats* self) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getFetchedRecords();
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<ISC_UINT64>(0);
+			}
+		}
+
+		static IPerformanceCounters* CLOOP_CARG cloopgetGlobalCountersDispatcher(IPerformanceStats* self) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getGlobalCounters();
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<IPerformanceCounters*>(0);
+			}
+		}
+
+		static IPerformanceCounters* CLOOP_CARG cloopgetPageCountersDispatcher(IPerformanceStats* self) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getPageCounters();
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<IPerformanceCounters*>(0);
+			}
+		}
+
+		static IPerformanceCounters* CLOOP_CARG cloopgetRelationCountersDispatcher(IPerformanceStats* self) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getRelationCounters();
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<IPerformanceCounters*>(0);
+			}
+		}
+	};
+
+	template <typename Name, typename StatusType, typename Base = IVersionedImpl<Name, StatusType, Inherit<IPerformanceStats> > >
+	class IPerformanceStatsImpl : public IPerformanceStatsBaseImpl<Name, StatusType, Base>
+	{
+	protected:
+		IPerformanceStatsImpl(DoNotInherit = DoNotInherit())
+		{
+		}
+
+	public:
+		virtual ~IPerformanceStatsImpl()
+		{
+		}
+
+		virtual ISC_UINT64 getElapsedTime() = 0;
+		virtual ISC_UINT64 getFetchedRecords() = 0;
+		virtual IPerformanceCounters* getGlobalCounters() = 0;
+		virtual IPerformanceCounters* getPageCounters() = 0;
+		virtual IPerformanceCounters* getRelationCounters() = 0;
 	};
 };
 

--- a/src/include/firebird/IdlFbInterfaces.h
+++ b/src/include/firebird/IdlFbInterfaces.h
@@ -7613,11 +7613,11 @@ namespace Firebird
 	public:
 		struct VTable : public IVersioned::VTable
 		{
-			unsigned (CLOOP_CARG *getCount)(IPerformanceCounters* self) CLOOP_NOEXCEPT;
-			unsigned (CLOOP_CARG *getVectorCapacity)(IPerformanceCounters* self) CLOOP_NOEXCEPT;
-			unsigned (CLOOP_CARG *getId)(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT;
-			const char* (CLOOP_CARG *getName)(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT;
-			const ISC_INT64* (CLOOP_CARG *getCounterVector)(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT;
+			unsigned (CLOOP_CARG *getObjectCount)(IPerformanceCounters* self) CLOOP_NOEXCEPT;
+			unsigned (CLOOP_CARG *getCountersCapacity)(IPerformanceCounters* self) CLOOP_NOEXCEPT;
+			unsigned (CLOOP_CARG *getObjectId)(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT;
+			const char* (CLOOP_CARG *getObjectName)(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT;
+			const ISC_INT64* (CLOOP_CARG *getObjectCounters)(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT;
 		};
 
 	protected:
@@ -7633,33 +7633,53 @@ namespace Firebird
 	public:
 		static CLOOP_CONSTEXPR unsigned VERSION = FIREBIRD_IPERFORMANCE_COUNTERS_VERSION;
 
-		unsigned getCount()
+		static CLOOP_CONSTEXPR unsigned PAGE_FETCHES = 0;
+		static CLOOP_CONSTEXPR unsigned PAGE_READS = 1;
+		static CLOOP_CONSTEXPR unsigned PAGE_MARKS = 2;
+		static CLOOP_CONSTEXPR unsigned PAGE_WRITES = 3;
+		static CLOOP_CONSTEXPR unsigned RECORD_SEQ_READS = 0;
+		static CLOOP_CONSTEXPR unsigned RECORD_IDX_READS = 1;
+		static CLOOP_CONSTEXPR unsigned RECORD_UPDATES = 2;
+		static CLOOP_CONSTEXPR unsigned RECORD_INSERTS = 3;
+		static CLOOP_CONSTEXPR unsigned RECORD_DELETES = 4;
+		static CLOOP_CONSTEXPR unsigned RECORD_BACKOUTS = 5;
+		static CLOOP_CONSTEXPR unsigned RECORD_PURGES = 6;
+		static CLOOP_CONSTEXPR unsigned RECORD_EXPUNGES = 7;
+		static CLOOP_CONSTEXPR unsigned RECORD_LOCKS = 8;
+		static CLOOP_CONSTEXPR unsigned RECORD_WAITS = 9;
+		static CLOOP_CONSTEXPR unsigned RECORD_CONFLICTS = 10;
+		static CLOOP_CONSTEXPR unsigned RECORD_BACK_READS = 11;
+		static CLOOP_CONSTEXPR unsigned RECORD_FRAGMENT_READS = 12;
+		static CLOOP_CONSTEXPR unsigned RECORD_RPT_READS = 13;
+		static CLOOP_CONSTEXPR unsigned RECORD_IMGC = 14;
+
+		unsigned getObjectCount()
 		{
-			unsigned ret = static_cast<VTable*>(this->cloopVTable)->getCount(this);
+			unsigned ret = static_cast<VTable*>(this->cloopVTable)->getObjectCount(this);
 			return ret;
 		}
 
-		unsigned getVectorCapacity()
+		unsigned getCountersCapacity()
 		{
-			unsigned ret = static_cast<VTable*>(this->cloopVTable)->getVectorCapacity(this);
+			unsigned ret = static_cast<VTable*>(this->cloopVTable)->getCountersCapacity(this);
 			return ret;
 		}
 
-		unsigned getId(unsigned index)
+		unsigned getObjectId(unsigned index)
 		{
-			unsigned ret = static_cast<VTable*>(this->cloopVTable)->getId(this, index);
+			unsigned ret = static_cast<VTable*>(this->cloopVTable)->getObjectId(this, index);
 			return ret;
 		}
 
-		const char* getName(unsigned index)
+		const char* getObjectName(unsigned index)
 		{
-			const char* ret = static_cast<VTable*>(this->cloopVTable)->getName(this, index);
+			const char* ret = static_cast<VTable*>(this->cloopVTable)->getObjectName(this, index);
 			return ret;
 		}
 
-		const ISC_INT64* getCounterVector(unsigned index)
+		const ISC_INT64* getObjectCounters(unsigned index)
 		{
-			const ISC_INT64* ret = static_cast<VTable*>(this->cloopVTable)->getCounterVector(this, index);
+			const ISC_INT64* ret = static_cast<VTable*>(this->cloopVTable)->getObjectCounters(this, index);
 			return ret;
 		}
 	};
@@ -7673,9 +7693,8 @@ namespace Firebird
 		{
 			ISC_UINT64 (CLOOP_CARG *getElapsedTime)(IPerformanceStats* self) CLOOP_NOEXCEPT;
 			ISC_UINT64 (CLOOP_CARG *getFetchedRecords)(IPerformanceStats* self) CLOOP_NOEXCEPT;
-			IPerformanceCounters* (CLOOP_CARG *getGlobalCounters)(IPerformanceStats* self) CLOOP_NOEXCEPT;
 			IPerformanceCounters* (CLOOP_CARG *getPageCounters)(IPerformanceStats* self) CLOOP_NOEXCEPT;
-			IPerformanceCounters* (CLOOP_CARG *getRelationCounters)(IPerformanceStats* self) CLOOP_NOEXCEPT;
+			IPerformanceCounters* (CLOOP_CARG *getTableCounters)(IPerformanceStats* self) CLOOP_NOEXCEPT;
 		};
 
 	protected:
@@ -7703,21 +7722,15 @@ namespace Firebird
 			return ret;
 		}
 
-		IPerformanceCounters* getGlobalCounters()
-		{
-			IPerformanceCounters* ret = static_cast<VTable*>(this->cloopVTable)->getGlobalCounters(this);
-			return ret;
-		}
-
 		IPerformanceCounters* getPageCounters()
 		{
 			IPerformanceCounters* ret = static_cast<VTable*>(this->cloopVTable)->getPageCounters(this);
 			return ret;
 		}
 
-		IPerformanceCounters* getRelationCounters()
+		IPerformanceCounters* getTableCounters()
 		{
-			IPerformanceCounters* ret = static_cast<VTable*>(this->cloopVTable)->getRelationCounters(this);
+			IPerformanceCounters* ret = static_cast<VTable*>(this->cloopVTable)->getTableCounters(this);
 			return ret;
 		}
 	};
@@ -22014,22 +22027,22 @@ namespace Firebird
 				VTableImpl()
 				{
 					this->version = Base::VERSION;
-					this->getCount = &Name::cloopgetCountDispatcher;
-					this->getVectorCapacity = &Name::cloopgetVectorCapacityDispatcher;
-					this->getId = &Name::cloopgetIdDispatcher;
-					this->getName = &Name::cloopgetNameDispatcher;
-					this->getCounterVector = &Name::cloopgetCounterVectorDispatcher;
+					this->getObjectCount = &Name::cloopgetObjectCountDispatcher;
+					this->getCountersCapacity = &Name::cloopgetCountersCapacityDispatcher;
+					this->getObjectId = &Name::cloopgetObjectIdDispatcher;
+					this->getObjectName = &Name::cloopgetObjectNameDispatcher;
+					this->getObjectCounters = &Name::cloopgetObjectCountersDispatcher;
 				}
 			} vTable;
 
 			this->cloopVTable = &vTable;
 		}
 
-		static unsigned CLOOP_CARG cloopgetCountDispatcher(IPerformanceCounters* self) CLOOP_NOEXCEPT
+		static unsigned CLOOP_CARG cloopgetObjectCountDispatcher(IPerformanceCounters* self) CLOOP_NOEXCEPT
 		{
 			try
 			{
-				return static_cast<Name*>(self)->Name::getCount();
+				return static_cast<Name*>(self)->Name::getObjectCount();
 			}
 			catch (...)
 			{
@@ -22038,11 +22051,11 @@ namespace Firebird
 			}
 		}
 
-		static unsigned CLOOP_CARG cloopgetVectorCapacityDispatcher(IPerformanceCounters* self) CLOOP_NOEXCEPT
+		static unsigned CLOOP_CARG cloopgetCountersCapacityDispatcher(IPerformanceCounters* self) CLOOP_NOEXCEPT
 		{
 			try
 			{
-				return static_cast<Name*>(self)->Name::getVectorCapacity();
+				return static_cast<Name*>(self)->Name::getCountersCapacity();
 			}
 			catch (...)
 			{
@@ -22051,11 +22064,11 @@ namespace Firebird
 			}
 		}
 
-		static unsigned CLOOP_CARG cloopgetIdDispatcher(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT
+		static unsigned CLOOP_CARG cloopgetObjectIdDispatcher(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT
 		{
 			try
 			{
-				return static_cast<Name*>(self)->Name::getId(index);
+				return static_cast<Name*>(self)->Name::getObjectId(index);
 			}
 			catch (...)
 			{
@@ -22064,11 +22077,11 @@ namespace Firebird
 			}
 		}
 
-		static const char* CLOOP_CARG cloopgetNameDispatcher(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT
+		static const char* CLOOP_CARG cloopgetObjectNameDispatcher(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT
 		{
 			try
 			{
-				return static_cast<Name*>(self)->Name::getName(index);
+				return static_cast<Name*>(self)->Name::getObjectName(index);
 			}
 			catch (...)
 			{
@@ -22077,11 +22090,11 @@ namespace Firebird
 			}
 		}
 
-		static const ISC_INT64* CLOOP_CARG cloopgetCounterVectorDispatcher(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT
+		static const ISC_INT64* CLOOP_CARG cloopgetObjectCountersDispatcher(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT
 		{
 			try
 			{
-				return static_cast<Name*>(self)->Name::getCounterVector(index);
+				return static_cast<Name*>(self)->Name::getObjectCounters(index);
 			}
 			catch (...)
 			{
@@ -22104,11 +22117,11 @@ namespace Firebird
 		{
 		}
 
-		virtual unsigned getCount() = 0;
-		virtual unsigned getVectorCapacity() = 0;
-		virtual unsigned getId(unsigned index) = 0;
-		virtual const char* getName(unsigned index) = 0;
-		virtual const ISC_INT64* getCounterVector(unsigned index) = 0;
+		virtual unsigned getObjectCount() = 0;
+		virtual unsigned getCountersCapacity() = 0;
+		virtual unsigned getObjectId(unsigned index) = 0;
+		virtual const char* getObjectName(unsigned index) = 0;
+		virtual const ISC_INT64* getObjectCounters(unsigned index) = 0;
 	};
 
 	template <typename Name, typename StatusType, typename Base>
@@ -22126,9 +22139,8 @@ namespace Firebird
 					this->version = Base::VERSION;
 					this->getElapsedTime = &Name::cloopgetElapsedTimeDispatcher;
 					this->getFetchedRecords = &Name::cloopgetFetchedRecordsDispatcher;
-					this->getGlobalCounters = &Name::cloopgetGlobalCountersDispatcher;
 					this->getPageCounters = &Name::cloopgetPageCountersDispatcher;
-					this->getRelationCounters = &Name::cloopgetRelationCountersDispatcher;
+					this->getTableCounters = &Name::cloopgetTableCountersDispatcher;
 				}
 			} vTable;
 
@@ -22161,19 +22173,6 @@ namespace Firebird
 			}
 		}
 
-		static IPerformanceCounters* CLOOP_CARG cloopgetGlobalCountersDispatcher(IPerformanceStats* self) CLOOP_NOEXCEPT
-		{
-			try
-			{
-				return static_cast<Name*>(self)->Name::getGlobalCounters();
-			}
-			catch (...)
-			{
-				StatusType::catchException(0);
-				return static_cast<IPerformanceCounters*>(0);
-			}
-		}
-
 		static IPerformanceCounters* CLOOP_CARG cloopgetPageCountersDispatcher(IPerformanceStats* self) CLOOP_NOEXCEPT
 		{
 			try
@@ -22187,11 +22186,11 @@ namespace Firebird
 			}
 		}
 
-		static IPerformanceCounters* CLOOP_CARG cloopgetRelationCountersDispatcher(IPerformanceStats* self) CLOOP_NOEXCEPT
+		static IPerformanceCounters* CLOOP_CARG cloopgetTableCountersDispatcher(IPerformanceStats* self) CLOOP_NOEXCEPT
 		{
 			try
 			{
-				return static_cast<Name*>(self)->Name::getRelationCounters();
+				return static_cast<Name*>(self)->Name::getTableCounters();
 			}
 			catch (...)
 			{
@@ -22216,9 +22215,8 @@ namespace Firebird
 
 		virtual ISC_UINT64 getElapsedTime() = 0;
 		virtual ISC_UINT64 getFetchedRecords() = 0;
-		virtual IPerformanceCounters* getGlobalCounters() = 0;
 		virtual IPerformanceCounters* getPageCounters() = 0;
-		virtual IPerformanceCounters* getRelationCounters() = 0;
+		virtual IPerformanceCounters* getTableCounters() = 0;
 	};
 };
 

--- a/src/include/firebird/IdlFbInterfaces.h
+++ b/src/include/firebird/IdlFbInterfaces.h
@@ -7693,8 +7693,7 @@ namespace Firebird
 		{
 			ISC_UINT64 (CLOOP_CARG *getElapsedTime)(IPerformanceStats* self) CLOOP_NOEXCEPT;
 			ISC_UINT64 (CLOOP_CARG *getFetchedRecords)(IPerformanceStats* self) CLOOP_NOEXCEPT;
-			IPerformanceCounters* (CLOOP_CARG *getPageCounters)(IPerformanceStats* self) CLOOP_NOEXCEPT;
-			IPerformanceCounters* (CLOOP_CARG *getTableCounters)(IPerformanceStats* self) CLOOP_NOEXCEPT;
+			IPerformanceCounters* (CLOOP_CARG *getCounters)(IPerformanceStats* self, unsigned group) CLOOP_NOEXCEPT;
 		};
 
 	protected:
@@ -7710,6 +7709,9 @@ namespace Firebird
 	public:
 		static CLOOP_CONSTEXPR unsigned VERSION = FIREBIRD_IPERFORMANCE_STATS_VERSION;
 
+		static CLOOP_CONSTEXPR unsigned COUNTER_GROUP_PAGES = 0;
+		static CLOOP_CONSTEXPR unsigned COUNTER_GROUP_TABLES = 1;
+
 		ISC_UINT64 getElapsedTime()
 		{
 			ISC_UINT64 ret = static_cast<VTable*>(this->cloopVTable)->getElapsedTime(this);
@@ -7722,15 +7724,9 @@ namespace Firebird
 			return ret;
 		}
 
-		IPerformanceCounters* getPageCounters()
+		IPerformanceCounters* getCounters(unsigned group)
 		{
-			IPerformanceCounters* ret = static_cast<VTable*>(this->cloopVTable)->getPageCounters(this);
-			return ret;
-		}
-
-		IPerformanceCounters* getTableCounters()
-		{
-			IPerformanceCounters* ret = static_cast<VTable*>(this->cloopVTable)->getTableCounters(this);
+			IPerformanceCounters* ret = static_cast<VTable*>(this->cloopVTable)->getCounters(this, group);
 			return ret;
 		}
 	};
@@ -22139,8 +22135,7 @@ namespace Firebird
 					this->version = Base::VERSION;
 					this->getElapsedTime = &Name::cloopgetElapsedTimeDispatcher;
 					this->getFetchedRecords = &Name::cloopgetFetchedRecordsDispatcher;
-					this->getPageCounters = &Name::cloopgetPageCountersDispatcher;
-					this->getTableCounters = &Name::cloopgetTableCountersDispatcher;
+					this->getCounters = &Name::cloopgetCountersDispatcher;
 				}
 			} vTable;
 
@@ -22173,24 +22168,11 @@ namespace Firebird
 			}
 		}
 
-		static IPerformanceCounters* CLOOP_CARG cloopgetPageCountersDispatcher(IPerformanceStats* self) CLOOP_NOEXCEPT
+		static IPerformanceCounters* CLOOP_CARG cloopgetCountersDispatcher(IPerformanceStats* self, unsigned group) CLOOP_NOEXCEPT
 		{
 			try
 			{
-				return static_cast<Name*>(self)->Name::getPageCounters();
-			}
-			catch (...)
-			{
-				StatusType::catchException(0);
-				return static_cast<IPerformanceCounters*>(0);
-			}
-		}
-
-		static IPerformanceCounters* CLOOP_CARG cloopgetTableCountersDispatcher(IPerformanceStats* self) CLOOP_NOEXCEPT
-		{
-			try
-			{
-				return static_cast<Name*>(self)->Name::getTableCounters();
+				return static_cast<Name*>(self)->Name::getCounters(group);
 			}
 			catch (...)
 			{
@@ -22215,8 +22197,7 @@ namespace Firebird
 
 		virtual ISC_UINT64 getElapsedTime() = 0;
 		virtual ISC_UINT64 getFetchedRecords() = 0;
-		virtual IPerformanceCounters* getPageCounters() = 0;
-		virtual IPerformanceCounters* getTableCounters() = 0;
+		virtual IPerformanceCounters* getCounters(unsigned group) = 0;
 	};
 };
 

--- a/src/include/firebird/IdlFbInterfaces.h
+++ b/src/include/firebird/IdlFbInterfaces.h
@@ -7614,7 +7614,7 @@ namespace Firebird
 		struct VTable : public IVersioned::VTable
 		{
 			unsigned (CLOOP_CARG *getObjectCount)(IPerformanceCounters* self) CLOOP_NOEXCEPT;
-			unsigned (CLOOP_CARG *getCountersCapacity)(IPerformanceCounters* self) CLOOP_NOEXCEPT;
+			unsigned (CLOOP_CARG *getMaxCounterIndex)(IPerformanceCounters* self) CLOOP_NOEXCEPT;
 			unsigned (CLOOP_CARG *getObjectId)(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT;
 			const char* (CLOOP_CARG *getObjectName)(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT;
 			const ISC_INT64* (CLOOP_CARG *getObjectCounters)(IPerformanceCounters* self, unsigned index) CLOOP_NOEXCEPT;
@@ -7659,9 +7659,9 @@ namespace Firebird
 			return ret;
 		}
 
-		unsigned getCountersCapacity()
+		unsigned getMaxCounterIndex()
 		{
-			unsigned ret = static_cast<VTable*>(this->cloopVTable)->getCountersCapacity(this);
+			unsigned ret = static_cast<VTable*>(this->cloopVTable)->getMaxCounterIndex(this);
 			return ret;
 		}
 
@@ -22024,7 +22024,7 @@ namespace Firebird
 				{
 					this->version = Base::VERSION;
 					this->getObjectCount = &Name::cloopgetObjectCountDispatcher;
-					this->getCountersCapacity = &Name::cloopgetCountersCapacityDispatcher;
+					this->getMaxCounterIndex = &Name::cloopgetMaxCounterIndexDispatcher;
 					this->getObjectId = &Name::cloopgetObjectIdDispatcher;
 					this->getObjectName = &Name::cloopgetObjectNameDispatcher;
 					this->getObjectCounters = &Name::cloopgetObjectCountersDispatcher;
@@ -22047,11 +22047,11 @@ namespace Firebird
 			}
 		}
 
-		static unsigned CLOOP_CARG cloopgetCountersCapacityDispatcher(IPerformanceCounters* self) CLOOP_NOEXCEPT
+		static unsigned CLOOP_CARG cloopgetMaxCounterIndexDispatcher(IPerformanceCounters* self) CLOOP_NOEXCEPT
 		{
 			try
 			{
-				return static_cast<Name*>(self)->Name::getCountersCapacity();
+				return static_cast<Name*>(self)->Name::getMaxCounterIndex();
 			}
 			catch (...)
 			{
@@ -22114,7 +22114,7 @@ namespace Firebird
 		}
 
 		virtual unsigned getObjectCount() = 0;
-		virtual unsigned getCountersCapacity() = 0;
+		virtual unsigned getMaxCounterIndex() = 0;
 		virtual unsigned getObjectId(unsigned index) = 0;
 		virtual const char* getObjectName(unsigned index) = 0;
 		virtual const ISC_INT64* getObjectCounters(unsigned index) = 0;

--- a/src/include/gen/Firebird.pas
+++ b/src/include/gen/Firebird.pas
@@ -779,7 +779,7 @@ type
 	IProfilerSession_defineStatement2Ptr = procedure(this: IProfilerSession; status: IStatus; statementId: Int64; parentStatementId: Int64; type_: PAnsiChar; schemaName: PAnsiChar; packageName: PAnsiChar; routineName: PAnsiChar; sqlText: PAnsiChar); cdecl;
 	IProfilerStats_getElapsedTicksPtr = function(this: IProfilerStats): QWord; cdecl;
 	IPerformanceCounters_getObjectCountPtr = function(this: IPerformanceCounters): Cardinal; cdecl;
-	IPerformanceCounters_getCountersCapacityPtr = function(this: IPerformanceCounters): Cardinal; cdecl;
+	IPerformanceCounters_getMaxCounterIndexPtr = function(this: IPerformanceCounters): Cardinal; cdecl;
 	IPerformanceCounters_getObjectIdPtr = function(this: IPerformanceCounters; index: Cardinal): Cardinal; cdecl;
 	IPerformanceCounters_getObjectNamePtr = function(this: IPerformanceCounters; index: Cardinal): PAnsiChar; cdecl;
 	IPerformanceCounters_getObjectCountersPtr = function(this: IPerformanceCounters; index: Cardinal): Int64Ptr; cdecl;
@@ -4063,7 +4063,7 @@ type
 
 	PerformanceCountersVTable = class(VersionedVTable)
 		getObjectCount: IPerformanceCounters_getObjectCountPtr;
-		getCountersCapacity: IPerformanceCounters_getCountersCapacityPtr;
+		getMaxCounterIndex: IPerformanceCounters_getMaxCounterIndexPtr;
 		getObjectId: IPerformanceCounters_getObjectIdPtr;
 		getObjectName: IPerformanceCounters_getObjectNamePtr;
 		getObjectCounters: IPerformanceCounters_getObjectCountersPtr;
@@ -4092,7 +4092,7 @@ type
 		const RECORD_IMGC = Cardinal(14);
 
 		function getObjectCount(): Cardinal;
-		function getCountersCapacity(): Cardinal;
+		function getMaxCounterIndex(): Cardinal;
 		function getObjectId(index: Cardinal): Cardinal;
 		function getObjectName(index: Cardinal): PAnsiChar;
 		function getObjectCounters(index: Cardinal): Int64Ptr;
@@ -4102,7 +4102,7 @@ type
 		constructor create;
 
 		function getObjectCount(): Cardinal; virtual; abstract;
-		function getCountersCapacity(): Cardinal; virtual; abstract;
+		function getMaxCounterIndex(): Cardinal; virtual; abstract;
 		function getObjectId(index: Cardinal): Cardinal; virtual; abstract;
 		function getObjectName(index: Cardinal): PAnsiChar; virtual; abstract;
 		function getObjectCounters(index: Cardinal): Int64Ptr; virtual; abstract;
@@ -10221,9 +10221,9 @@ begin
 	Result := PerformanceCountersVTable(vTable).getObjectCount(Self);
 end;
 
-function IPerformanceCounters.getCountersCapacity(): Cardinal;
+function IPerformanceCounters.getMaxCounterIndex(): Cardinal;
 begin
-	Result := PerformanceCountersVTable(vTable).getCountersCapacity(Self);
+	Result := PerformanceCountersVTable(vTable).getMaxCounterIndex(Self);
 end;
 
 function IPerformanceCounters.getObjectId(index: Cardinal): Cardinal;
@@ -17840,11 +17840,11 @@ begin
 	end
 end;
 
-function IPerformanceCountersImpl_getCountersCapacityDispatcher(this: IPerformanceCounters): Cardinal; cdecl;
+function IPerformanceCountersImpl_getMaxCounterIndexDispatcher(this: IPerformanceCounters): Cardinal; cdecl;
 begin
 	Result := 0;
 	try
-		Result := IPerformanceCountersImpl(this).getCountersCapacity();
+		Result := IPerformanceCountersImpl(this).getMaxCounterIndex();
 	except
 		on e: Exception do FbException.catchException(nil, e);
 	end
@@ -18994,7 +18994,7 @@ initialization
 	IPerformanceCountersImpl_vTable := PerformanceCountersVTable.create;
 	IPerformanceCountersImpl_vTable.version := 2;
 	IPerformanceCountersImpl_vTable.getObjectCount := @IPerformanceCountersImpl_getObjectCountDispatcher;
-	IPerformanceCountersImpl_vTable.getCountersCapacity := @IPerformanceCountersImpl_getCountersCapacityDispatcher;
+	IPerformanceCountersImpl_vTable.getMaxCounterIndex := @IPerformanceCountersImpl_getMaxCounterIndexDispatcher;
 	IPerformanceCountersImpl_vTable.getObjectId := @IPerformanceCountersImpl_getObjectIdDispatcher;
 	IPerformanceCountersImpl_vTable.getObjectName := @IPerformanceCountersImpl_getObjectNameDispatcher;
 	IPerformanceCountersImpl_vTable.getObjectCounters := @IPerformanceCountersImpl_getObjectCountersDispatcher;

--- a/src/include/gen/Firebird.pas
+++ b/src/include/gen/Firebird.pas
@@ -114,6 +114,8 @@ type
 	IProfilerPlugin = class;
 	IProfilerSession = class;
 	IProfilerStats = class;
+	IPerformanceCounters = class;
+	IPerformanceStats = class;
 
 	FbException = class(Exception)
 	public
@@ -611,11 +613,13 @@ type
 	ITraceTransaction_getPerfPtr = function(this: ITraceTransaction): PerformanceInfoPtr; cdecl;
 	ITraceTransaction_getInitialIDPtr = function(this: ITraceTransaction): Int64; cdecl;
 	ITraceTransaction_getPreviousIDPtr = function(this: ITraceTransaction): Int64; cdecl;
+	ITraceTransaction_getPerfStatsPtr = function(this: ITraceTransaction): IPerformanceStats; cdecl;
 	ITraceParams_getCountPtr = function(this: ITraceParams): Cardinal; cdecl;
 	ITraceParams_getParamPtr = function(this: ITraceParams; idx: Cardinal): paramdscPtr; cdecl;
 	ITraceParams_getTextUTF8Ptr = function(this: ITraceParams; status: IStatus; idx: Cardinal): PAnsiChar; cdecl;
 	ITraceStatement_getStmtIDPtr = function(this: ITraceStatement): Int64; cdecl;
 	ITraceStatement_getPerfPtr = function(this: ITraceStatement): PerformanceInfoPtr; cdecl;
+	ITraceStatement_getPerfStatsPtr = function(this: ITraceStatement): IPerformanceStats; cdecl;
 	ITraceSQLStatement_getTextPtr = function(this: ITraceSQLStatement): PAnsiChar; cdecl;
 	ITraceSQLStatement_getPlanPtr = function(this: ITraceSQLStatement): PAnsiChar; cdecl;
 	ITraceSQLStatement_getInputsPtr = function(this: ITraceSQLStatement): ITraceParams; cdecl;
@@ -636,6 +640,7 @@ type
 	ITraceProcedure_getStmtIDPtr = function(this: ITraceProcedure): Int64; cdecl;
 	ITraceProcedure_getPlanPtr = function(this: ITraceProcedure): PAnsiChar; cdecl;
 	ITraceProcedure_getExplainedPlanPtr = function(this: ITraceProcedure): PAnsiChar; cdecl;
+	ITraceProcedure_getPerfStatsPtr = function(this: ITraceProcedure): IPerformanceStats; cdecl;
 	ITraceFunction_getFuncNamePtr = function(this: ITraceFunction): PAnsiChar; cdecl;
 	ITraceFunction_getInputsPtr = function(this: ITraceFunction): ITraceParams; cdecl;
 	ITraceFunction_getResultPtr = function(this: ITraceFunction): ITraceParams; cdecl;
@@ -643,6 +648,7 @@ type
 	ITraceFunction_getStmtIDPtr = function(this: ITraceFunction): Int64; cdecl;
 	ITraceFunction_getPlanPtr = function(this: ITraceFunction): PAnsiChar; cdecl;
 	ITraceFunction_getExplainedPlanPtr = function(this: ITraceFunction): PAnsiChar; cdecl;
+	ITraceFunction_getPerfStatsPtr = function(this: ITraceFunction): IPerformanceStats; cdecl;
 	ITraceTrigger_getTriggerNamePtr = function(this: ITraceTrigger): PAnsiChar; cdecl;
 	ITraceTrigger_getRelationNamePtr = function(this: ITraceTrigger): PAnsiChar; cdecl;
 	ITraceTrigger_getActionPtr = function(this: ITraceTrigger): Integer; cdecl;
@@ -651,6 +657,7 @@ type
 	ITraceTrigger_getStmtIDPtr = function(this: ITraceTrigger): Int64; cdecl;
 	ITraceTrigger_getPlanPtr = function(this: ITraceTrigger): PAnsiChar; cdecl;
 	ITraceTrigger_getExplainedPlanPtr = function(this: ITraceTrigger): PAnsiChar; cdecl;
+	ITraceTrigger_getPerfStatsPtr = function(this: ITraceTrigger): IPerformanceStats; cdecl;
 	ITraceServiceConnection_getServiceIDPtr = function(this: ITraceServiceConnection): Pointer; cdecl;
 	ITraceServiceConnection_getServiceMgrPtr = function(this: ITraceServiceConnection): PAnsiChar; cdecl;
 	ITraceServiceConnection_getServiceNamePtr = function(this: ITraceServiceConnection): PAnsiChar; cdecl;
@@ -663,6 +670,7 @@ type
 	ITraceSweepInfo_getOATPtr = function(this: ITraceSweepInfo): Int64; cdecl;
 	ITraceSweepInfo_getNextPtr = function(this: ITraceSweepInfo): Int64; cdecl;
 	ITraceSweepInfo_getPerfPtr = function(this: ITraceSweepInfo): PerformanceInfoPtr; cdecl;
+	ITraceSweepInfo_getPerfStatsPtr = function(this: ITraceSweepInfo): IPerformanceStats; cdecl;
 	ITraceLogWriter_writePtr = function(this: ITraceLogWriter; buf: Pointer; size: Cardinal): Cardinal; cdecl;
 	ITraceLogWriter_write_sPtr = function(this: ITraceLogWriter; status: IStatus; buf: Pointer; size: Cardinal): Cardinal; cdecl;
 	ITraceInitInfo_getConfigTextPtr = function(this: ITraceInitInfo): PAnsiChar; cdecl;
@@ -770,6 +778,16 @@ type
 	IProfilerSession_afterRecordSourceGetRecordPtr = procedure(this: IProfilerSession; statementId: Int64; requestId: Int64; cursorId: Cardinal; recSourceId: Cardinal; stats: IProfilerStats); cdecl;
 	IProfilerSession_defineStatement2Ptr = procedure(this: IProfilerSession; status: IStatus; statementId: Int64; parentStatementId: Int64; type_: PAnsiChar; schemaName: PAnsiChar; packageName: PAnsiChar; routineName: PAnsiChar; sqlText: PAnsiChar); cdecl;
 	IProfilerStats_getElapsedTicksPtr = function(this: IProfilerStats): QWord; cdecl;
+	IPerformanceCounters_getCountPtr = function(this: IPerformanceCounters): Cardinal; cdecl;
+	IPerformanceCounters_getVectorCapacityPtr = function(this: IPerformanceCounters): Cardinal; cdecl;
+	IPerformanceCounters_getIdPtr = function(this: IPerformanceCounters; index: Cardinal): Cardinal; cdecl;
+	IPerformanceCounters_getNamePtr = function(this: IPerformanceCounters; index: Cardinal): PAnsiChar; cdecl;
+	IPerformanceCounters_getCounterVectorPtr = function(this: IPerformanceCounters; index: Cardinal): Int64Ptr; cdecl;
+	IPerformanceStats_getElapsedTimePtr = function(this: IPerformanceStats): QWord; cdecl;
+	IPerformanceStats_getFetchedRecordsPtr = function(this: IPerformanceStats): QWord; cdecl;
+	IPerformanceStats_getGlobalCountersPtr = function(this: IPerformanceStats): IPerformanceCounters; cdecl;
+	IPerformanceStats_getPageCountersPtr = function(this: IPerformanceStats): IPerformanceCounters; cdecl;
+	IPerformanceStats_getRelationCountersPtr = function(this: IPerformanceStats): IPerformanceCounters; cdecl;
 
 	VersionedVTable = class
 		version: NativeInt;
@@ -3052,10 +3070,11 @@ type
 		getPerf: ITraceTransaction_getPerfPtr;
 		getInitialID: ITraceTransaction_getInitialIDPtr;
 		getPreviousID: ITraceTransaction_getPreviousIDPtr;
+		getPerfStats: ITraceTransaction_getPerfStatsPtr;
 	end;
 
 	ITraceTransaction = class(IVersioned)
-		const VERSION = 3;
+		const VERSION = 4;
 		const ISOLATION_CONSISTENCY = Cardinal(1);
 		const ISOLATION_CONCURRENCY = Cardinal(2);
 		const ISOLATION_READ_COMMITTED_RECVER = Cardinal(3);
@@ -3069,6 +3088,7 @@ type
 		function getPerf(): PerformanceInfoPtr;
 		function getInitialID(): Int64;
 		function getPreviousID(): Int64;
+		function getPerfStats(): IPerformanceStats;
 	end;
 
 	ITraceTransactionImpl = class(ITraceTransaction)
@@ -3081,6 +3101,7 @@ type
 		function getPerf(): PerformanceInfoPtr; virtual; abstract;
 		function getInitialID(): Int64; virtual; abstract;
 		function getPreviousID(): Int64; virtual; abstract;
+		function getPerfStats(): IPerformanceStats; virtual; abstract;
 	end;
 
 	TraceParamsVTable = class(VersionedVTable)
@@ -3108,13 +3129,15 @@ type
 	TraceStatementVTable = class(VersionedVTable)
 		getStmtID: ITraceStatement_getStmtIDPtr;
 		getPerf: ITraceStatement_getPerfPtr;
+		getPerfStats: ITraceStatement_getPerfStatsPtr;
 	end;
 
 	ITraceStatement = class(IVersioned)
-		const VERSION = 2;
+		const VERSION = 3;
 
 		function getStmtID(): Int64;
 		function getPerf(): PerformanceInfoPtr;
+		function getPerfStats(): IPerformanceStats;
 	end;
 
 	ITraceStatementImpl = class(ITraceStatement)
@@ -3122,6 +3145,7 @@ type
 
 		function getStmtID(): Int64; virtual; abstract;
 		function getPerf(): PerformanceInfoPtr; virtual; abstract;
+		function getPerfStats(): IPerformanceStats; virtual; abstract;
 	end;
 
 	TraceSQLStatementVTable = class(TraceStatementVTable)
@@ -3133,7 +3157,7 @@ type
 	end;
 
 	ITraceSQLStatement = class(ITraceStatement)
-		const VERSION = 3;
+		const VERSION = 4;
 
 		function getText(): PAnsiChar;
 		function getPlan(): PAnsiChar;
@@ -3147,6 +3171,7 @@ type
 
 		function getStmtID(): Int64; virtual; abstract;
 		function getPerf(): PerformanceInfoPtr; virtual; abstract;
+		function getPerfStats(): IPerformanceStats; virtual; abstract;
 		function getText(): PAnsiChar; virtual; abstract;
 		function getPlan(): PAnsiChar; virtual; abstract;
 		function getInputs(): ITraceParams; virtual; abstract;
@@ -3161,7 +3186,7 @@ type
 	end;
 
 	ITraceBLRStatement = class(ITraceStatement)
-		const VERSION = 3;
+		const VERSION = 4;
 
 		function getData(): BytePtr;
 		function getDataLength(): Cardinal;
@@ -3173,6 +3198,7 @@ type
 
 		function getStmtID(): Int64; virtual; abstract;
 		function getPerf(): PerformanceInfoPtr; virtual; abstract;
+		function getPerfStats(): IPerformanceStats; virtual; abstract;
 		function getData(): BytePtr; virtual; abstract;
 		function getDataLength(): Cardinal; virtual; abstract;
 		function getText(): PAnsiChar; virtual; abstract;
@@ -3229,10 +3255,11 @@ type
 		getStmtID: ITraceProcedure_getStmtIDPtr;
 		getPlan: ITraceProcedure_getPlanPtr;
 		getExplainedPlan: ITraceProcedure_getExplainedPlanPtr;
+		getPerfStats: ITraceProcedure_getPerfStatsPtr;
 	end;
 
 	ITraceProcedure = class(IVersioned)
-		const VERSION = 3;
+		const VERSION = 4;
 
 		function getProcName(): PAnsiChar;
 		function getInputs(): ITraceParams;
@@ -3240,6 +3267,7 @@ type
 		function getStmtID(): Int64;
 		function getPlan(): PAnsiChar;
 		function getExplainedPlan(): PAnsiChar;
+		function getPerfStats(): IPerformanceStats;
 	end;
 
 	ITraceProcedureImpl = class(ITraceProcedure)
@@ -3251,6 +3279,7 @@ type
 		function getStmtID(): Int64; virtual; abstract;
 		function getPlan(): PAnsiChar; virtual; abstract;
 		function getExplainedPlan(): PAnsiChar; virtual; abstract;
+		function getPerfStats(): IPerformanceStats; virtual; abstract;
 	end;
 
 	TraceFunctionVTable = class(VersionedVTable)
@@ -3261,10 +3290,11 @@ type
 		getStmtID: ITraceFunction_getStmtIDPtr;
 		getPlan: ITraceFunction_getPlanPtr;
 		getExplainedPlan: ITraceFunction_getExplainedPlanPtr;
+		getPerfStats: ITraceFunction_getPerfStatsPtr;
 	end;
 
 	ITraceFunction = class(IVersioned)
-		const VERSION = 3;
+		const VERSION = 4;
 
 		function getFuncName(): PAnsiChar;
 		function getInputs(): ITraceParams;
@@ -3273,6 +3303,7 @@ type
 		function getStmtID(): Int64;
 		function getPlan(): PAnsiChar;
 		function getExplainedPlan(): PAnsiChar;
+		function getPerfStats(): IPerformanceStats;
 	end;
 
 	ITraceFunctionImpl = class(ITraceFunction)
@@ -3285,6 +3316,7 @@ type
 		function getStmtID(): Int64; virtual; abstract;
 		function getPlan(): PAnsiChar; virtual; abstract;
 		function getExplainedPlan(): PAnsiChar; virtual; abstract;
+		function getPerfStats(): IPerformanceStats; virtual; abstract;
 	end;
 
 	TraceTriggerVTable = class(VersionedVTable)
@@ -3296,10 +3328,11 @@ type
 		getStmtID: ITraceTrigger_getStmtIDPtr;
 		getPlan: ITraceTrigger_getPlanPtr;
 		getExplainedPlan: ITraceTrigger_getExplainedPlanPtr;
+		getPerfStats: ITraceTrigger_getPerfStatsPtr;
 	end;
 
 	ITraceTrigger = class(IVersioned)
-		const VERSION = 3;
+		const VERSION = 4;
 		const TYPE_ALL = Cardinal(0);
 		const TYPE_BEFORE = Cardinal(1);
 		const TYPE_AFTER = Cardinal(2);
@@ -3312,6 +3345,7 @@ type
 		function getStmtID(): Int64;
 		function getPlan(): PAnsiChar;
 		function getExplainedPlan(): PAnsiChar;
+		function getPerfStats(): IPerformanceStats;
 	end;
 
 	ITraceTriggerImpl = class(ITraceTrigger)
@@ -3325,6 +3359,7 @@ type
 		function getStmtID(): Int64; virtual; abstract;
 		function getPlan(): PAnsiChar; virtual; abstract;
 		function getExplainedPlan(): PAnsiChar; virtual; abstract;
+		function getPerfStats(): IPerformanceStats; virtual; abstract;
 	end;
 
 	TraceServiceConnectionVTable = class(TraceConnectionVTable)
@@ -3389,16 +3424,18 @@ type
 		getOAT: ITraceSweepInfo_getOATPtr;
 		getNext: ITraceSweepInfo_getNextPtr;
 		getPerf: ITraceSweepInfo_getPerfPtr;
+		getPerfStats: ITraceSweepInfo_getPerfStatsPtr;
 	end;
 
 	ITraceSweepInfo = class(IVersioned)
-		const VERSION = 2;
+		const VERSION = 3;
 
 		function getOIT(): Int64;
 		function getOST(): Int64;
 		function getOAT(): Int64;
 		function getNext(): Int64;
 		function getPerf(): PerformanceInfoPtr;
+		function getPerfStats(): IPerformanceStats;
 	end;
 
 	ITraceSweepInfoImpl = class(ITraceSweepInfo)
@@ -3409,6 +3446,7 @@ type
 		function getOAT(): Int64; virtual; abstract;
 		function getNext(): Int64; virtual; abstract;
 		function getPerf(): PerformanceInfoPtr; virtual; abstract;
+		function getPerfStats(): IPerformanceStats; virtual; abstract;
 	end;
 
 	TraceLogWriterVTable = class(ReferenceCountedVTable)
@@ -4023,6 +4061,62 @@ type
 		constructor create;
 
 		function getElapsedTicks(): QWord; virtual; abstract;
+	end;
+
+	PerformanceCountersVTable = class(VersionedVTable)
+		getCount: IPerformanceCounters_getCountPtr;
+		getVectorCapacity: IPerformanceCounters_getVectorCapacityPtr;
+		getId: IPerformanceCounters_getIdPtr;
+		getName: IPerformanceCounters_getNamePtr;
+		getCounterVector: IPerformanceCounters_getCounterVectorPtr;
+	end;
+
+	IPerformanceCounters = class(IVersioned)
+		const VERSION = 2;
+
+		function getCount(): Cardinal;
+		function getVectorCapacity(): Cardinal;
+		function getId(index: Cardinal): Cardinal;
+		function getName(index: Cardinal): PAnsiChar;
+		function getCounterVector(index: Cardinal): Int64Ptr;
+	end;
+
+	IPerformanceCountersImpl = class(IPerformanceCounters)
+		constructor create;
+
+		function getCount(): Cardinal; virtual; abstract;
+		function getVectorCapacity(): Cardinal; virtual; abstract;
+		function getId(index: Cardinal): Cardinal; virtual; abstract;
+		function getName(index: Cardinal): PAnsiChar; virtual; abstract;
+		function getCounterVector(index: Cardinal): Int64Ptr; virtual; abstract;
+	end;
+
+	PerformanceStatsVTable = class(VersionedVTable)
+		getElapsedTime: IPerformanceStats_getElapsedTimePtr;
+		getFetchedRecords: IPerformanceStats_getFetchedRecordsPtr;
+		getGlobalCounters: IPerformanceStats_getGlobalCountersPtr;
+		getPageCounters: IPerformanceStats_getPageCountersPtr;
+		getRelationCounters: IPerformanceStats_getRelationCountersPtr;
+	end;
+
+	IPerformanceStats = class(IVersioned)
+		const VERSION = 2;
+
+		function getElapsedTime(): QWord;
+		function getFetchedRecords(): QWord;
+		function getGlobalCounters(): IPerformanceCounters;
+		function getPageCounters(): IPerformanceCounters;
+		function getRelationCounters(): IPerformanceCounters;
+	end;
+
+	IPerformanceStatsImpl = class(IPerformanceStats)
+		constructor create;
+
+		function getElapsedTime(): QWord; virtual; abstract;
+		function getFetchedRecords(): QWord; virtual; abstract;
+		function getGlobalCounters(): IPerformanceCounters; virtual; abstract;
+		function getPageCounters(): IPerformanceCounters; virtual; abstract;
+		function getRelationCounters(): IPerformanceCounters; virtual; abstract;
 	end;
 
 {$IFNDEF NO_FBCLIENT}
@@ -9100,6 +9194,16 @@ begin
 	end;
 end;
 
+function ITraceTransaction.getPerfStats(): IPerformanceStats;
+begin
+	if (vTable.version < 4) then begin
+		Result := nil;
+	end
+	else begin
+		Result := TraceTransactionVTable(vTable).getPerfStats(Self);
+	end;
+end;
+
 function ITraceParams.getCount(): Cardinal;
 begin
 	Result := TraceParamsVTable(vTable).getCount(Self);
@@ -9130,6 +9234,16 @@ end;
 function ITraceStatement.getPerf(): PerformanceInfoPtr;
 begin
 	Result := TraceStatementVTable(vTable).getPerf(Self);
+end;
+
+function ITraceStatement.getPerfStats(): IPerformanceStats;
+begin
+	if (vTable.version < 3) then begin
+		Result := nil;
+	end
+	else begin
+		Result := TraceStatementVTable(vTable).getPerfStats(Self);
+	end;
 end;
 
 function ITraceSQLStatement.getText(): PAnsiChar;
@@ -9247,6 +9361,16 @@ begin
 	end;
 end;
 
+function ITraceProcedure.getPerfStats(): IPerformanceStats;
+begin
+	if (vTable.version < 4) then begin
+		Result := nil;
+	end
+	else begin
+		Result := TraceProcedureVTable(vTable).getPerfStats(Self);
+	end;
+end;
+
 function ITraceFunction.getFuncName(): PAnsiChar;
 begin
 	Result := TraceFunctionVTable(vTable).getFuncName(Self);
@@ -9294,6 +9418,16 @@ begin
 	end
 	else begin
 		Result := TraceFunctionVTable(vTable).getExplainedPlan(Self);
+	end;
+end;
+
+function ITraceFunction.getPerfStats(): IPerformanceStats;
+begin
+	if (vTable.version < 4) then begin
+		Result := nil;
+	end
+	else begin
+		Result := TraceFunctionVTable(vTable).getPerfStats(Self);
 	end;
 end;
 
@@ -9349,6 +9483,16 @@ begin
 	end
 	else begin
 		Result := TraceTriggerVTable(vTable).getExplainedPlan(Self);
+	end;
+end;
+
+function ITraceTrigger.getPerfStats(): IPerformanceStats;
+begin
+	if (vTable.version < 4) then begin
+		Result := nil;
+	end
+	else begin
+		Result := TraceTriggerVTable(vTable).getPerfStats(Self);
 	end;
 end;
 
@@ -9410,6 +9554,16 @@ end;
 function ITraceSweepInfo.getPerf(): PerformanceInfoPtr;
 begin
 	Result := TraceSweepInfoVTable(vTable).getPerf(Self);
+end;
+
+function ITraceSweepInfo.getPerfStats(): IPerformanceStats;
+begin
+	if (vTable.version < 3) then begin
+		Result := nil;
+	end
+	else begin
+		Result := TraceSweepInfoVTable(vTable).getPerfStats(Self);
+	end;
 end;
 
 function ITraceLogWriter.write(buf: Pointer; size: Cardinal): Cardinal;
@@ -10047,6 +10201,56 @@ end;
 function IProfilerStats.getElapsedTicks(): QWord;
 begin
 	Result := ProfilerStatsVTable(vTable).getElapsedTicks(Self);
+end;
+
+function IPerformanceCounters.getCount(): Cardinal;
+begin
+	Result := PerformanceCountersVTable(vTable).getCount(Self);
+end;
+
+function IPerformanceCounters.getVectorCapacity(): Cardinal;
+begin
+	Result := PerformanceCountersVTable(vTable).getVectorCapacity(Self);
+end;
+
+function IPerformanceCounters.getId(index: Cardinal): Cardinal;
+begin
+	Result := PerformanceCountersVTable(vTable).getId(Self, index);
+end;
+
+function IPerformanceCounters.getName(index: Cardinal): PAnsiChar;
+begin
+	Result := PerformanceCountersVTable(vTable).getName(Self, index);
+end;
+
+function IPerformanceCounters.getCounterVector(index: Cardinal): Int64Ptr;
+begin
+	Result := PerformanceCountersVTable(vTable).getCounterVector(Self, index);
+end;
+
+function IPerformanceStats.getElapsedTime(): QWord;
+begin
+	Result := PerformanceStatsVTable(vTable).getElapsedTime(Self);
+end;
+
+function IPerformanceStats.getFetchedRecords(): QWord;
+begin
+	Result := PerformanceStatsVTable(vTable).getFetchedRecords(Self);
+end;
+
+function IPerformanceStats.getGlobalCounters(): IPerformanceCounters;
+begin
+	Result := PerformanceStatsVTable(vTable).getGlobalCounters(Self);
+end;
+
+function IPerformanceStats.getPageCounters(): IPerformanceCounters;
+begin
+	Result := PerformanceStatsVTable(vTable).getPageCounters(Self);
+end;
+
+function IPerformanceStats.getRelationCounters(): IPerformanceCounters;
+begin
+	Result := PerformanceStatsVTable(vTable).getRelationCounters(Self);
 end;
 
 var
@@ -15428,6 +15632,16 @@ begin
 	end
 end;
 
+function ITraceTransactionImpl_getPerfStatsDispatcher(this: ITraceTransaction): IPerformanceStats; cdecl;
+begin
+	Result := nil;
+	try
+		Result := ITraceTransactionImpl(this).getPerfStats();
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
 var
 	ITraceTransactionImpl_vTable: TraceTransactionVTable;
 
@@ -15494,6 +15708,16 @@ begin
 	end
 end;
 
+function ITraceStatementImpl_getPerfStatsDispatcher(this: ITraceStatement): IPerformanceStats; cdecl;
+begin
+	Result := nil;
+	try
+		Result := ITraceStatementImpl(this).getPerfStats();
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
 var
 	ITraceStatementImpl_vTable: TraceStatementVTable;
 
@@ -15517,6 +15741,16 @@ begin
 	Result := nil;
 	try
 		Result := ITraceSQLStatementImpl(this).getPerf();
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
+function ITraceSQLStatementImpl_getPerfStatsDispatcher(this: ITraceSQLStatement): IPerformanceStats; cdecl;
+begin
+	Result := nil;
+	try
+		Result := ITraceSQLStatementImpl(this).getPerfStats();
 	except
 		on e: Exception do FbException.catchException(nil, e);
 	end
@@ -15595,6 +15829,16 @@ begin
 	Result := nil;
 	try
 		Result := ITraceBLRStatementImpl(this).getPerf();
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
+function ITraceBLRStatementImpl_getPerfStatsDispatcher(this: ITraceBLRStatement): IPerformanceStats; cdecl;
+begin
+	Result := nil;
+	try
+		Result := ITraceBLRStatementImpl(this).getPerfStats();
 	except
 		on e: Exception do FbException.catchException(nil, e);
 	end
@@ -15774,6 +16018,16 @@ begin
 	end
 end;
 
+function ITraceProcedureImpl_getPerfStatsDispatcher(this: ITraceProcedure): IPerformanceStats; cdecl;
+begin
+	Result := nil;
+	try
+		Result := ITraceProcedureImpl(this).getPerfStats();
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
 var
 	ITraceProcedureImpl_vTable: TraceProcedureVTable;
 
@@ -15847,6 +16101,16 @@ begin
 	Result := nil;
 	try
 		Result := ITraceFunctionImpl(this).getExplainedPlan();
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
+function ITraceFunctionImpl_getPerfStatsDispatcher(this: ITraceFunction): IPerformanceStats; cdecl;
+begin
+	Result := nil;
+	try
+		Result := ITraceFunctionImpl(this).getPerfStats();
 	except
 		on e: Exception do FbException.catchException(nil, e);
 	end
@@ -15935,6 +16199,16 @@ begin
 	Result := nil;
 	try
 		Result := ITraceTriggerImpl(this).getExplainedPlan();
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
+function ITraceTriggerImpl_getPerfStatsDispatcher(this: ITraceTrigger): IPerformanceStats; cdecl;
+begin
+	Result := nil;
+	try
+		Result := ITraceTriggerImpl(this).getPerfStats();
 	except
 		on e: Exception do FbException.catchException(nil, e);
 	end
@@ -16169,6 +16443,16 @@ begin
 	Result := nil;
 	try
 		Result := ITraceSweepInfoImpl(this).getPerf();
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
+function ITraceSweepInfoImpl_getPerfStatsDispatcher(this: ITraceSweepInfo): IPerformanceStats; cdecl;
+begin
+	Result := nil;
+	try
+		Result := ITraceSweepInfoImpl(this).getPerfStats();
 	except
 		on e: Exception do FbException.catchException(nil, e);
 	end
@@ -17543,6 +17827,122 @@ begin
 	vTable := IProfilerStatsImpl_vTable;
 end;
 
+function IPerformanceCountersImpl_getCountDispatcher(this: IPerformanceCounters): Cardinal; cdecl;
+begin
+	Result := 0;
+	try
+		Result := IPerformanceCountersImpl(this).getCount();
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
+function IPerformanceCountersImpl_getVectorCapacityDispatcher(this: IPerformanceCounters): Cardinal; cdecl;
+begin
+	Result := 0;
+	try
+		Result := IPerformanceCountersImpl(this).getVectorCapacity();
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
+function IPerformanceCountersImpl_getIdDispatcher(this: IPerformanceCounters; index: Cardinal): Cardinal; cdecl;
+begin
+	Result := 0;
+	try
+		Result := IPerformanceCountersImpl(this).getId(index);
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
+function IPerformanceCountersImpl_getNameDispatcher(this: IPerformanceCounters; index: Cardinal): PAnsiChar; cdecl;
+begin
+	Result := nil;
+	try
+		Result := IPerformanceCountersImpl(this).getName(index);
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
+function IPerformanceCountersImpl_getCounterVectorDispatcher(this: IPerformanceCounters; index: Cardinal): Int64Ptr; cdecl;
+begin
+	Result := nil;
+	try
+		Result := IPerformanceCountersImpl(this).getCounterVector(index);
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
+var
+	IPerformanceCountersImpl_vTable: PerformanceCountersVTable;
+
+constructor IPerformanceCountersImpl.create;
+begin
+	vTable := IPerformanceCountersImpl_vTable;
+end;
+
+function IPerformanceStatsImpl_getElapsedTimeDispatcher(this: IPerformanceStats): QWord; cdecl;
+begin
+	Result := 0;
+	try
+		Result := IPerformanceStatsImpl(this).getElapsedTime();
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
+function IPerformanceStatsImpl_getFetchedRecordsDispatcher(this: IPerformanceStats): QWord; cdecl;
+begin
+	Result := 0;
+	try
+		Result := IPerformanceStatsImpl(this).getFetchedRecords();
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
+function IPerformanceStatsImpl_getGlobalCountersDispatcher(this: IPerformanceStats): IPerformanceCounters; cdecl;
+begin
+	Result := nil;
+	try
+		Result := IPerformanceStatsImpl(this).getGlobalCounters();
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
+function IPerformanceStatsImpl_getPageCountersDispatcher(this: IPerformanceStats): IPerformanceCounters; cdecl;
+begin
+	Result := nil;
+	try
+		Result := IPerformanceStatsImpl(this).getPageCounters();
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
+function IPerformanceStatsImpl_getRelationCountersDispatcher(this: IPerformanceStats): IPerformanceCounters; cdecl;
+begin
+	Result := nil;
+	try
+		Result := IPerformanceStatsImpl(this).getRelationCounters();
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
+var
+	IPerformanceStatsImpl_vTable: PerformanceStatsVTable;
+
+constructor IPerformanceStatsImpl.create;
+begin
+	vTable := IPerformanceStatsImpl_vTable;
+end;
+
 constructor FbException.create(status: IStatus);
 begin
 	inherited Create('FbException');
@@ -18308,7 +18708,7 @@ initialization
 	ITraceDatabaseConnectionImpl_vTable.getDatabaseName := @ITraceDatabaseConnectionImpl_getDatabaseNameDispatcher;
 
 	ITraceTransactionImpl_vTable := TraceTransactionVTable.create;
-	ITraceTransactionImpl_vTable.version := 3;
+	ITraceTransactionImpl_vTable.version := 4;
 	ITraceTransactionImpl_vTable.getTransactionID := @ITraceTransactionImpl_getTransactionIDDispatcher;
 	ITraceTransactionImpl_vTable.getReadOnly := @ITraceTransactionImpl_getReadOnlyDispatcher;
 	ITraceTransactionImpl_vTable.getWait := @ITraceTransactionImpl_getWaitDispatcher;
@@ -18316,6 +18716,7 @@ initialization
 	ITraceTransactionImpl_vTable.getPerf := @ITraceTransactionImpl_getPerfDispatcher;
 	ITraceTransactionImpl_vTable.getInitialID := @ITraceTransactionImpl_getInitialIDDispatcher;
 	ITraceTransactionImpl_vTable.getPreviousID := @ITraceTransactionImpl_getPreviousIDDispatcher;
+	ITraceTransactionImpl_vTable.getPerfStats := @ITraceTransactionImpl_getPerfStatsDispatcher;
 
 	ITraceParamsImpl_vTable := TraceParamsVTable.create;
 	ITraceParamsImpl_vTable.version := 3;
@@ -18324,14 +18725,16 @@ initialization
 	ITraceParamsImpl_vTable.getTextUTF8 := @ITraceParamsImpl_getTextUTF8Dispatcher;
 
 	ITraceStatementImpl_vTable := TraceStatementVTable.create;
-	ITraceStatementImpl_vTable.version := 2;
+	ITraceStatementImpl_vTable.version := 3;
 	ITraceStatementImpl_vTable.getStmtID := @ITraceStatementImpl_getStmtIDDispatcher;
 	ITraceStatementImpl_vTable.getPerf := @ITraceStatementImpl_getPerfDispatcher;
+	ITraceStatementImpl_vTable.getPerfStats := @ITraceStatementImpl_getPerfStatsDispatcher;
 
 	ITraceSQLStatementImpl_vTable := TraceSQLStatementVTable.create;
-	ITraceSQLStatementImpl_vTable.version := 3;
+	ITraceSQLStatementImpl_vTable.version := 4;
 	ITraceSQLStatementImpl_vTable.getStmtID := @ITraceSQLStatementImpl_getStmtIDDispatcher;
 	ITraceSQLStatementImpl_vTable.getPerf := @ITraceSQLStatementImpl_getPerfDispatcher;
+	ITraceSQLStatementImpl_vTable.getPerfStats := @ITraceSQLStatementImpl_getPerfStatsDispatcher;
 	ITraceSQLStatementImpl_vTable.getText := @ITraceSQLStatementImpl_getTextDispatcher;
 	ITraceSQLStatementImpl_vTable.getPlan := @ITraceSQLStatementImpl_getPlanDispatcher;
 	ITraceSQLStatementImpl_vTable.getInputs := @ITraceSQLStatementImpl_getInputsDispatcher;
@@ -18339,9 +18742,10 @@ initialization
 	ITraceSQLStatementImpl_vTable.getExplainedPlan := @ITraceSQLStatementImpl_getExplainedPlanDispatcher;
 
 	ITraceBLRStatementImpl_vTable := TraceBLRStatementVTable.create;
-	ITraceBLRStatementImpl_vTable.version := 3;
+	ITraceBLRStatementImpl_vTable.version := 4;
 	ITraceBLRStatementImpl_vTable.getStmtID := @ITraceBLRStatementImpl_getStmtIDDispatcher;
 	ITraceBLRStatementImpl_vTable.getPerf := @ITraceBLRStatementImpl_getPerfDispatcher;
+	ITraceBLRStatementImpl_vTable.getPerfStats := @ITraceBLRStatementImpl_getPerfStatsDispatcher;
 	ITraceBLRStatementImpl_vTable.getData := @ITraceBLRStatementImpl_getDataDispatcher;
 	ITraceBLRStatementImpl_vTable.getDataLength := @ITraceBLRStatementImpl_getDataLengthDispatcher;
 	ITraceBLRStatementImpl_vTable.getText := @ITraceBLRStatementImpl_getTextDispatcher;
@@ -18359,16 +18763,17 @@ initialization
 	ITraceContextVariableImpl_vTable.getVarValue := @ITraceContextVariableImpl_getVarValueDispatcher;
 
 	ITraceProcedureImpl_vTable := TraceProcedureVTable.create;
-	ITraceProcedureImpl_vTable.version := 3;
+	ITraceProcedureImpl_vTable.version := 4;
 	ITraceProcedureImpl_vTable.getProcName := @ITraceProcedureImpl_getProcNameDispatcher;
 	ITraceProcedureImpl_vTable.getInputs := @ITraceProcedureImpl_getInputsDispatcher;
 	ITraceProcedureImpl_vTable.getPerf := @ITraceProcedureImpl_getPerfDispatcher;
 	ITraceProcedureImpl_vTable.getStmtID := @ITraceProcedureImpl_getStmtIDDispatcher;
 	ITraceProcedureImpl_vTable.getPlan := @ITraceProcedureImpl_getPlanDispatcher;
 	ITraceProcedureImpl_vTable.getExplainedPlan := @ITraceProcedureImpl_getExplainedPlanDispatcher;
+	ITraceProcedureImpl_vTable.getPerfStats := @ITraceProcedureImpl_getPerfStatsDispatcher;
 
 	ITraceFunctionImpl_vTable := TraceFunctionVTable.create;
-	ITraceFunctionImpl_vTable.version := 3;
+	ITraceFunctionImpl_vTable.version := 4;
 	ITraceFunctionImpl_vTable.getFuncName := @ITraceFunctionImpl_getFuncNameDispatcher;
 	ITraceFunctionImpl_vTable.getInputs := @ITraceFunctionImpl_getInputsDispatcher;
 	ITraceFunctionImpl_vTable.getResult := @ITraceFunctionImpl_getResultDispatcher;
@@ -18376,9 +18781,10 @@ initialization
 	ITraceFunctionImpl_vTable.getStmtID := @ITraceFunctionImpl_getStmtIDDispatcher;
 	ITraceFunctionImpl_vTable.getPlan := @ITraceFunctionImpl_getPlanDispatcher;
 	ITraceFunctionImpl_vTable.getExplainedPlan := @ITraceFunctionImpl_getExplainedPlanDispatcher;
+	ITraceFunctionImpl_vTable.getPerfStats := @ITraceFunctionImpl_getPerfStatsDispatcher;
 
 	ITraceTriggerImpl_vTable := TraceTriggerVTable.create;
-	ITraceTriggerImpl_vTable.version := 3;
+	ITraceTriggerImpl_vTable.version := 4;
 	ITraceTriggerImpl_vTable.getTriggerName := @ITraceTriggerImpl_getTriggerNameDispatcher;
 	ITraceTriggerImpl_vTable.getRelationName := @ITraceTriggerImpl_getRelationNameDispatcher;
 	ITraceTriggerImpl_vTable.getAction := @ITraceTriggerImpl_getActionDispatcher;
@@ -18387,6 +18793,7 @@ initialization
 	ITraceTriggerImpl_vTable.getStmtID := @ITraceTriggerImpl_getStmtIDDispatcher;
 	ITraceTriggerImpl_vTable.getPlan := @ITraceTriggerImpl_getPlanDispatcher;
 	ITraceTriggerImpl_vTable.getExplainedPlan := @ITraceTriggerImpl_getExplainedPlanDispatcher;
+	ITraceTriggerImpl_vTable.getPerfStats := @ITraceTriggerImpl_getPerfStatsDispatcher;
 
 	ITraceServiceConnectionImpl_vTable := TraceServiceConnectionVTable.create;
 	ITraceServiceConnectionImpl_vTable.version := 3;
@@ -18411,12 +18818,13 @@ initialization
 	ITraceStatusVectorImpl_vTable.getText := @ITraceStatusVectorImpl_getTextDispatcher;
 
 	ITraceSweepInfoImpl_vTable := TraceSweepInfoVTable.create;
-	ITraceSweepInfoImpl_vTable.version := 2;
+	ITraceSweepInfoImpl_vTable.version := 3;
 	ITraceSweepInfoImpl_vTable.getOIT := @ITraceSweepInfoImpl_getOITDispatcher;
 	ITraceSweepInfoImpl_vTable.getOST := @ITraceSweepInfoImpl_getOSTDispatcher;
 	ITraceSweepInfoImpl_vTable.getOAT := @ITraceSweepInfoImpl_getOATDispatcher;
 	ITraceSweepInfoImpl_vTable.getNext := @ITraceSweepInfoImpl_getNextDispatcher;
 	ITraceSweepInfoImpl_vTable.getPerf := @ITraceSweepInfoImpl_getPerfDispatcher;
+	ITraceSweepInfoImpl_vTable.getPerfStats := @ITraceSweepInfoImpl_getPerfStatsDispatcher;
 
 	ITraceLogWriterImpl_vTable := TraceLogWriterVTable.create;
 	ITraceLogWriterImpl_vTable.version := 4;
@@ -18600,6 +19008,22 @@ initialization
 	IProfilerStatsImpl_vTable.version := 2;
 	IProfilerStatsImpl_vTable.getElapsedTicks := @IProfilerStatsImpl_getElapsedTicksDispatcher;
 
+	IPerformanceCountersImpl_vTable := PerformanceCountersVTable.create;
+	IPerformanceCountersImpl_vTable.version := 2;
+	IPerformanceCountersImpl_vTable.getCount := @IPerformanceCountersImpl_getCountDispatcher;
+	IPerformanceCountersImpl_vTable.getVectorCapacity := @IPerformanceCountersImpl_getVectorCapacityDispatcher;
+	IPerformanceCountersImpl_vTable.getId := @IPerformanceCountersImpl_getIdDispatcher;
+	IPerformanceCountersImpl_vTable.getName := @IPerformanceCountersImpl_getNameDispatcher;
+	IPerformanceCountersImpl_vTable.getCounterVector := @IPerformanceCountersImpl_getCounterVectorDispatcher;
+
+	IPerformanceStatsImpl_vTable := PerformanceStatsVTable.create;
+	IPerformanceStatsImpl_vTable.version := 2;
+	IPerformanceStatsImpl_vTable.getElapsedTime := @IPerformanceStatsImpl_getElapsedTimeDispatcher;
+	IPerformanceStatsImpl_vTable.getFetchedRecords := @IPerformanceStatsImpl_getFetchedRecordsDispatcher;
+	IPerformanceStatsImpl_vTable.getGlobalCounters := @IPerformanceStatsImpl_getGlobalCountersDispatcher;
+	IPerformanceStatsImpl_vTable.getPageCounters := @IPerformanceStatsImpl_getPageCountersDispatcher;
+	IPerformanceStatsImpl_vTable.getRelationCounters := @IPerformanceStatsImpl_getRelationCountersDispatcher;
+
 finalization
 	IVersionedImpl_vTable.destroy;
 	IReferenceCountedImpl_vTable.destroy;
@@ -18699,5 +19123,7 @@ finalization
 	IProfilerPluginImpl_vTable.destroy;
 	IProfilerSessionImpl_vTable.destroy;
 	IProfilerStatsImpl_vTable.destroy;
+	IPerformanceCountersImpl_vTable.destroy;
+	IPerformanceStatsImpl_vTable.destroy;
 
 end.

--- a/src/include/gen/Firebird.pas
+++ b/src/include/gen/Firebird.pas
@@ -778,16 +778,15 @@ type
 	IProfilerSession_afterRecordSourceGetRecordPtr = procedure(this: IProfilerSession; statementId: Int64; requestId: Int64; cursorId: Cardinal; recSourceId: Cardinal; stats: IProfilerStats); cdecl;
 	IProfilerSession_defineStatement2Ptr = procedure(this: IProfilerSession; status: IStatus; statementId: Int64; parentStatementId: Int64; type_: PAnsiChar; schemaName: PAnsiChar; packageName: PAnsiChar; routineName: PAnsiChar; sqlText: PAnsiChar); cdecl;
 	IProfilerStats_getElapsedTicksPtr = function(this: IProfilerStats): QWord; cdecl;
-	IPerformanceCounters_getCountPtr = function(this: IPerformanceCounters): Cardinal; cdecl;
-	IPerformanceCounters_getVectorCapacityPtr = function(this: IPerformanceCounters): Cardinal; cdecl;
-	IPerformanceCounters_getIdPtr = function(this: IPerformanceCounters; index: Cardinal): Cardinal; cdecl;
-	IPerformanceCounters_getNamePtr = function(this: IPerformanceCounters; index: Cardinal): PAnsiChar; cdecl;
-	IPerformanceCounters_getCounterVectorPtr = function(this: IPerformanceCounters; index: Cardinal): Int64Ptr; cdecl;
+	IPerformanceCounters_getObjectCountPtr = function(this: IPerformanceCounters): Cardinal; cdecl;
+	IPerformanceCounters_getCountersCapacityPtr = function(this: IPerformanceCounters): Cardinal; cdecl;
+	IPerformanceCounters_getObjectIdPtr = function(this: IPerformanceCounters; index: Cardinal): Cardinal; cdecl;
+	IPerformanceCounters_getObjectNamePtr = function(this: IPerformanceCounters; index: Cardinal): PAnsiChar; cdecl;
+	IPerformanceCounters_getObjectCountersPtr = function(this: IPerformanceCounters; index: Cardinal): Int64Ptr; cdecl;
 	IPerformanceStats_getElapsedTimePtr = function(this: IPerformanceStats): QWord; cdecl;
 	IPerformanceStats_getFetchedRecordsPtr = function(this: IPerformanceStats): QWord; cdecl;
-	IPerformanceStats_getGlobalCountersPtr = function(this: IPerformanceStats): IPerformanceCounters; cdecl;
 	IPerformanceStats_getPageCountersPtr = function(this: IPerformanceStats): IPerformanceCounters; cdecl;
-	IPerformanceStats_getRelationCountersPtr = function(this: IPerformanceStats): IPerformanceCounters; cdecl;
+	IPerformanceStats_getTableCountersPtr = function(this: IPerformanceStats): IPerformanceCounters; cdecl;
 
 	VersionedVTable = class
 		version: NativeInt;
@@ -4064,39 +4063,57 @@ type
 	end;
 
 	PerformanceCountersVTable = class(VersionedVTable)
-		getCount: IPerformanceCounters_getCountPtr;
-		getVectorCapacity: IPerformanceCounters_getVectorCapacityPtr;
-		getId: IPerformanceCounters_getIdPtr;
-		getName: IPerformanceCounters_getNamePtr;
-		getCounterVector: IPerformanceCounters_getCounterVectorPtr;
+		getObjectCount: IPerformanceCounters_getObjectCountPtr;
+		getCountersCapacity: IPerformanceCounters_getCountersCapacityPtr;
+		getObjectId: IPerformanceCounters_getObjectIdPtr;
+		getObjectName: IPerformanceCounters_getObjectNamePtr;
+		getObjectCounters: IPerformanceCounters_getObjectCountersPtr;
 	end;
 
 	IPerformanceCounters = class(IVersioned)
 		const VERSION = 2;
+		const PAGE_FETCHES = Cardinal(0);
+		const PAGE_READS = Cardinal(1);
+		const PAGE_MARKS = Cardinal(2);
+		const PAGE_WRITES = Cardinal(3);
+		const RECORD_SEQ_READS = Cardinal(0);
+		const RECORD_IDX_READS = Cardinal(1);
+		const RECORD_UPDATES = Cardinal(2);
+		const RECORD_INSERTS = Cardinal(3);
+		const RECORD_DELETES = Cardinal(4);
+		const RECORD_BACKOUTS = Cardinal(5);
+		const RECORD_PURGES = Cardinal(6);
+		const RECORD_EXPUNGES = Cardinal(7);
+		const RECORD_LOCKS = Cardinal(8);
+		const RECORD_WAITS = Cardinal(9);
+		const RECORD_CONFLICTS = Cardinal(10);
+		const RECORD_BACK_READS = Cardinal(11);
+		const RECORD_FRAGMENT_READS = Cardinal(12);
+		const RECORD_RPT_READS = Cardinal(13);
+		const RECORD_IMGC = Cardinal(14);
 
-		function getCount(): Cardinal;
-		function getVectorCapacity(): Cardinal;
-		function getId(index: Cardinal): Cardinal;
-		function getName(index: Cardinal): PAnsiChar;
-		function getCounterVector(index: Cardinal): Int64Ptr;
+		function getObjectCount(): Cardinal;
+		function getCountersCapacity(): Cardinal;
+		function getObjectId(index: Cardinal): Cardinal;
+		function getObjectName(index: Cardinal): PAnsiChar;
+		function getObjectCounters(index: Cardinal): Int64Ptr;
 	end;
 
 	IPerformanceCountersImpl = class(IPerformanceCounters)
 		constructor create;
 
-		function getCount(): Cardinal; virtual; abstract;
-		function getVectorCapacity(): Cardinal; virtual; abstract;
-		function getId(index: Cardinal): Cardinal; virtual; abstract;
-		function getName(index: Cardinal): PAnsiChar; virtual; abstract;
-		function getCounterVector(index: Cardinal): Int64Ptr; virtual; abstract;
+		function getObjectCount(): Cardinal; virtual; abstract;
+		function getCountersCapacity(): Cardinal; virtual; abstract;
+		function getObjectId(index: Cardinal): Cardinal; virtual; abstract;
+		function getObjectName(index: Cardinal): PAnsiChar; virtual; abstract;
+		function getObjectCounters(index: Cardinal): Int64Ptr; virtual; abstract;
 	end;
 
 	PerformanceStatsVTable = class(VersionedVTable)
 		getElapsedTime: IPerformanceStats_getElapsedTimePtr;
 		getFetchedRecords: IPerformanceStats_getFetchedRecordsPtr;
-		getGlobalCounters: IPerformanceStats_getGlobalCountersPtr;
 		getPageCounters: IPerformanceStats_getPageCountersPtr;
-		getRelationCounters: IPerformanceStats_getRelationCountersPtr;
+		getTableCounters: IPerformanceStats_getTableCountersPtr;
 	end;
 
 	IPerformanceStats = class(IVersioned)
@@ -4104,9 +4121,8 @@ type
 
 		function getElapsedTime(): QWord;
 		function getFetchedRecords(): QWord;
-		function getGlobalCounters(): IPerformanceCounters;
 		function getPageCounters(): IPerformanceCounters;
-		function getRelationCounters(): IPerformanceCounters;
+		function getTableCounters(): IPerformanceCounters;
 	end;
 
 	IPerformanceStatsImpl = class(IPerformanceStats)
@@ -4114,9 +4130,8 @@ type
 
 		function getElapsedTime(): QWord; virtual; abstract;
 		function getFetchedRecords(): QWord; virtual; abstract;
-		function getGlobalCounters(): IPerformanceCounters; virtual; abstract;
 		function getPageCounters(): IPerformanceCounters; virtual; abstract;
-		function getRelationCounters(): IPerformanceCounters; virtual; abstract;
+		function getTableCounters(): IPerformanceCounters; virtual; abstract;
 	end;
 
 {$IFNDEF NO_FBCLIENT}
@@ -10203,29 +10218,29 @@ begin
 	Result := ProfilerStatsVTable(vTable).getElapsedTicks(Self);
 end;
 
-function IPerformanceCounters.getCount(): Cardinal;
+function IPerformanceCounters.getObjectCount(): Cardinal;
 begin
-	Result := PerformanceCountersVTable(vTable).getCount(Self);
+	Result := PerformanceCountersVTable(vTable).getObjectCount(Self);
 end;
 
-function IPerformanceCounters.getVectorCapacity(): Cardinal;
+function IPerformanceCounters.getCountersCapacity(): Cardinal;
 begin
-	Result := PerformanceCountersVTable(vTable).getVectorCapacity(Self);
+	Result := PerformanceCountersVTable(vTable).getCountersCapacity(Self);
 end;
 
-function IPerformanceCounters.getId(index: Cardinal): Cardinal;
+function IPerformanceCounters.getObjectId(index: Cardinal): Cardinal;
 begin
-	Result := PerformanceCountersVTable(vTable).getId(Self, index);
+	Result := PerformanceCountersVTable(vTable).getObjectId(Self, index);
 end;
 
-function IPerformanceCounters.getName(index: Cardinal): PAnsiChar;
+function IPerformanceCounters.getObjectName(index: Cardinal): PAnsiChar;
 begin
-	Result := PerformanceCountersVTable(vTable).getName(Self, index);
+	Result := PerformanceCountersVTable(vTable).getObjectName(Self, index);
 end;
 
-function IPerformanceCounters.getCounterVector(index: Cardinal): Int64Ptr;
+function IPerformanceCounters.getObjectCounters(index: Cardinal): Int64Ptr;
 begin
-	Result := PerformanceCountersVTable(vTable).getCounterVector(Self, index);
+	Result := PerformanceCountersVTable(vTable).getObjectCounters(Self, index);
 end;
 
 function IPerformanceStats.getElapsedTime(): QWord;
@@ -10238,19 +10253,14 @@ begin
 	Result := PerformanceStatsVTable(vTable).getFetchedRecords(Self);
 end;
 
-function IPerformanceStats.getGlobalCounters(): IPerformanceCounters;
-begin
-	Result := PerformanceStatsVTable(vTable).getGlobalCounters(Self);
-end;
-
 function IPerformanceStats.getPageCounters(): IPerformanceCounters;
 begin
 	Result := PerformanceStatsVTable(vTable).getPageCounters(Self);
 end;
 
-function IPerformanceStats.getRelationCounters(): IPerformanceCounters;
+function IPerformanceStats.getTableCounters(): IPerformanceCounters;
 begin
-	Result := PerformanceStatsVTable(vTable).getRelationCounters(Self);
+	Result := PerformanceStatsVTable(vTable).getTableCounters(Self);
 end;
 
 var
@@ -17827,51 +17837,51 @@ begin
 	vTable := IProfilerStatsImpl_vTable;
 end;
 
-function IPerformanceCountersImpl_getCountDispatcher(this: IPerformanceCounters): Cardinal; cdecl;
+function IPerformanceCountersImpl_getObjectCountDispatcher(this: IPerformanceCounters): Cardinal; cdecl;
 begin
 	Result := 0;
 	try
-		Result := IPerformanceCountersImpl(this).getCount();
+		Result := IPerformanceCountersImpl(this).getObjectCount();
 	except
 		on e: Exception do FbException.catchException(nil, e);
 	end
 end;
 
-function IPerformanceCountersImpl_getVectorCapacityDispatcher(this: IPerformanceCounters): Cardinal; cdecl;
+function IPerformanceCountersImpl_getCountersCapacityDispatcher(this: IPerformanceCounters): Cardinal; cdecl;
 begin
 	Result := 0;
 	try
-		Result := IPerformanceCountersImpl(this).getVectorCapacity();
+		Result := IPerformanceCountersImpl(this).getCountersCapacity();
 	except
 		on e: Exception do FbException.catchException(nil, e);
 	end
 end;
 
-function IPerformanceCountersImpl_getIdDispatcher(this: IPerformanceCounters; index: Cardinal): Cardinal; cdecl;
+function IPerformanceCountersImpl_getObjectIdDispatcher(this: IPerformanceCounters; index: Cardinal): Cardinal; cdecl;
 begin
 	Result := 0;
 	try
-		Result := IPerformanceCountersImpl(this).getId(index);
+		Result := IPerformanceCountersImpl(this).getObjectId(index);
 	except
 		on e: Exception do FbException.catchException(nil, e);
 	end
 end;
 
-function IPerformanceCountersImpl_getNameDispatcher(this: IPerformanceCounters; index: Cardinal): PAnsiChar; cdecl;
+function IPerformanceCountersImpl_getObjectNameDispatcher(this: IPerformanceCounters; index: Cardinal): PAnsiChar; cdecl;
 begin
 	Result := nil;
 	try
-		Result := IPerformanceCountersImpl(this).getName(index);
+		Result := IPerformanceCountersImpl(this).getObjectName(index);
 	except
 		on e: Exception do FbException.catchException(nil, e);
 	end
 end;
 
-function IPerformanceCountersImpl_getCounterVectorDispatcher(this: IPerformanceCounters; index: Cardinal): Int64Ptr; cdecl;
+function IPerformanceCountersImpl_getObjectCountersDispatcher(this: IPerformanceCounters; index: Cardinal): Int64Ptr; cdecl;
 begin
 	Result := nil;
 	try
-		Result := IPerformanceCountersImpl(this).getCounterVector(index);
+		Result := IPerformanceCountersImpl(this).getObjectCounters(index);
 	except
 		on e: Exception do FbException.catchException(nil, e);
 	end
@@ -17905,16 +17915,6 @@ begin
 	end
 end;
 
-function IPerformanceStatsImpl_getGlobalCountersDispatcher(this: IPerformanceStats): IPerformanceCounters; cdecl;
-begin
-	Result := nil;
-	try
-		Result := IPerformanceStatsImpl(this).getGlobalCounters();
-	except
-		on e: Exception do FbException.catchException(nil, e);
-	end
-end;
-
 function IPerformanceStatsImpl_getPageCountersDispatcher(this: IPerformanceStats): IPerformanceCounters; cdecl;
 begin
 	Result := nil;
@@ -17925,11 +17925,11 @@ begin
 	end
 end;
 
-function IPerformanceStatsImpl_getRelationCountersDispatcher(this: IPerformanceStats): IPerformanceCounters; cdecl;
+function IPerformanceStatsImpl_getTableCountersDispatcher(this: IPerformanceStats): IPerformanceCounters; cdecl;
 begin
 	Result := nil;
 	try
-		Result := IPerformanceStatsImpl(this).getRelationCounters();
+		Result := IPerformanceStatsImpl(this).getTableCounters();
 	except
 		on e: Exception do FbException.catchException(nil, e);
 	end
@@ -19010,19 +19010,18 @@ initialization
 
 	IPerformanceCountersImpl_vTable := PerformanceCountersVTable.create;
 	IPerformanceCountersImpl_vTable.version := 2;
-	IPerformanceCountersImpl_vTable.getCount := @IPerformanceCountersImpl_getCountDispatcher;
-	IPerformanceCountersImpl_vTable.getVectorCapacity := @IPerformanceCountersImpl_getVectorCapacityDispatcher;
-	IPerformanceCountersImpl_vTable.getId := @IPerformanceCountersImpl_getIdDispatcher;
-	IPerformanceCountersImpl_vTable.getName := @IPerformanceCountersImpl_getNameDispatcher;
-	IPerformanceCountersImpl_vTable.getCounterVector := @IPerformanceCountersImpl_getCounterVectorDispatcher;
+	IPerformanceCountersImpl_vTable.getObjectCount := @IPerformanceCountersImpl_getObjectCountDispatcher;
+	IPerformanceCountersImpl_vTable.getCountersCapacity := @IPerformanceCountersImpl_getCountersCapacityDispatcher;
+	IPerformanceCountersImpl_vTable.getObjectId := @IPerformanceCountersImpl_getObjectIdDispatcher;
+	IPerformanceCountersImpl_vTable.getObjectName := @IPerformanceCountersImpl_getObjectNameDispatcher;
+	IPerformanceCountersImpl_vTable.getObjectCounters := @IPerformanceCountersImpl_getObjectCountersDispatcher;
 
 	IPerformanceStatsImpl_vTable := PerformanceStatsVTable.create;
 	IPerformanceStatsImpl_vTable.version := 2;
 	IPerformanceStatsImpl_vTable.getElapsedTime := @IPerformanceStatsImpl_getElapsedTimeDispatcher;
 	IPerformanceStatsImpl_vTable.getFetchedRecords := @IPerformanceStatsImpl_getFetchedRecordsDispatcher;
-	IPerformanceStatsImpl_vTable.getGlobalCounters := @IPerformanceStatsImpl_getGlobalCountersDispatcher;
 	IPerformanceStatsImpl_vTable.getPageCounters := @IPerformanceStatsImpl_getPageCountersDispatcher;
-	IPerformanceStatsImpl_vTable.getRelationCounters := @IPerformanceStatsImpl_getRelationCountersDispatcher;
+	IPerformanceStatsImpl_vTable.getTableCounters := @IPerformanceStatsImpl_getTableCountersDispatcher;
 
 finalization
 	IVersionedImpl_vTable.destroy;

--- a/src/jrd/Monitoring.cpp
+++ b/src/jrd/Monitoring.cpp
@@ -1451,36 +1451,39 @@ void Monitoring::putStatistics(SnapshotData::DumpRecord& record, const RuntimeSt
 
 	// logical I/O statistics (table wise)
 
-	for (auto iter(statistics.getRelCounters()); iter; ++iter)
+	for (const auto& counts : statistics.getRelationCounters())
 	{
+		if (counts.isEmpty())
+			continue;
+
 		const auto rec_stat_id = getGlobalId(fb_utils::genUniqueId());
 
 		record.reset(rel_mon_tab_stats);
 		record.storeGlobalId(f_mon_tab_stat_id, id);
 		record.storeInteger(f_mon_tab_stat_group, stat_group);
-		record.storeTableIdSchemaName(f_mon_tab_sch_name, (*iter).getRelationId());
-		record.storeTableIdObjectName(f_mon_tab_name, (*iter).getRelationId());
+		record.storeTableIdSchemaName(f_mon_tab_sch_name, counts.getGroupKey());
+		record.storeTableIdObjectName(f_mon_tab_name, counts.getGroupKey());
 		record.storeGlobalId(f_mon_tab_rec_stat_id, rec_stat_id);
 		record.write();
 
 		record.reset(rel_mon_rec_stats);
 		record.storeGlobalId(f_mon_rec_stat_id, rec_stat_id);
 		record.storeInteger(f_mon_rec_stat_group, stat_group);
-		record.storeInteger(f_mon_rec_seq_reads, (*iter)[RecordStatType::SEQ_READS]);
-		record.storeInteger(f_mon_rec_idx_reads, (*iter)[RecordStatType::IDX_READS]);
-		record.storeInteger(f_mon_rec_inserts, (*iter)[RecordStatType::INSERTS]);
-		record.storeInteger(f_mon_rec_updates, (*iter)[RecordStatType::UPDATES]);
-		record.storeInteger(f_mon_rec_deletes, (*iter)[RecordStatType::DELETES]);
-		record.storeInteger(f_mon_rec_backouts, (*iter)[RecordStatType::BACKOUTS]);
-		record.storeInteger(f_mon_rec_purges, (*iter)[RecordStatType::PURGES]);
-		record.storeInteger(f_mon_rec_expunges, (*iter)[RecordStatType::EXPUNGES]);
-		record.storeInteger(f_mon_rec_locks, (*iter)[RecordStatType::LOCKS]);
-		record.storeInteger(f_mon_rec_waits, (*iter)[RecordStatType::WAITS]);
-		record.storeInteger(f_mon_rec_conflicts, (*iter)[RecordStatType::CONFLICTS]);
-		record.storeInteger(f_mon_rec_bkver_reads, (*iter)[RecordStatType::BACK_READS]);
-		record.storeInteger(f_mon_rec_frg_reads, (*iter)[RecordStatType::FRAGMENT_READS]);
-		record.storeInteger(f_mon_rec_rpt_reads, (*iter)[RecordStatType::RPT_READS]);
-		record.storeInteger(f_mon_rec_imgc, (*iter)[RecordStatType::IMGC]);
+		record.storeInteger(f_mon_rec_seq_reads, counts[RecordStatType::SEQ_READS]);
+		record.storeInteger(f_mon_rec_idx_reads, counts[RecordStatType::IDX_READS]);
+		record.storeInteger(f_mon_rec_inserts, counts[RecordStatType::INSERTS]);
+		record.storeInteger(f_mon_rec_updates, counts[RecordStatType::UPDATES]);
+		record.storeInteger(f_mon_rec_deletes, counts[RecordStatType::DELETES]);
+		record.storeInteger(f_mon_rec_backouts, counts[RecordStatType::BACKOUTS]);
+		record.storeInteger(f_mon_rec_purges, counts[RecordStatType::PURGES]);
+		record.storeInteger(f_mon_rec_expunges, counts[RecordStatType::EXPUNGES]);
+		record.storeInteger(f_mon_rec_locks, counts[RecordStatType::LOCKS]);
+		record.storeInteger(f_mon_rec_waits, counts[RecordStatType::WAITS]);
+		record.storeInteger(f_mon_rec_conflicts, counts[RecordStatType::CONFLICTS]);
+		record.storeInteger(f_mon_rec_bkver_reads, counts[RecordStatType::BACK_READS]);
+		record.storeInteger(f_mon_rec_frg_reads, counts[RecordStatType::FRAGMENT_READS]);
+		record.storeInteger(f_mon_rec_rpt_reads, counts[RecordStatType::RPT_READS]);
+		record.storeInteger(f_mon_rec_imgc, counts[RecordStatType::IMGC]);
 		record.write();
 	}
 }

--- a/src/jrd/Monitoring.cpp
+++ b/src/jrd/Monitoring.cpp
@@ -1451,7 +1451,7 @@ void Monitoring::putStatistics(SnapshotData::DumpRecord& record, const RuntimeSt
 
 	// logical I/O statistics (table wise)
 
-	for (const auto& counts : statistics.getRelationCounters())
+	for (const auto& counts : statistics.getTableCounters())
 	{
 		if (counts.isEmpty())
 			continue;
@@ -1461,8 +1461,8 @@ void Monitoring::putStatistics(SnapshotData::DumpRecord& record, const RuntimeSt
 		record.reset(rel_mon_tab_stats);
 		record.storeGlobalId(f_mon_tab_stat_id, id);
 		record.storeInteger(f_mon_tab_stat_group, stat_group);
-		record.storeTableIdSchemaName(f_mon_tab_sch_name, counts.getGroupKey());
-		record.storeTableIdObjectName(f_mon_tab_name, counts.getGroupKey());
+		record.storeTableIdSchemaName(f_mon_tab_sch_name, counts.getGroupId());
+		record.storeTableIdObjectName(f_mon_tab_name, counts.getGroupId());
 		record.storeGlobalId(f_mon_tab_rec_stat_id, rec_stat_id);
 		record.write();
 

--- a/src/jrd/RuntimeStatistics.cpp
+++ b/src/jrd/RuntimeStatistics.cpp
@@ -33,145 +33,6 @@ namespace Jrd {
 
 GlobalPtr<RuntimeStatistics> RuntimeStatistics::dummy;
 
-void RuntimeStatistics::adjustRelStats(const RuntimeStatistics& baseStats, const RuntimeStatistics& newStats)
-{
-	if (baseStats.relChgNumber == newStats.relChgNumber)
-		return;
-
-	relChgNumber++;
-
-	auto locate = [this](SLONG relId) -> FB_SIZE_T
-	{
-		FB_SIZE_T pos;
-		if (!rel_counts.find(relId, pos))
-			rel_counts.insert(pos, RelationCounts(relId));
-		return pos;
-	};
-
-	auto baseIter = baseStats.rel_counts.begin(), newIter = newStats.rel_counts.begin();
-	const auto baseEnd = baseStats.rel_counts.end(), newEnd = newStats.rel_counts.end();
-
-	// The loop below assumes that newStats cannot miss relations existing in baseStats,
-	// this must be always the case as long as newStats is an incremented version of baseStats
-
-	while (newIter != newEnd || baseIter != baseEnd)
-	{
-		if (baseIter == baseEnd)
-		{
-			// Relation exists in newStats but missing in baseStats
-			const auto newRelId = newIter->getRelationId();
-			rel_counts[locate(newRelId)] += *newIter++;
-		}
-		else if (newIter != newEnd)
-		{
-			const auto baseRelId = baseIter->getRelationId();
-			const auto newRelId = newIter->getRelationId();
-
-			if (newRelId == baseRelId)
-			{
-				// Relation exists in both newStats and baseStats
-				fb_assert(baseRelId == newRelId);
-				const auto pos = locate(baseRelId);
-				rel_counts[pos] -= *baseIter++;
-				rel_counts[pos] += *newIter++;
-			}
-			else if (newRelId < baseRelId)
-			{
-				// Relation exists in newStats but missing in baseStats
-				rel_counts[locate(newRelId)] += *newIter++;
-			}
-			else
-				fb_assert(false); // should never happen
-		}
-		else
-			fb_assert(false); // should never happen
-	}
-}
-
-PerformanceInfo* RuntimeStatistics::computeDifference(Attachment* att,
-													  const RuntimeStatistics& new_stat,
-													  PerformanceInfo& dest,
-													  TraceCountsArray& temp,
-													  ObjectsArray<string>& tempNames)
-{
-	// NOTE: we do not initialize dest.pin_time. This must be done by the caller
-
-	// Calculate database-level statistics
-	for (size_t i = 0; i < GLOBAL_ITEMS; i++)
-		values[i] = new_stat.values[i] - values[i];
-
-	dest.pin_counters = values;
-
-	// Calculate relation-level statistics
-	temp.clear();
-	tempNames.clear();
-
-	// This loop assumes that base array is smaller than new one
-	RelCounters::iterator base_cnts = rel_counts.begin();
-	bool base_found = (base_cnts != rel_counts.end());
-
-	for (const auto& new_cnts : new_stat.rel_counts)
-	{
-		const SLONG rel_id = new_cnts.getRelationId();
-
-		if (base_found && base_cnts->getRelationId() == rel_id)
-		{
-			// Point TraceCounts to counts array from baseline object
-			if (base_cnts->setToDiff(new_cnts))
-			{
-				jrd_rel* const relation =
-					rel_id < static_cast<SLONG>(att->att_relations->count()) ?
-					(*att->att_relations)[rel_id] : NULL;
-
-				TraceCounts traceCounts;
-				traceCounts.trc_relation_id = rel_id;
-				traceCounts.trc_counters = base_cnts->getCounterVector();
-
-				if (relation)
-				{
-					auto& tempName = tempNames.add();
-					tempName = relation->rel_name.toQuotedString();
-					traceCounts.trc_relation_name = tempName.c_str();
-				}
-				else
-					traceCounts.trc_relation_name = nullptr;
-
-				temp.add(traceCounts);
-			}
-
-			++base_cnts;
-			base_found = (base_cnts != rel_counts.end());
-		}
-		else
-		{
-			jrd_rel* const relation =
-				rel_id < static_cast<SLONG>(att->att_relations->count()) ?
-				(*att->att_relations)[rel_id] : NULL;
-
-			// Point TraceCounts to counts array from object with updated counters
-			TraceCounts traceCounts;
-			traceCounts.trc_relation_id = rel_id;
-			traceCounts.trc_counters = new_cnts.getCounterVector();
-
-			if (relation)
-			{
-				auto& tempName = tempNames.add();
-				tempName = relation->rel_name.toQuotedString();
-				traceCounts.trc_relation_name = tempName.c_str();
-			}
-			else
-				traceCounts.trc_relation_name = nullptr;
-
-			temp.add(traceCounts);
-		}
-	};
-
-	dest.pin_count = temp.getCount();
-	dest.pin_tables = temp.begin();
-
-	return &dest;
-}
-
 void RuntimeStatistics::adjust(const RuntimeStatistics& baseStats, const RuntimeStatistics& newStats)
 {
 	if (baseStats.allChgNumber == newStats.allChgNumber)
@@ -181,7 +42,17 @@ void RuntimeStatistics::adjust(const RuntimeStatistics& baseStats, const Runtime
 	for (size_t i = 0; i < GLOBAL_ITEMS; ++i)
 		values[i] += newStats.values[i] - baseStats.values[i];
 
-	adjustRelStats(baseStats, newStats);
+	if (baseStats.pageChgNumber != newStats.pageChgNumber)
+	{
+		pageChgNumber++;
+		page_counts.adjust(baseStats.page_counts, newStats.page_counts);
+	}
+
+	if (baseStats.relChgNumber != newStats.relChgNumber)
+	{
+		relChgNumber++;
+		rel_counts.adjust(baseStats.rel_counts, newStats.rel_counts);
+	}
 }
 
 void RuntimeStatistics::adjustPageStats(RuntimeStatistics& baseStats, const RuntimeStatistics& newStats)
@@ -197,6 +68,97 @@ void RuntimeStatistics::adjustPageStats(RuntimeStatistics& baseStats, const Runt
 		values[i] += delta;
 		baseStats.values[i] += delta;
 	}
+}
+
+template <class Counts, typename Key>
+void RuntimeStatistics::GroupedCountsArray<Counts, Key>::adjust(const GroupedCountsArray& baseStats, const GroupedCountsArray& newStats)
+{
+	auto baseIter = baseStats.m_counts.begin(), newIter = newStats.m_counts.begin();
+	const auto baseEnd = baseStats.m_counts.end(), newEnd = newStats.m_counts.end();
+
+	// The loop below assumes that newStats cannot miss objects existing in baseStats,
+	// this must be always the case as long as newStats is an incremented version of baseStats
+
+	while (newIter != newEnd || baseIter != baseEnd)
+	{
+		if (baseIter == baseEnd)
+		{
+			// Object exists in newStats but missing in baseStats
+			const auto newKey = newIter->getGroupKey();
+			(*this)[newKey] += *newIter++;
+		}
+		else if (newIter != newEnd)
+		{
+			const auto baseKey = baseIter->getGroupKey();
+			const auto newKey = newIter->getGroupKey();
+
+			if (newKey == baseKey)
+			{
+				// Object exists in both newStats and baseStats
+				(*this)[newKey] += *newIter++;
+				(*this)[newKey] -= *baseIter++;
+			}
+			else if (newKey < baseKey)
+			{
+				// Object exists in newStats but missing in baseStats
+				(*this)[newKey] += *newIter++;
+			}
+			else
+				fb_assert(false); // should never happen
+		}
+		else
+			fb_assert(false); // should never happen
+	}
+}
+
+PerformanceInfo* RuntimeStatistics::computeDifference(Attachment* att,
+													  const RuntimeStatistics& newStats,
+													  PerformanceInfo& dest,
+													  TraceCountsArray& relStatsTemp,
+													  ObjectsArray<string>& tempNames)
+{
+	// NOTE: we do not initialize dest.pin_time. This must be done by the caller
+
+	// Calculate database-level statistics
+
+	for (size_t i = 0; i < GLOBAL_ITEMS; i++)
+		values[i] = newStats.values[i] - values[i];
+
+	// Calculate relation-level statistics
+
+	relStatsTemp.clear();
+
+	for (const auto& newCounts : newStats.rel_counts)
+	{
+		const auto relationId = newCounts.getGroupKey();
+		auto& counts = rel_counts[relationId];
+
+		if (counts.setToDiff(newCounts))
+		{
+			const char* relationName = nullptr;
+
+			if (relationId < static_cast<SLONG>(att->att_relations->count()))
+			{
+				if (const auto relation = (*att->att_relations)[relationId])
+				{
+					auto& tempName = tempNames.add();
+					tempName = relation->rel_name.toQuotedString();
+					relationName = tempName.c_str();
+				}
+			}
+
+			TraceCounts traceCounts;
+			traceCounts.trc_relation_id = relationId;
+			traceCounts.trc_relation_name = relationName;
+			traceCounts.trc_counters = counts.getCounterVector();
+			relStatsTemp.add(traceCounts);
+		}
+	}
+
+	dest.pin_count = relStatsTemp.getCount();
+	dest.pin_tables = relStatsTemp.begin();
+
+	return &dest;
 }
 
 RuntimeStatistics::Accumulator::Accumulator(thread_db* tdbb, const jrd_rel* relation,

--- a/src/jrd/inf.cpp
+++ b/src/jrd/inf.cpp
@@ -273,11 +273,11 @@ void INF_database_info(thread_db* tdbb,
 		resultBuffer.clear();
 		FB_SIZE_T bufferLength = 0;
 
-		for (const auto& counts : recordStats->getRelationCounters())
+		for (const auto& counts : recordStats->getTableCounters())
 		{
 			if (const SINT64 n = counts[type])
 			{
-				const USHORT relationId = counts.getGroupKey();
+				const USHORT relationId = counts.getGroupId();
 				const USHORT length = INF_convert(n, numBuffer);
 				const FB_SIZE_T newBufferLength = bufferLength + length + sizeof(USHORT);
 				resultBuffer.grow(newBufferLength);

--- a/src/jrd/inf.cpp
+++ b/src/jrd/inf.cpp
@@ -273,11 +273,11 @@ void INF_database_info(thread_db* tdbb,
 		resultBuffer.clear();
 		FB_SIZE_T bufferLength = 0;
 
-		for (auto iter(recordStats->getRelCounters()); iter; ++iter)
+		for (const auto& counts : recordStats->getRelationCounters())
 		{
-			if (const SINT64 n = (*iter)[type])
+			if (const SINT64 n = counts[type])
 			{
-				const USHORT relationId = (*iter).getRelationId();
+				const USHORT relationId = counts.getGroupKey();
 				const USHORT length = INF_convert(n, numBuffer);
 				const FB_SIZE_T newBufferLength = bufferLength + length + sizeof(USHORT);
 				resultBuffer.grow(newBufferLength);

--- a/src/jrd/tra.cpp
+++ b/src/jrd/tra.cpp
@@ -4330,7 +4330,7 @@ void TraceSweepEvent::endSweepRelation(jrd_rel* relation)
 		fb_utils::query_performance_counter() - m_relation_clock,
 		0);
 
-	m_sweep_info.setPerf(stats.getPerf());
+	m_sweep_info.setStats(&stats);
 
 	TraceConnectionImpl conn(att);
 	TraceManager* trace_mgr = att->att_trace_manager;
@@ -4377,7 +4377,7 @@ void TraceSweepEvent::report(ntrace_process_state_t state)
 
 	TraceRuntimeStats stats(att, &m_base_stats, &att->att_stats, finiTime, 0);
 
-	m_sweep_info.setPerf(stats.getPerf());
+	m_sweep_info.setStats(&stats);
 	trace_mgr->event_sweep(&conn, &m_sweep_info, state);
 
 	if (state == ITracePlugin::SWEEP_STATE_FAILED || state == ITracePlugin::SWEEP_STATE_FINISHED)

--- a/src/jrd/trace/TraceDSQLHelpers.h
+++ b/src/jrd/trace/TraceDSQLHelpers.h
@@ -173,7 +173,7 @@ public:
 			fb_utils::query_performance_counter() - m_start_clock,
 			m_dsqlRequest->req_fetch_rowcount);
 
-		TraceSQLStatementImpl stmt(m_dsqlRequest, stats.getPerf(), m_data);
+		TraceSQLStatementImpl stmt(m_dsqlRequest, &stats, m_data);
 		TraceManager::event_dsql_execute(m_attachment, m_dsqlRequest->req_transaction, &stmt, false, result);
 
 		m_dsqlRequest->req_fetch_baseline = NULL;
@@ -233,7 +233,7 @@ public:
 			&m_dsqlRequest->getRequest()->req_stats, m_dsqlRequest->req_fetch_elapsed,
 			m_dsqlRequest->req_fetch_rowcount);
 
-		TraceSQLStatementImpl stmt(m_dsqlRequest, stats.getPerf(), nullptr);
+		TraceSQLStatementImpl stmt(m_dsqlRequest, &stats, nullptr);
 
 		TraceManager::event_dsql_execute(m_attachment, m_dsqlRequest->req_transaction,
 			&stmt, false, result);

--- a/src/jrd/trace/TraceJrdHelpers.h
+++ b/src/jrd/trace/TraceJrdHelpers.h
@@ -75,7 +75,7 @@ public:
 			fb_utils::query_performance_counter() - m_start_clock, 0);
 
 		TraceConnectionImpl conn(attachment);
-		TraceTransactionImpl tran(m_transaction, stats.getPerf(), m_prevID);
+		TraceTransactionImpl tran(m_transaction, &stats, m_prevID);
 
 		attachment->att_trace_manager->event_transaction_end(&conn, &tran, m_commit, m_retain, result);
 		m_baseline = NULL;
@@ -205,7 +205,7 @@ public:
 
 		TraceConnectionImpl conn(attachment);
 		TraceTransactionImpl tran(transaction);
-		TraceProcedureImpl proc(m_request, stats.getPerf());
+		TraceProcedureImpl proc(m_request, &stats);
 
 		const auto trace_mgr = attachment->att_trace_manager;
 		trace_mgr->event_proc_execute(&conn, &tran, &proc, false, result);
@@ -268,7 +268,7 @@ public:
 
 		TraceConnectionImpl conn(attachment);
 		TraceTransactionImpl tran(transaction);
-		TraceProcedureImpl proc(m_request, stats.getPerf());
+		TraceProcedureImpl proc(m_request, &stats);
 
 		const auto trace_mgr = attachment->att_trace_manager;
 		trace_mgr->event_proc_execute(&conn, &tran, &proc, false, result);
@@ -402,7 +402,7 @@ public:
 		TraceTransactionImpl tran(transaction);
 
 		TraceDscFromMsg inputs(m_request->getStatement()->function->getInputFormat(), m_inMsg, m_inMsgLength);
-		TraceFunctionImpl func(m_request, stats.getPerf(), inputs, value);
+		TraceFunctionImpl func(m_request, &stats, inputs, value);
 
 		const auto trace_mgr = attachment->att_trace_manager;
 		trace_mgr->event_func_execute(&conn, &tran, &func,  false, result);
@@ -566,7 +566,7 @@ public:
 
 		TraceConnectionImpl conn(attachment);
 		TraceTransactionImpl tran(transaction);
-		TraceTriggerImpl trig(m_which, m_request, stats.getPerf());
+		TraceTriggerImpl trig(m_which, m_request, &stats);
 
 		const auto trace_mgr = attachment->att_trace_manager;
 		trace_mgr->event_trigger_execute(&conn, &tran, &trig, false, result);
@@ -689,7 +689,7 @@ public:
 
 		TraceConnectionImpl conn(m_tdbb->getAttachment());
 		TraceTransactionImpl tran(m_tdbb->getTransaction());
-		TraceBLRStatementImpl stmt(m_request->getStatement(), stats.getPerf());
+		TraceBLRStatementImpl stmt(m_request->getStatement(), &stats);
 
 		TraceManager* trace_mgr = m_tdbb->getAttachment()->att_trace_manager;
 		trace_mgr->event_blr_execute(&conn, &tran, &stmt, result);

--- a/src/jrd/trace/TraceObjects.h
+++ b/src/jrd/trace/TraceObjects.h
@@ -124,9 +124,9 @@ class TraceRuntimeStats :
 			return m_counts ? m_counts->getCount() : 0;
 		}
 
-		unsigned getCountersCapacity()
+		unsigned getMaxCounterIndex()
 		{
-			return T::getVectorCapacity();
+			return T::getVectorCapacity() - 1;
 		}
 
 		unsigned getObjectId(unsigned index)

--- a/src/jrd/trace/TraceObjects.h
+++ b/src/jrd/trace/TraceObjects.h
@@ -182,14 +182,25 @@ public:
 		return m_info.pin_records_fetched;
 	}
 
-	Firebird::IPerformanceCounters* getPageCounters()
+	Firebird::IPerformanceCounters* getCounters(unsigned group)
 	{
-		return &m_pageCounters;
-	}
+		Firebird::IPerformanceCounters* counters = nullptr;
 
-	Firebird::IPerformanceCounters* getTableCounters()
-	{
-		return &m_tableCounters;
+		switch (group)
+		{
+			case IPerformanceStats::COUNTER_GROUP_PAGES:
+				counters = &m_pageCounters;
+				break;
+
+			case IPerformanceStats::COUNTER_GROUP_TABLES:
+				counters = &m_tableCounters;
+				break;
+
+			default:
+				fb_assert(false);
+		}
+
+		return counters;
 	}
 
 	Firebird::PerformanceInfo* getInfo()

--- a/src/utilities/ntrace/TracePluginImpl.cpp
+++ b/src/utilities/ntrace/TracePluginImpl.cpp
@@ -636,7 +636,8 @@ void TracePluginImpl::appendGlobalCounts(IPerformanceStats* stats)
 	temp.printf("%7" QUADFORMAT"d ms", stats->getElapsedTime());
 	record.append(temp);
 
-	const auto pageCounters = stats->getPageCounters();
+	const auto pageCounters = stats->getCounters(IPerformanceStats::COUNTER_GROUP_PAGES);
+	fb_assert(pageCounters);
 
 	if (const auto count = pageCounters->getObjectCount())
 	{
@@ -681,10 +682,14 @@ void TracePluginImpl::appendGlobalCounts(IPerformanceStats* stats)
 
 void TracePluginImpl::appendTableCounts(IPerformanceStats* stats)
 {
-	const auto tableCounters = stats->getTableCounters();
-	const auto count = tableCounters->getObjectCount();
+	if (!config.print_perf)
+		return;
 
-	if (!config.print_perf || !count)
+	const auto tableCounters = stats->getCounters(IPerformanceStats::COUNTER_GROUP_TABLES);
+	fb_assert(tableCounters);
+
+	const auto count = tableCounters->getObjectCount();
+	if (!count)
 		return;
 
 	FB_SIZE_T max_len = 0;

--- a/src/utilities/ntrace/TracePluginImpl.h
+++ b/src/utilities/ntrace/TracePluginImpl.h
@@ -178,8 +178,8 @@ private:
 	GdsCodesArray include_codes;
 	GdsCodesArray exclude_codes;
 
-	void appendGlobalCounts(const Firebird::PerformanceInfo* info);
-	void appendTableCounts(const Firebird::PerformanceInfo* info);
+	void appendGlobalCounts(Firebird::IPerformanceStats* stats);
+	void appendTableCounts(Firebird::IPerformanceStats* stats);
 	void appendParams(Firebird::ITraceParams* params);
 	void appendServiceQueryParams(size_t send_item_length, const ntrace_byte_t* send_items,
 								  size_t recv_item_length, const ntrace_byte_t* recv_items);


### PR DESCRIPTION
- Deprecate non-extendable PerformanceInfo struct in favor of the new PerformanceCounters/PerformanceStats interfaces
- Adjust the trace implementation to the new API
- Add internal support for per-pagespace I/O statistics. It's not used now, but will be used by PR #8314. This part is moved here to simplify review of the tablespaces.