### PR TITLE
Fix locking error if IN/EXISTS is converted into a semi-join

### DIFF
--- a/src/jrd/recsrc/HashJoin.cpp
+++ b/src/jrd/recsrc/HashJoin.cpp
@@ -543,8 +543,11 @@ bool HashJoin::refetchRecord(thread_db* /*tdbb*/) const
 	return true;
 }
 
-WriteLockResult HashJoin::lockRecord(thread_db* /*tdbb*/) const
+WriteLockResult HashJoin::lockRecord(thread_db* tdbb) const
 {
+	if (m_joinType == SEMI_JOIN || m_joinType == ANTI_JOIN)
+		return m_leader.source->lockRecord(tdbb);
+
 	status_exception::raise(Arg::Gds(isc_record_lock_not_supp));
 }
 

--- a/src/jrd/recsrc/NestedLoopJoin.cpp
+++ b/src/jrd/recsrc/NestedLoopJoin.cpp
@@ -247,8 +247,11 @@ bool NestedLoopJoin::refetchRecord(thread_db* /*tdbb*/) const
 	return true;
 }
 
-WriteLockResult NestedLoopJoin::lockRecord(thread_db* /*tdbb*/) const
+WriteLockResult NestedLoopJoin::lockRecord(thread_db* tdbb) const
 {
+	if (m_joinType == SEMI_JOIN || m_joinType == ANTI_JOIN)
+		return m_args.front()->lockRecord(tdbb);
+
 	status_exception::raise(Arg::Gds(isc_record_lock_not_supp));
 }
 


### PR DESCRIPTION
Example:

`select * from T1 where exists (select null from T2 where T2.PARENT_ID =T1.ID) with lock`

raises an error _"Stream does not support record locking"_ because `EXISTS` is converted into a semi-join but joins don't support record locking. It affects v6 and v5 with `SubQueryConversion` setting enabled.

It could be fixed by disabling sub-query conversion if `WITH LOCK` is used for a parent query, but I prefer to fix it at the join level - because it allows faster query plans. Also I'd suggest to consider whether we should generally allow record locking for joins in v6. PG allows that, but it also allows (optionally) to specify which joined table must be locked -- which we miss. 

The provided patch is for v5. I'm postponing a patch for v6 for a little bit, expecting some feedback on the question above.
