### PR TITLE
Fix #8822: Some procedures containing LIST aggregate function are not restored in Firebird 6.0

### DIFF
--- a/src/dsql/parse.y
+++ b/src/dsql/parse.y
@@ -8685,7 +8685,7 @@ listagg_count_indication
 
 %type <valueListNode> within_group_specification_opt
 within_group_specification_opt
-	: /* nothing */					{ $$ = newNode<ValueListNode>(0); }
+	: /* nothing */					{ $$ = nullptr; }
 	| within_group_specification	{ $$ = $1; }
 	;
 

--- a/src/include/firebird/impl/blr.h
+++ b/src/include/firebird/impl/blr.h
@@ -507,10 +507,12 @@
 
 // Table value function
 #define blr_table_value_fun				(unsigned char) 229
+// subcodes of blr_table_value_fun
 #define blr_table_value_fun_unlist		(unsigned char) 1
 #define blr_table_value_fun_gen_series	(unsigned char) 2
 
 #define blr_for_range								(unsigned char) 230
+// subcodes of blr_for_range
 #define blr_for_range_variable						(unsigned char) 1
 #define blr_for_range_initial_value					(unsigned char) 2
 #define blr_for_range_final_value					(unsigned char) 3
@@ -523,9 +525,11 @@
 #define blr_gen_id3					(unsigned char) 231
 #define blr_default2				(unsigned char) 232
 #define blr_current_schema			(unsigned char) 233
-#define blr_flags					(unsigned char) 234
 
+#define blr_flags						(unsigned char) 234
 // subcodes of blr_flags
 #define blr_flags_search_system_schema	(unsigned char) 1
+
+#define blr_within_group_order		(unsigned char) 235
 
 #endif // FIREBIRD_IMPL_BLR_H

--- a/src/jrd/blp.h
+++ b/src/jrd/blp.h
@@ -196,8 +196,8 @@ static inline constexpr struct
 	{"cursor_stmt", cursor_stmt},
 	{"current_timestamp2", byte_line},
 	{"current_time2", byte_line},
-	{"agg_list", two}, // 170
-	{"agg_list_distinct", two},
+	{"agg_list", list_function}, // 170
+	{"agg_list_distinct", list_function},
 	{"modify2", modify2},
 	{"erase2", erase2},
 	// New BLR in FB1
@@ -229,7 +229,7 @@ static inline constexpr struct
 	{"partition_by", partition_by},
 	{"continue_loop", byte_line},
 	{"procedure4", procedure4},
-	{"agg_function", function},
+	{"agg_function", agg_function},
 	{"substring_similar", three}, // 200
 	{"bool_as_value", one},
 	{"coalesce", byte_args},
@@ -267,5 +267,6 @@ static inline constexpr struct
 	{"default2", default2},
 	{"current_schema", zero},
 	{NULL, NULL},	// flags - part of header
+	{NULL, NULL},
 	{0, 0}
 };

--- a/src/jrd/blp.h
+++ b/src/jrd/blp.h
@@ -267,6 +267,6 @@ static inline constexpr struct
 	{"default2", default2},
 	{"current_schema", zero},
 	{NULL, NULL},	// flags - part of header
-	{NULL, NULL},
+	{NULL, NULL},	// blr_within_group_order - part of blr_agg_list[_distinct] and blr_agg_function
 	{0, 0}
 };

--- a/src/yvalve/gds.cpp
+++ b/src/yvalve/gds.cpp
@@ -327,6 +327,7 @@ constexpr int op_invoke_function	= 33;
 constexpr int op_invsel_procedure	= 34;
 constexpr int op_table_value_fun	= 35;
 constexpr int op_for_range		= 36;
+constexpr int op_within_group_order	= 37;
 
 static constexpr UCHAR
 	// generic print formats
@@ -433,7 +434,9 @@ static constexpr UCHAR
 	default2[] = { op_line, op_indent, op_byte, op_literal,
 				   op_line, op_indent, op_byte, op_literal,
 				   op_line, op_indent, op_byte, op_literal,
-				   op_pad, op_line, 0};
+				   op_pad, op_line, 0 },
+	list_function[] = { op_line, op_verb, op_verb, op_within_group_order, 0 },
+	agg_function[] = { op_byte, op_literal, op_byte, op_line, op_args, op_within_group_order, 0 };
 
 
 #include "../jrd/blp.h"
@@ -4429,6 +4432,20 @@ static void blr_print_verb(gds_ctl* control, SSHORT level)
 			// print blr_end
 			control->ctl_blr_reader.seekBackward(1);
 			blr_print_verb(control, level);
+			break;
+		}
+
+		case op_within_group_order:
+		{
+			if (control->ctl_blr_reader.peekByte() == blr_within_group_order)
+			{
+				blr_indent(control, level);
+				blr_print_blr(control, control->ctl_blr_reader.getByte());
+				n = blr_print_byte(control);
+				blr_print_line(control, (SSHORT) offset);
+				while (--n >= 0)
+					blr_print_verb(control, level + 1);
+			}
 			break;
 		}
 


### PR DESCRIPTION
Since a new BLR verb is required anyway, I've added just one (for custom order) instead of duplicating both `blr_agg_list_*` verbs.

Also, the BLR printer is extended to support (optionally) `WITHIN GROUP` clause in other aggregate functions.

Once merged, `PERCENTILE_CONT` and `PERCENTILE_DISC` functions (PR #8807) should also be changed to utilize `blr_within_group_order`.