### PR TITLE
Fixed: ASan heap-use-after-free in Statement/Rsr ownership

### DIFF
--- a/src/remote/client/interface.cpp
+++ b/src/remote/client/interface.cpp
@@ -739,6 +739,12 @@ private:
 	void freeClientData(CheckStatusWrapper* status, bool force = false);
 	void internalFree(CheckStatusWrapper* status);
 
+	~Statement()
+	{
+		if (statement)
+			statement->rsr_self = NULL;
+	}
+
 	StatementMetadata metadata;
 	Attachment* remAtt;
 	Rsr* statement;
@@ -4278,6 +4284,8 @@ void Statement::freeClientData(CheckStatusWrapper* status, bool force)
 			clear_queue(rdb->rdb_port);
 			REMOTE_reset_statement(statement);
 		}
+		if (statement)
+			statement->rsr_self = NULL;
 		statement = NULL;
 	}
 	catch (const Exception& ex)


### PR DESCRIPTION
Clear rsr_self before Statement::statement member becomes invalid.

The Rsr::rsr_self pointer was left dangling when Statement was freed before the Rsr, causing use-after-free when Rsr destructor accessed it.

Added Statement destructor and explicit clear in freeClientData.