### PR TITLE
Restore the broken record layout optimization by gbak and extend it to the new datatypes

### DIFF
--- a/src/burp/backup.epp
+++ b/src/burp/backup.epp
@@ -1940,6 +1940,7 @@ void put_relation( burp_rel* relation)
 	burp_fld* unaligned = NULL;
 	burp_fld* aligned4 = NULL;
 	burp_fld* aligned8 = NULL;
+	burp_fld* aligned16 = NULL;
 
 	burp_fld* fields = get_fields(relation);
 
@@ -1951,7 +1952,13 @@ void put_relation( burp_rel* relation)
 		USHORT l = field->fld_length;
 		if (field->fld_type == blr_varying)
 			l += sizeof(USHORT);
-		if (!(l & 7))
+
+		if (!(l & 15))
+		{
+			field->fld_next = aligned16;
+			aligned16 = field;
+		}
+		else if (!(l & 7))
 		{
 			field->fld_next = aligned8;
 			aligned8 = field;
@@ -2001,6 +2008,13 @@ void put_relation( burp_rel* relation)
 	while ((field = aligned8))
 	{
 		aligned8 = field->fld_next;
+		field->fld_next = relation->rel_fields;
+		relation->rel_fields = field;
+	}
+
+	while ((field = aligned16))
+	{
+		aligned16 = field->fld_next;
 		field->fld_next = relation->rel_fields;
 		relation->rel_fields = field;
 	}

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -132,7 +132,7 @@ bool	get_collation(BurpGlobals* tdgbl);
 SLONG	get_compressed(BurpGlobals* tdgbl, UCHAR* buffer, SLONG length);
 void	get_data(BurpGlobals* tdgbl, burp_rel*, WriteRelationReq* req);
 bool	get_exception(BurpGlobals* tdgbl);
-burp_fld*	get_field(BurpGlobals* tdgbl, burp_rel*);
+burp_fld*	get_field(BurpGlobals* tdgbl, burp_rel*, USHORT id);
 bool	get_field_dimensions(BurpGlobals* tdgbl);
 bool	get_files(BurpGlobals* tdgbl);
 bool	get_filter(BurpGlobals* tdgbl);
@@ -3806,7 +3806,7 @@ bool get_exception(BurpGlobals* tdgbl)
 }
 
 
-burp_fld* get_field(BurpGlobals* tdgbl, burp_rel* relation)
+burp_fld* get_field(BurpGlobals* tdgbl, burp_rel* relation, USHORT id)
 {
 /**************************************
  *
@@ -3864,6 +3864,9 @@ burp_fld* get_field(BurpGlobals* tdgbl, burp_rel* relation)
 			X.RDB$IDENTITY_TYPE.NULL = TRUE;
 			// ODS 14
 			X.RDB$FIELD_SOURCE_SCHEMA_NAME.NULL = TRUE;
+
+			X.RDB$FIELD_ID.NULL = FALSE;
+			X.RDB$FIELD_ID = id;
 
 			if (relation->rel_name.schema.hasData())
 			{
@@ -4083,6 +4086,9 @@ burp_fld* get_field(BurpGlobals* tdgbl, burp_rel* relation)
 			X.RDB$DEFAULT_VALUE.NULL = TRUE;
 			X.RDB$NULL_FLAG.NULL = TRUE;
 			X.RDB$COLLATION_ID.NULL = TRUE;
+
+			X.RDB$FIELD_ID.NULL = FALSE;
+			X.RDB$FIELD_ID = id;
 
 			skip_init(&scan_next_attr);
 			while (get_attribute(&attribute, tdgbl) != att_end)
@@ -8249,6 +8255,7 @@ bool get_relation(BurpGlobals* tdgbl, Coordinator* coord, RestoreRelationTask* t
 	// Eat up misc. records
 	burp_fld* field = NULL;
 	burp_fld** ptr = &relation->rel_fields;
+	USHORT id = 0;
 
 	rec_type record;
 	while (get_record(&record, tdgbl) != rec_data)
@@ -8277,7 +8284,7 @@ bool get_relation(BurpGlobals* tdgbl, Coordinator* coord, RestoreRelationTask* t
 			return true;
 
 		case rec_field:
-			*ptr = field = get_field (tdgbl, relation);
+			*ptr = field = get_field(tdgbl, relation, id++);
 			if (!field)
 				return false;
 			ptr = &field->fld_next;


### PR DESCRIPTION
The order of field ID generation inside DFW is not reliable, because it joins two system tables and generally the retrieval order would depend on the query plan. The added `SORTED BY` clause fixes it for `CREATE/ALTER TABLE`, but the resulting order does not match the order of insertions into `RDB$RELATION_FIELDS` anymore. However, _gbak_ does its best to optimize the record layout and it relies on the ID generation being performed in the storage order. Thus I moved the ID generation to the _gbak_ side to ensure the record format is created with the expected (optimized) layout.