### PR TITLE
Fix incorrect platform detection in setenvvar.bat on VS2022

### DIFF
--- a/builds/win32/setenvvar.bat
+++ b/builds/win32/setenvvar.bat
@@ -16,12 +16,13 @@
 
 @echo off
 
-::set FB_PROCESSOR_ARCHITECTURE=AMD64
+:: 1. Determine target platform
+if "%Platform%"=="x86"  set FB_TARGET_PLATFORM=Win32
+if "%Platform%"=="x64"  set FB_TARGET_PLATFORM=x64
 
-:: Default target CPU architecture is the native environment
-if NOT DEFINED FB_PROCESSOR_ARCHITECTURE (
-set FB_PROCESSOR_ARCHITECTURE=%PROCESSOR_ARCHITECTURE%
-)
+:: 2.If Platform variable is not set, use PROCESSOR_ARCHITECTURE
+if "%FB_TARGET_PLATFORM%"=="Win32" set FB_PROCESSOR_ARCHITECTURE=x86
+if "%FB_TARGET_PLATFORM%"=="x64"   set FB_PROCESSOR_ARCHITECTURE=AMD64
 
 ::===============================
 ::Set up the compiler environment


### PR DESCRIPTION
This pull request fixes incorrect platform detection in `setenvvar.bat` when
building Firebird on modern Visual Studio environments (VS2022 Build Tools).

The current script relies on `PROCESSOR_ARCHITECTURE`, which always reports
`AMD64` even when using the x86 Native Tools Command Prompt. As a result,
`FB_TARGET_PLATFORM` is always set to `x64`, and Win32 builds do not behave
correctly.

This patch replaces the detection logic with the `%Platform%` variable, which
correctly reports `x86` or `x64` depending on the toolchain.

Fixes #8865