### PR TITLE
Fixes a loop in the GENERATE_SERIES function on boundary values.

### DIFF
--- a/src/jrd/recsrc/RecordSource.h
+++ b/src/jrd/recsrc/RecordSource.h
@@ -1626,32 +1626,14 @@ namespace Jrd
 
 		struct Impure final : public TableValueFunctionScan::Impure
 		{
-			union
-			{
-				SINT64 vlu_int64;
-				Firebird::Int128 vlu_int128;
-			} m_start;
+			impure_value m_start;
+			impure_value m_finish;
+			impure_value m_step;
+			impure_value m_result;
 
-			union
-			{
-				SINT64 vlu_int64;
-				Firebird::Int128 vlu_int128;
-			} m_finish;
-
-			union
-			{
-				SINT64 vlu_int64;
-				Firebird::Int128 vlu_int128;
-			} m_step;
-
-			union
-			{
-				SINT64 vlu_int64;
-				Firebird::Int128 vlu_int128;
-			} m_result;
-
-			UCHAR m_dtype;
+			USHORT m_flags;
 			SCHAR m_scale;
+			SCHAR m_stepSign;
 		};
 
 	public:

--- a/src/jrd/recsrc/TableValueFunctionScan.cpp
+++ b/src/jrd/recsrc/TableValueFunctionScan.cpp
@@ -522,7 +522,13 @@ bool GenSeriesFunctionScan::nextBuffer(thread_db* tdbb) const
 			fromDesc.makeInt64(impure->m_scale, &result);
 			assignParameter(tdbb, &fromDesc, toDesc, 0, record);
 
-			result += step;
+			// Fixes freezing at boundary values.
+			if (((step < 0) && (result == MIN_SINT64)) || 
+				((step > 0) && (result == MAX_SINT64)))
+				impure->m_step.vlu_int64 = 0;
+			else
+			    result += step;
+
 			impure->m_result.vlu_int64 = result;
 
 			return true;
@@ -545,7 +551,12 @@ bool GenSeriesFunctionScan::nextBuffer(thread_db* tdbb) const
 			fromDesc.makeInt128(impure->m_scale, &result);
 			assignParameter(tdbb, &fromDesc, toDesc, 0, record);
 
-			result = result.add(step);
+			// Fixes freezing at boundary values.
+			if (((step.sign() < 0) && (result.compare(MIN_Int128) == 0)) ||
+				((step.sign() > 0) && (result.compare(MAX_Int128) == 0)))
+				impure->m_step.vlu_int128.set(0, 0);
+			else
+				result = result.add(step);
 			impure->m_result.vlu_int128 = result;
 
 			return true;

--- a/src/jrd/recsrc/TableValueFunctionScan.cpp
+++ b/src/jrd/recsrc/TableValueFunctionScan.cpp
@@ -441,7 +441,7 @@ void GenSeriesFunctionScan::internalOpen(thread_db* tdbb) const
 	}
 	// result = start
 	MOV_move(tdbb, startDesc, &impure->m_result.vlu_desc);
-	
+
 	impure->irsb_flags |= irsb_open;
 
 	VIO_record(tdbb, rpb, m_format, &pool);
@@ -493,9 +493,9 @@ bool GenSeriesFunctionScan::nextBuffer(thread_db* tdbb) const
 	const auto impure = request->getImpure<Impure>(m_impure);
 
 
-	const auto ñomparison = MOV_compare(tdbb, &impure->m_result.vlu_desc, &impure->m_finish.vlu_desc);
-	if (((impure->m_stepSign > 0) && (ñomparison <= 0)) ||
-		((impure->m_stepSign < 0) && (ñomparison >= 0)))
+	const auto comparison = MOV_compare(tdbb, &impure->m_result.vlu_desc, &impure->m_finish.vlu_desc);
+	if (((impure->m_stepSign > 0) && (comparison <= 0)) ||
+		((impure->m_stepSign < 0) && (comparison >= 0)))
 	{
 		Record* const record = request->req_rpb[m_stream].rpb_record;
 
@@ -504,7 +504,7 @@ bool GenSeriesFunctionScan::nextBuffer(thread_db* tdbb) const
 		assignParameter(tdbb, &impure->m_result.vlu_desc, toDesc, 0, record);
 
 		// evaluate next result
-		try 
+		try
 		{
 			impure_value nextValue;
 

--- a/src/jrd/recsrc/TableValueFunctionScan.cpp
+++ b/src/jrd/recsrc/TableValueFunctionScan.cpp
@@ -429,16 +429,18 @@ void GenSeriesFunctionScan::internalOpen(thread_db* tdbb) const
 	EVL_make_value(tdbb, finishDesc, &impure->m_finish);
 	EVL_make_value(tdbb, stepDesc, &impure->m_step);
 
-	switch (impure->m_result.vlu_desc.dsc_dtype) {
-	case dtype_int64:
-		impure->m_result.vlu_desc.dsc_address = reinterpret_cast<UCHAR*>(&impure->m_result.vlu_misc.vlu_int64);
-		break;
-	case dtype_int128:
-		impure->m_result.vlu_desc.dsc_address = reinterpret_cast<UCHAR*>(&impure->m_result.vlu_misc.vlu_int128);
-		break;
-	default:
-		fb_assert(false);
+	switch (impure->m_result.vlu_desc.dsc_dtype)
+	{
+		case dtype_int64:
+			impure->m_result.vlu_desc.dsc_address = reinterpret_cast<UCHAR*>(&impure->m_result.vlu_misc.vlu_int64);
+			break;
+		case dtype_int128:
+			impure->m_result.vlu_desc.dsc_address = reinterpret_cast<UCHAR*>(&impure->m_result.vlu_misc.vlu_int128);
+			break;
+		default:
+			fb_assert(false);
 	}
+
 	// result = start
 	MOV_move(tdbb, startDesc, &impure->m_result.vlu_desc);
 
@@ -492,7 +494,6 @@ bool GenSeriesFunctionScan::nextBuffer(thread_db* tdbb) const
 	const auto request = tdbb->getRequest();
 	const auto impure = request->getImpure<Impure>(m_impure);
 
-
 	const auto comparison = MOV_compare(tdbb, &impure->m_result.vlu_desc, &impure->m_finish.vlu_desc);
 	if (((impure->m_stepSign > 0) && (comparison <= 0)) ||
 		((impure->m_stepSign < 0) && (comparison >= 0)))
@@ -525,6 +526,7 @@ bool GenSeriesFunctionScan::nextBuffer(thread_db* tdbb) const
 			// stop evaluate next result
 			impure->m_stepSign = 0;
 		}
+
 		return true;
 	}
 

--- a/src/jrd/recsrc/TableValueFunctionScan.cpp
+++ b/src/jrd/recsrc/TableValueFunctionScan.cpp
@@ -522,10 +522,12 @@ bool GenSeriesFunctionScan::nextBuffer(thread_db* tdbb) const
 			fromDesc.makeInt64(impure->m_scale, &result);
 			assignParameter(tdbb, &fromDesc, toDesc, 0, record);
 
-			// Fixes freezing at boundary values.
-			if (((step < 0) && (result == MIN_SINT64)) || 
+			// Prevent freezing at boundary values
+			if (((step < 0) && (result == MIN_SINT64)) ||
 				((step > 0) && (result == MAX_SINT64)))
+			{
 				impure->m_step.vlu_int64 = 0;
+			}
 			else
 			    result += step;
 
@@ -551,10 +553,12 @@ bool GenSeriesFunctionScan::nextBuffer(thread_db* tdbb) const
 			fromDesc.makeInt128(impure->m_scale, &result);
 			assignParameter(tdbb, &fromDesc, toDesc, 0, record);
 
-			// Fixes freezing at boundary values.
+			// Prevent freezing at boundary values
 			if (((step.sign() < 0) && (result.compare(MIN_Int128) == 0)) ||
 				((step.sign() > 0) && (result.compare(MAX_Int128) == 0)))
+			{
 				impure->m_step.vlu_int128.set(0, 0);
+			}
 			else
 				result = result.add(step);
 			impure->m_result.vlu_int128 = result;

--- a/src/jrd/recsrc/TableValueFunctionScan.cpp
+++ b/src/jrd/recsrc/TableValueFunctionScan.cpp
@@ -407,54 +407,41 @@ void GenSeriesFunctionScan::internalOpen(thread_db* tdbb) const
 	const auto impure = request->getImpure<Impure>(m_impure);
 	impure->m_recordBuffer = nullptr;
 
-	// common scale
-	impure->m_scale = MIN(MIN(startDesc->dsc_scale, finishDesc->dsc_scale), stepDesc->dsc_scale);
-	// common type
-	impure->m_dtype = MAX(MAX(startDesc->dsc_dtype, finishDesc->dsc_dtype), stepDesc->dsc_dtype);
+	ArithmeticNode::getDescDialect3(tdbb, &impure->m_result.vlu_desc, *startDesc, *stepDesc, blr_add, &impure->m_scale, &impure->m_flags);
 
-	if (impure->m_dtype != dtype_int128)
+	SLONG zero = 0;
+	dsc zeroDesc;
+	zeroDesc.makeLong(0, &zero);
+	impure->m_stepSign = MOV_compare(tdbb, stepDesc, &zeroDesc);
+
+	if (impure->m_stepSign == 0)
+		status_exception::raise(Arg::Gds(isc_genseq_stepmustbe_nonzero) << Arg::Str(m_name));
+
+	const auto boundaryComparison = MOV_compare(tdbb, startDesc, finishDesc);
+	// validate parameter value
+	if (((impure->m_stepSign > 0) && (boundaryComparison > 0)) ||
+		((impure->m_stepSign < 0) && (boundaryComparison < 0)))
 	{
-		const auto start = MOV_get_int64(tdbb, startDesc, impure->m_scale);
-		const auto finish = MOV_get_int64(tdbb, finishDesc, impure->m_scale);
-		const auto step = MOV_get_int64(tdbb, stepDesc, impure->m_scale);
-
-		if (step == 0)
-			status_exception::raise(Arg::Gds(isc_genseq_stepmustbe_nonzero) << Arg::Str(m_name));
-
-		// validate parameter value
-		if (((step > 0) && (start > finish)) ||
-			((step < 0) && (start < finish)))
-		{
-			return;
-		}
-
-		impure->m_start.vlu_int64 = start;
-		impure->m_finish.vlu_int64 = finish;
-		impure->m_step.vlu_int64 = step;
-		impure->m_result.vlu_int64 = start;
-	}
-	else
-	{
-		const auto start = MOV_get_int128(tdbb, startDesc, impure->m_scale);
-		const auto finish = MOV_get_int128(tdbb, finishDesc, impure->m_scale);
-		const auto step = MOV_get_int128(tdbb, stepDesc, impure->m_scale);
-
-		if (step.sign() == 0)
-			status_exception::raise(Arg::Gds(isc_genseq_stepmustbe_nonzero) << Arg::Str(m_name));
-
-		// validate parameter value
-		if (((step.sign() > 0) && (start.compare(finish) > 0)) ||
-			((step.sign() < 0) && (start.compare(finish) < 0)))
-		{
-			return;
-		}
-
-		impure->m_start.vlu_int128 = start;
-		impure->m_finish.vlu_int128 = finish;
-		impure->m_step.vlu_int128 = step;
-		impure->m_result.vlu_int128 = start;
+		return;
 	}
 
+	EVL_make_value(tdbb, startDesc, &impure->m_start);
+	EVL_make_value(tdbb, finishDesc, &impure->m_finish);
+	EVL_make_value(tdbb, stepDesc, &impure->m_step);
+
+	switch (impure->m_result.vlu_desc.dsc_dtype) {
+	case dtype_int64:
+		impure->m_result.vlu_desc.dsc_address = reinterpret_cast<UCHAR*>(&impure->m_result.vlu_misc.vlu_int64);
+		break;
+	case dtype_int128:
+		impure->m_result.vlu_desc.dsc_address = reinterpret_cast<UCHAR*>(&impure->m_result.vlu_misc.vlu_int128);
+		break;
+	default:
+		fb_assert(false);
+	}
+	// result = start
+	MOV_move(tdbb, startDesc, &impure->m_result.vlu_desc);
+	
 	impure->irsb_flags |= irsb_open;
 
 	VIO_record(tdbb, rpb, m_format, &pool);
@@ -505,93 +492,40 @@ bool GenSeriesFunctionScan::nextBuffer(thread_db* tdbb) const
 	const auto request = tdbb->getRequest();
 	const auto impure = request->getImpure<Impure>(m_impure);
 
-	if (impure->m_dtype != dtype_int128)
+
+	const auto ñomparison = MOV_compare(tdbb, &impure->m_result.vlu_desc, &impure->m_finish.vlu_desc);
+	if (((impure->m_stepSign > 0) && (ñomparison <= 0)) ||
+		((impure->m_stepSign < 0) && (ñomparison >= 0)))
 	{
-		auto result = impure->m_result.vlu_int64;
-		const auto finish = impure->m_finish.vlu_int64;
-		const auto step = impure->m_step.vlu_int64;
+		Record* const record = request->req_rpb[m_stream].rpb_record;
 
-		if (((step > 0) && (result <= finish)) ||
-			((step < 0) && (result >= finish)))
+		auto toDesc = m_format->fmt_desc.begin();
+
+		assignParameter(tdbb, &impure->m_result.vlu_desc, toDesc, 0, record);
+
+		// evaluate next result
+		try 
 		{
-			Record* const record = request->req_rpb[m_stream].rpb_record;
+			impure_value nextValue;
 
-			auto toDesc = m_format->fmt_desc.begin();
+			ArithmeticNode::add(tdbb,
+				&impure->m_step.vlu_desc,
+				&impure->m_result.vlu_desc,
+				&nextValue,
+				blr_add,
+				false,
+				impure->m_scale,
+				impure->m_flags);
 
-			dsc fromDesc;
-			fromDesc.makeInt64(impure->m_scale, &result);
-			assignParameter(tdbb, &fromDesc, toDesc, 0, record);
-
-			// Prevents overflows for SINT64 type at boundary values
-			bool reachedBoundary = false;
-			if (step > 0)
-			{
-				if (result > MAX_SINT64 - step)
-					reachedBoundary = true;
-				else
-					reachedBoundary = (result + step > finish);
-			}
-			else if (step < 0)
-			{
-				if (result < MIN_SINT64 - step)
-					reachedBoundary = true;
-				else
-					reachedBoundary = (result + step < finish);
-			}
-
-			if ((result == finish) || reachedBoundary)
-				impure->m_step.vlu_int64 = 0;
-			else
-			    result += step;
-
-			impure->m_result.vlu_int64 = result;
-
-			return true;
+			MOV_move(tdbb, &nextValue.vlu_desc, &impure->m_result.vlu_desc);
 		}
-	}
-	else
-	{
-		auto result = impure->m_result.vlu_int128;
-		const auto finish = impure->m_finish.vlu_int128;
-		const auto step = impure->m_step.vlu_int128;
-
-		if (((step.sign() > 0) && (result.compare(finish) <= 0)) ||
-			((step.sign() < 0) && (result.compare(finish) >= 0)))
+		catch (const status_exception&)
 		{
-			Record* const record = request->req_rpb[m_stream].rpb_record;
-
-			auto toDesc = m_format->fmt_desc.begin();
-
-			dsc fromDesc;
-			fromDesc.makeInt128(impure->m_scale, &result);
-			assignParameter(tdbb, &fromDesc, toDesc, 0, record);
-
-			// Prevents overflows for INT128 type at boundary values
-			bool reachedBoundary = false;
-			if (step.sign() > 0)
-			{
-				if (result.compare(MAX_Int128.sub(step)) > 0)
-					reachedBoundary = true;
-				else
-					reachedBoundary = (result.add(step).compare(finish) > 0);
-			}
-			else if (step.sign() < 0)
-			{
-				if (result.compare(MIN_Int128.sub(step)) < 0)
-					reachedBoundary = true;
-				else
-					reachedBoundary = (result.add(step).compare(finish) < 0);
-			}
-
-			if (reachedBoundary || (result.compare(finish) == 0))
-				impure->m_step.vlu_int128.set(0, 0);
-			else
-				result = result.add(step);
-
-			impure->m_result.vlu_int128 = result;
-
-			return true;
+			tdbb->tdbb_status_vector->clearException();
+			// stop evaluate next result
+			impure->m_stepSign = 0;
 		}
+		return true;
 	}
 
 	return false;


### PR DESCRIPTION
The GENERATE_SERIES function behaves incorrectly at boundary values ​​for the BIGINT and INT128 types. A loop occurs with the BIGINT type, and an exception is thrown with the INT128 type. Examples of incorrect behavior:

```sql
select * from generate_series(-9223372036854775807, -9223372036854775809, -1) as x rows 10;
```

```
INPUT message field count: 0
 
OUTPUT message field count: 1
01: sqltype: 32752 INT128 scale: 0 subtype: 0 len: 16
  :  name: GENERATE_SERIES  alias: GENERATE_SERIES
  : table:   schema:   owner:
 
                              GENERATE_SERIES
=============================================
                         -9223372036854775807
                         -9223372036854775808
                         -9223372036854775809
```

(OK, expected)

```sql
select * from generate_series(-9223372036854775807, -9223372036854775808, -1) as x rows 10;
```

```
INPUT message field count: 0
 
OUTPUT message field count: 1
01: sqltype: 580 INT64 scale: 0 subtype: 0 len: 8
  :  name: GENERATE_SERIES  alias: GENERATE_SERIES
  : table:   schema:   owner:
 
      GENERATE_SERIES
=====================
 -9223372036854775807
 -9223372036854775808
  9223372036854775807 // <-- Error. 
  9223372036854775806
  9223372036854775805
  9223372036854775804
  9223372036854775803
  9223372036854775802
  9223372036854775801
  9223372036854775800
===============
```

For `INT128` example:

```sql
select * from generate_series(bin_shl(cast(2 as int128),126)+1, bin_shl(cast(2 as int128),126), -1) as x rows 10;
```

```
INPUT message field count: 0

OUTPUT message field count: 1
01: sqltype: 32752 INT128 scale: 0 subtype: 0 len: 16
  :  name: GENERATE_SERIES  alias: GENERATE_SERIES
  : table:   schema:   owner:

                              GENERATE_SERIES
=============================================
     -170141183460469231731687303715884105727
Statement failed, SQLSTATE = 22003
arithmetic exception, numeric overflow, or string truncation
-Integer overflow.  The result of an integer operation caused the most significant bit of the result to carry.
```