### PR TITLE
fix(attachment): Avoid recursive lock of `Sync` object on worker detach

### DIFF
--- a/src/jrd/WorkerAttachment.cpp
+++ b/src/jrd/WorkerAttachment.cpp
@@ -121,7 +121,8 @@ void WorkerStableAttachment::fini()
 		Database* dbb = attachment->att_database;
 
 		FbLocalStatus status_vector;
-		BackgroundContextHolder tdbb(dbb, attachment, &status_vector, FB_FUNCTION);
+		ThreadContextHolder tdbb(dbb, attachment, &status_vector);
+		DatabaseContextHolder dbHolder(tdbb);
 
 		Monitoring::cleanupAttachment(tdbb);
 		dbb->dbb_extManager->closeAttachment(tdbb, attachment);


### PR DESCRIPTION
Due to double locking of `mainSync` inside `WorkerStableAttachment::fini()` (`AttSyncLockGuard` + `BackgroundContextHolder`) `EngineCheckout` will become useless (it uses in `LCK_fini() -> LockManager::shutdownOwner()`). If `EngineCheckout` will not do its job, we can get a deadlock, for example inside `LockManager::shutdownOwner()`:
```cpp
	while (owner->own_ast_count)
	{
		{ // checkout scope
			LockTableCheckout checkout(this, FB_FUNCTION);
			callbacks.checkoutRun([] {
				Thread::sleep(10);
			});
		}

		owner = (own*) SRQ_ABS_PTR(owner_offset);
	}
```
If the AST will be called for our worker attachment we will be stuck in this loop, AST cannot continue its execution due to lock on `mainSync` and attachment cannot finish its own routine due to recursive lock.

This case can be reproduced with next steps.
```
1. Set `ParallelWorkers = 2` in firebird.conf;
2. Create index on some field;
3. Next steps need to be done instantly in one time:
3.1 Wait 1 minute until timeout will detach worker attachment;
3.2 Alter table for which the index was created to trigger the `rescan_ast_relation()` AST;
```
It's very hard to reproduce due to race condition nature of the bug, but it can still happen accidentally in production.

v5 is also affected by this bug.