### PR TITLE
Add missing help for SET SQLDA_DISPLAY and SET EXEC_PATH_DISPLAY

### DIFF
--- a/src/include/firebird/impl/msg/isql.h
+++ b/src/include/firebird/impl/msg/isql.h
@@ -208,3 +208,5 @@ FB_IMPL_MSG_SYMBOL(ISQL, 208, HLP_SETAUTOTERM, "    SET AUTOTERM           -- to
 FB_IMPL_MSG_SYMBOL(ISQL, 209, HLP_SETWIRESTATS, "    SET WIRE_stats         -- toggle display of wire (network) statistics")
 FB_IMPL_MSG_SYMBOL(ISQL, 210, USAGE_SEARCH_PATH, "	-(se)arch_path <path>   set schema search path")
 FB_IMPL_MSG_SYMBOL(ISQL, 211, MSG_SCHEMAS, "Schemas:")
+FB_IMPL_MSG_SYMBOL(ISQL, 212, HLP_SETSQLDADISPLAY, "    SET SQLDA_DISPLAY      -- toggle display of query parameters' info")
+FB_IMPL_MSG_SYMBOL(ISQL, 213, HLP_SETEXECPATHDISPLAY, "    SET EXEC_PATH_DISPLAY <BLR|OFF> -- toggle display of query execution path")

--- a/src/isql/isql.epp
+++ b/src/isql/isql.epp
@@ -5947,6 +5947,7 @@ static processing_state help(const TEXT* what)
 		HLP_SETCOUNT,			//	SET COUNT				-- toggle count of selected rows on/off
 		HLP_SETMAXROWS,			//	SET MAXROWS [<n>]		-- toggle limit of selected rows to <n>, zero is no limit
 		HLP_SETECHO,			//	SET ECHO				-- toggle command echo on/off
+		HLP_SETEXECPATHDISPLAY,	//  SET EXEC_PATH_DISPLAY <BLR|OFF> -- toggle display of query execution path
 		HLP_SETEXPLAIN,			//	SET EXPLAIN				-- toggle display of query plan in the explained form
 		HLP_SETHEADING,			//  SET HEADING 	        -- toggle column titles display on/off
 		HLP_SETKEEPTRAN,		//	SET KEEP_TRAN_params	-- toggle to keep or not to keep text of following successful SET TRANSACTION statement
@@ -5956,6 +5957,7 @@ static processing_state help(const TEXT* what)
 		HLP_SETPLAN,			//	SET PLAN				-- toggle display of query access plan
 		HLP_SETPLANONLY,		//	SET PLANONLY			-- toggle display of query plan without executing
 		HLP_SETSQLDIALECT,		//	SET SQL DIALECT <n>		-- set sql dialect to <n>
+		HLP_SETSQLDADISPLAY,	//  SET SQLDA_DISPLAY       -- toggle display of query parameters' info
 		HLP_SETSTAT,			//	SET STATs				-- toggle display of performance statistics
 		HLP_SETTIME,			//	SET TIME				-- toggle display of timestamp with DATE values
 		HLP_SETTERM,			//	SET TERM <string>		-- change statement terminator string


### PR DESCRIPTION
I'm not sure if these settings also must be displayed in `SET` output. Opinions?