### PR TITLE
Fixed: UBSAN strict aliasing violation in xdr_enum serialization

### DIFF
--- a/src/common/xdr.cpp
+++ b/src/common/xdr.cpp
@@ -444,40 +444,7 @@ bool_t xdr_int128(xdr_t* xdrs, Firebird::Int128* ip)
 #endif
 }
 
-
-bool_t xdr_enum(xdr_t* xdrs, xdr_op* ip)
-{
-/**************************************
- *
- *	x d r _ e n u m
- *
- **************************************
- *
- * Functional description
- *	Map from external to internal representation (or vice versa).
- *
- **************************************/
-	SLONG temp;
-
-	switch (xdrs->x_op)
-	{
-	case XDR_ENCODE:
-		temp = (SLONG) *ip;
-		return PUTLONG(xdrs, &temp);
-
-	case XDR_DECODE:
-		if (!GETLONG(xdrs, &temp))
-			return FALSE;
-		*ip = (xdr_op) temp;
-		return TRUE;
-
-	case XDR_FREE:
-		return TRUE;
-	}
-
-	return FALSE;
-}
-
+// xdr_enum is now a template function in xdr_proto.h
 
 bool_t xdr_float(xdr_t* xdrs, float* ip)
 {

--- a/src/remote/protocol.cpp
+++ b/src/remote/protocol.cpp
@@ -292,7 +292,7 @@ bool_t xdr_protocol(RemoteXdr* xdrs, PACKET* p)
 
 	DEBUG_XDR_PACKET(xdrs, p);
 
-	if (!xdr_enum(xdrs, reinterpret_cast<xdr_op*>(&p->p_operation)))
+	if (!xdr_enum(xdrs, &p->p_operation))
 		return P_FALSE(xdrs, p);
 
 #if COMPRESS_DEBUG > 1
@@ -320,9 +320,9 @@ bool_t xdr_protocol(RemoteXdr* xdrs, PACKET* p)
 	case op_connect:
 		{
 			P_CNCT* connect = &p->p_cnct;
-			MAP(xdr_enum, reinterpret_cast<xdr_op&>(connect->p_cnct_operation));
+			MAP(xdr_enum, connect->p_cnct_operation);
 			MAP(xdr_short, reinterpret_cast<SSHORT&>(connect->p_cnct_cversion));
-			MAP(xdr_enum, reinterpret_cast<xdr_op&>(connect->p_cnct_client));
+			MAP(xdr_enum, connect->p_cnct_client);
 			MAP(xdr_cstring_const, connect->p_cnct_file);
 			MAP(xdr_short, reinterpret_cast<SSHORT&>(connect->p_cnct_count));
 
@@ -339,7 +339,7 @@ bool_t xdr_protocol(RemoteXdr* xdrs, PACKET* p)
 				}
 
 				MAP(xdr_short, reinterpret_cast<SSHORT&>(tail->p_cnct_version));
-				MAP(xdr_enum, reinterpret_cast<xdr_op&>(tail->p_cnct_architecture));
+				MAP(xdr_enum, tail->p_cnct_architecture);
 				MAP(xdr_u_short, tail->p_cnct_min_type);
 				MAP(xdr_u_short, tail->p_cnct_max_type);
 				MAP(xdr_short, reinterpret_cast<SSHORT&>(tail->p_cnct_weight));
@@ -358,7 +358,7 @@ bool_t xdr_protocol(RemoteXdr* xdrs, PACKET* p)
 	case op_accept:
 		accept = &p->p_acpt;
 		MAP(xdr_short, reinterpret_cast<SSHORT&>(accept->p_acpt_version));
-		MAP(xdr_enum, reinterpret_cast<xdr_op&>(accept->p_acpt_architecture));
+		MAP(xdr_enum, accept->p_acpt_architecture);
 		MAP(xdr_u_short, accept->p_acpt_type);
 		DEBUG_PRINTSIZE(xdrs, p->p_operation);
 		return P_TRUE(xdrs, p);
@@ -367,7 +367,7 @@ bool_t xdr_protocol(RemoteXdr* xdrs, PACKET* p)
 	case op_cond_accept:
 		accept_with_data = &p->p_acpd;
 		MAP(xdr_short, reinterpret_cast<SSHORT&>(accept_with_data->p_acpt_version));
-		MAP(xdr_enum, reinterpret_cast<xdr_op&>(accept_with_data->p_acpt_architecture));
+		MAP(xdr_enum, accept_with_data->p_acpt_architecture);
 		MAP(xdr_u_short, accept_with_data->p_acpt_type);
 		MAP(xdr_cstring, accept_with_data->p_acpt_data);
 		MAP(xdr_cstring, accept_with_data->p_acpt_plugin);


### PR DESCRIPTION
Replaced non-template xdr_enum(xdr_t*, xdr_op*) with a type-safe template that accepts any enum type.

This eliminates the need for reinterpret_cast<xdr_op*> at call sites which violates strict aliasing rules and triggers undefined behavior under UBSAN.