### PR TITLE
Add Japanese installer resources for Firebird 3.0

### DIFF
--- a/builds/install/arch-specific/win32/FirebirdInstall_30.iss
+++ b/builds/install/arch-specific/win32/FirebirdInstall_30.iss
@@ -310,6 +310,7 @@ Name: fr; MessagesFile: compiler:Languages\French.isl; InfoBeforeFile: {#GenDir}
 ;Name: pt; MessagesFile: compiler:Languages\Portuguese.isl; InfoBeforeFile: {#GenDir}\pt\instalacao_leia-me.txt; InfoAfterFile: {#GenDir}\pt\leia-me.txt
 Name: ru; MessagesFile: compiler:Languages\Russian.isl; InfoBeforeFile: {#GenDir}\ru\installation_readme.txt; InfoAfterFile: {#GenDir}\ru\readme.txt;
 ;Name: si; MessagesFile: compiler:Languages\Slovenian.isl; InfoBeforeFile: {#GenDir}\si\instalacija_precitajMe.txt; InfoAfterFile: {#GenDir}\readme.txt;
+Name: ja; MessagesFile: compiler:Languages\Japanese.isl; InfoBeforeFile: {#GenDir}\ja\installation_readme.txt; InfoAfterFile: {#GenDir}\readme.txt;
 #endif
 
 [CustomMessages]
@@ -326,6 +327,7 @@ Name: ru; MessagesFile: compiler:Languages\Russian.isl; InfoBeforeFile: {#GenDir
 ;#include "pt\custom_messages_pt.inc"
 #include "ru\custom_messages_ru.inc"
 ;#include "si\custom_messages_si.inc"
+#include  "ja\custom_messages_ja.inc"
 #endif
 
 [Types]
@@ -433,6 +435,7 @@ Source: {#GenDir}\fr\*.txt; DestDir: {app}\doc; Components: DevAdminComponent; F
 ;Source: {#GenDir}\pt\*.txt; DestDir: {app}\doc; Components: DevAdminComponent; Flags: ignoreversion; Languages: pt;
 Source: {#GenDir}\ru\*.txt; DestDir: {app}\doc; Components: DevAdminComponent; Flags: ignoreversion; Languages: ru;
 ;Source: {#GenDir}\si\*.txt; DestDir: {app}\doc; Components: DevAdminComponent; Flags: ignoreversion; Languages: si;
+Source: {#GenDir}\ja\*.txt; DestDir: {app}\doc; Components: DevAdminComponent; Flags: ignoreversion; Languages: ja;
 #endif
 Source: {#FilesDir}\firebird.conf; DestDir: {app}; DestName: firebird.conf.default; Components: ServerComponent;
 Source: {#FilesDir}\firebird.conf; DestDir: {app}; DestName: firebird.conf; Components: ServerComponent; Flags: uninsneveruninstall; check: NoFirebirdConfExists

--- a/builds/install/arch-specific/win32/ja/custom_messages_ja.inc
+++ b/builds/install/arch-specific/win32/ja/custom_messages_ja.inc
@@ -1,0 +1,90 @@
+ja.MyAppName=Firebirdデータベースサーバー %1
+ja.ServerInstall=サーバーと開発ツールの完全なインストール。
+ja.SuperServerInstall=スーパーサーバーと開発ツールのフルインストール。
+ja.ClassicServerInstall=クラシックサーバーと開発ツールの完全インストール。
+ja.DeveloperInstall=開発者およびデータベース管理者向けのクライアント ツールのインストール。
+ja.ClientInstall=最小限のクライアント インストール - サーバーもツールも必要ありません。
+ja.CustomInstall=カスタムインストール
+ja.SuperServerComponent=スーパーサーバーバイナリ
+ja.ClassicServerComponent=クラシックサーバーバイナリ
+ja.ServerComponent=サーバーコンポーネント
+ja.DevAdminComponent=開発者および管理ツールのコンポーネント
+ja.ClientComponent=クライアントコンポーネント
+ja.UseGuardianTask=サーバー制御に &Guardian を使用しますか？
+ja.UseApplicationTaskMsg=&Application として実行しますか？
+ja.TaskGroupDescription=Firebirdサーバーを次で実行する:
+ja.UseServiceTask=&Service として実行しますか？
+ja.AutoStartTask=起動時に毎回 &Firebird を自動的に実行しますか？
+ja.SuperClassicTask=スーパークラシックを使用しますか？
+ja.CopyFbClientToSysTask=Firebirdの クライアント ライブラリをシステムディレクトリにコピーしますか？
+ja.CopyFbClientAsGds32Task=レガシー なInterBaseのサポートのために、GDS32.DLL クライアントライブラリを生成しますか？
+ja.InstallCPLAppletTask=コントロール パネル アプレットをインストールしますか？
+ja.instreg=レジストリをアップデート中
+ja.instclientCopyFbClient=fbclient を <sys> ディレクトリにコピー中
+ja.instclientGenGds32= gds32.dllを <sys> ディレクトリに生成中
+ja.instclientDecLibCountGds32=gds32 の共有ライブラリカウントを減らし、必要に応じて削除します。
+ja.instclientDecLibCountFbClient=fbclient の共有ライブラリカウントを減らし、必要に応じて削除します。
+ja.instsvcSetup=サービスをセットアップ中
+ja.instsvcStartQuestion=Firebirdサービスを今すぐ起動しますか?
+ja.instsvcStartMsg=サーバーを起動中
+ja.instsvcStopMsg=サービスを停止中
+ja.instsvcRemove=サービスを削除中
+ja.instappStartQuestion=Firebirdを今すぐスタートしますか？
+ja.instappStartMsg=サーバーを起動中
+
+ja.InstallSummarySuffix1=このバージョンの Firebird はデフォルトのインストールになります。
+ja.InstallSummarySuffix2=また、このバージョンの Firebird をインストールする際には注意してください。
+ja.InstallSummarySuffix3=より新しいバージョンがすでにインストールされている場合、
+ja.InstallSummarySuffix4=予測できない結果を引き起こす可能性があります。
+
+ja.InstallSummaryCancel1=このインストールを続行すると、Firebird はインストールされますが、設定は行われません。
+ja.InstallSummaryCancel2=インストールを手動で完了する必要があります。
+ja.InstallSummaryCancel3=このインストールをキャンセルしますか？
+
+ja.InstalledProducts=事前インストール分析により、%s の既存の Firebird または Interbase %s が検出されました。
+ja.InstalledProdCountSingular=単一のバージョンが存在します
+ja.InstalledProdCountPlural=複数のバージョンが存在します
+
+ja.FbRunning1=既存の %s サーバーが実行中です。
+ja.FbRunning2=続行する前に、アプリケーションを閉じるか、
+ja.FbRunning3=サービスを停止する必要があります。
+
+ja.PreviousInstallBroken=  （バージョン文字列の不一致により、インストールが破損しているように見えます。）
+ja.PreviousInstallGood=   (インストールは正常です。)
+
+ja.IconReadme=Firebird %1 Readme
+ja.IconUninstall=Firebird %1 をアンインストールする
+ja.ReleaseNotes= リリースノート。 (Acrobatリーダーが必要です。)
+ja.InstallationGuide= インストールガイド。 (Acrobatリーダーが必要です。)
+ja.BugFixes= バグフィックス。 (Acrobatリーダーが必要です。)
+ja.Uninstall=Firebird %1 をアンインストールする
+ja.Winsock2Web1=Winsock 2 がインストールされていません。
+ja.Winsock2Web2=Winsock 2 アップデートのホームページを訪問しますか？
+ja.NoWinsock2=続行する前に Winsock 2 のアップデートをインストールしてください
+ja.MSWinsock2Update=http://www.microsoft.com/windows95/downloads/contents/WUAdminTools/S_WUNetworkingTools/W95Sockets2/Default.asp
+
+ja.RunCSNoGuardian=Firebird クラシックサーバーを実行する (Guardian無し)
+ja.RunSSNoGuardian=Firebird スーパーサーバーを実行する (Guardian無し)
+ja.RunSSWithGuardian=Firebird スーパーサーバーを実行する (Guardian有り)
+ja.RunCSWithGuardian=Firebird クラシックサーバーを実行する (Guardian有り)
+ja.RunISQL=コマンドラインベースのインタラクティブ SQL tool（ISQL）を実行する
+
+ja.ReadmeFile=readme.txt
+ja.InstallationReadmeFile=installation_readme.txt
+ja.IncompleteTranslationNotice=この文書は最新ではありません。最新の情報については、オリジナルの英語版を参照してください。
+ja.RunCS=Firebird をクラシックサーバーモードで実行する
+ja.RunSC=Firebird をスーパークラシックモードで実行する
+ja.RunSS=Firebird をスーパーサーバーモードで実行する
+ja.ServerTaskDescription=サーバーアーキテクチャを選択:
+ja.initSecurityDb=SYSDBA をセキュリティデータベースに追加中。
+ja.SYSDBAPasswordMismatch=入力されたパスワードが一致しません。SYSDBA パスワードを再入力してください。
+ja.SYSDBAPasswordEmpty=パスワードが空欄です。SYSDBA パスワードは必ず入力してください。
+ja.EnableLegacyClientAuth=レガシーな Firebird 用の 認証を有効にしますか？
+ja.CreateSYSDBAPassword=データベースシステム管理者用のパスワードを作成する
+ja.ClickThroughPWCreation=または、デフォルトのパスワード「masterkey」を使用するにはそのまま進んでください。
+ja.PasswordNote=*** 注 - Firebird 3 では、masterkey と masterke は違うパスワードとして扱われます。 ***
+ja.SYSDBAPassword=SYSDBA パスワード:
+ja.RetypeSYSDBAPassword=SYSDBA パスワードを再入力:
+ja.InstallingMSVC32runtimes=MSVC 32-bit ランタイムライブラリをシステムディレクトリにインストール中
+ja.InstallingMSVC64runtimes=MSVC 64-bit ランタイムライブラリをシステムディレクトリにインストール中
+

--- a/builds/install/arch-specific/win32/ja/installation_readme.txt
+++ b/builds/install/arch-specific/win32/ja/installation_readme.txt
@@ -1,0 +1,144 @@
+Firebird Database Server $MAJOR.$MINOR.$RELEASE
+===============================================
+
+
+This document is a guide to installing this package of
+Firebird $MAJOR.$MINOR on the Windows platform. These notes refer
+to the installation package itself, rather than
+Firebird $MAJOR.$MINOR in general. In addition, these notes are
+primarily aimed at users of the binary installer.
+
+It is assumed that readers of this document are already
+familiar with Firebird. If you are evaluating Firebird $MAJOR.$MINOR
+as part of a migration from some older Firebird version you are advised
+to review the Firebird $MAJOR.$MINOR documentation to understand
+the changes made between your version and $MAJOR.$MINOR.
+
+
+Contents
+--------
+
+o Before installation
+o Deployment of gds32.dll
+o Installation of the Guardian
+o Re-installation of Firebird $MAJOR.$MINOR
+o Known installation problems
+o Uninstallation
+o Installation from a batch file
+
+
+Before installation
+-------------------
+
+It is recommended that you UNINSTALL all previous
+versions of Firebird or InterBase before installing
+this package. It is especially important to verify that
+fbclient.dll and gds32.dll are removed from <system32>.
+See the UNINSTALL section below for more info on this.
+
+
+Installation of the Guardian
+----------------------------
+
+We are hoping to phase out the Guardian. It doesn't
+work with the Classic server and the binary installer
+does not offer it at install time if Classic is
+chosen. If SuperServer or SuperClassic are chosen
+it is offered but not selected by default.
+
+
+Re-installation of Firebird
+---------------------------
+
+The binary installer does its best to detect and
+preserve a previous install. If the installer detects
+firebird.conf or security$MAJOR.fdb it will not offer the
+option to set the SYSDBA username and password.
+
+
+Known installation problems
+---------------------------------
+
+o It is only possible to use the binary installer
+  to install the default instance of Firebird $MAJOR.$MINOR. If
+  you wish to install additional, named instances you
+  should manually install them with the zipped install
+  image.
+
+o Unfortunately, the installer cannot reliably detect
+  if a previous version of Firebird Classic server
+  is running.
+
+o The service installer (instsvc) uses the same
+  default instance name for 32-bit and 64-bit
+  installations. This is by design. Services exist
+  in a single name space.
+
+o Be sure to install as an administrator. ie, if
+  using the binary installer right click and choose
+  'Run as administrator'. Otherwise the installer
+  may be unable to start the Firebird service at
+  the end of installation.
+
+o Installation may fail on older versions of windows up
+  to Win 8.1 and Windows Server 2008 if the most recent
+  security updates have not been installed. This will
+  also affect users of the zip packs as the problem
+  lies with runtime library dependencies of
+  applications such as instclient and instsvc.
+
+  If you do run into this problem you should consult
+  the microsoft knowledge base article KB2999226 for more
+  information on how to upgrade your version of windows
+  to use the latest run time libraries.
+
+
+Uninstallation
+--------------
+
+o It is preferred that this package be uninstalled
+  correctly using the uninstallation application
+  supplied. This can be called from the Control Panel.
+  Alternatively it can be uninstalled by running
+  unins000.exe directly from the installation
+  directory.
+
+o If Firebird is running as an application (instead of
+  as a service) it is recommended that you manually
+  stop the server before running the uninstaller. This
+  is because the uninstaller cannot stop a running
+  application. If a server is running during the
+  uninstall the uninstall will complete with errors.
+  You will have to delete the remnants by hand.
+
+o Uninstallation leaves six files in the install
+  directory:
+
+  - databases.conf
+  - firebird.conf
+  - fbtrace.conf
+  - replication.conf
+  - firebird.log
+  - security$MAJOR.fdb
+
+  This is intentional. These files are all
+  potentially modifiable by users and may be required
+  if Firebird is re-installed in the future. They can
+  be deleted if no longer required.
+
+o A new feature of the uninstaller is an option to
+  run it with the /CLEAN parameter. This will check
+  the shared file count of each of the above files. If
+  possible it will delete them.
+
+
+Installation from a batch file
+------------------------------
+
+The setup program can be run from a batch file.
+Please see this document:
+
+    installation_scripted.txt
+
+for full details.
+

--- a/builds/install/arch-specific/win32/ja/readme.txt
+++ b/builds/install/arch-specific/win32/ja/readme.txt
@@ -1,0 +1,80 @@
+
+====================================
+Firebird $MAJOR.$MINOR.$RELEASE    (Windows Build)
+====================================
+
+
+o Introduction
+o Intended Users
+o Features in this release (all platforms)
+o Installation
+o Reporting Bugs
+
+
+Introduction
+============
+
+Welcome to Firebird $MAJOR.$MINOR.
+
+
+Intended Users
+==============
+
+Firebird $MAJOR.$MINOR has undergone extensive testing and is
+intended for widespread production use. However, users
+are recommended to follow standard practices before
+deploying this release on a production server. ie:
+
+ o Please make sure you read the installation
+   readme and the release notes.
+
+ o If you have data you value remember to back it up
+   prior to installing this release.
+
+ o It is recommended that you remove any previous
+   version prior to installation. Uninstallation
+   preserves configuration files and log files.
+
+ o It is recommended that you carry out your own
+   tests in a development environment prior to
+   production deployment.
+
+
+Features in this release
+========================
+
+Please see the Release Notes for details of new
+features.
+
+
+Installation
+============
+
+Installation issues are covered in detail in the
+Installation Guide available in the doc directory
+after install. A brief summary of installation issues
+can also be found in the installation_readme.txt, also
+available from the doc directory after installation.
+
+
+Reporting Bugs
+==============
+
+Before you report a bug:
+
+ o Check you know how Firebird works.
+   Maybe it is not a bug at all.
+
+ o Perhaps someone has already reported this? Browse
+   existing bug reports here:
+
+    https://github.com/FirebirdSQL/firebird/issues
+
+ o If in doubt why not discuss the problem on the
+   Firebird-devel list? You can subscribe here:
+
+    https://groups.google.com/g/firebird-devel
+
+
+From the Firebird team.
+


### PR DESCRIPTION
Add Japanese installer resources for Firebird 3.0

This pull request adds Japanese language support to the Firebird 3.0 Windows installer.

Changes included:
- Added Japanese language entry to `FirebirdInstall_30.iss`
  - `Name: ja; MessagesFile: compiler:Languages\Japanese.isl`
  - Added Japanese-specific InfoBefore/InfoAfter files
- Added `ja/custom_messages_ja.inc` with translated installer messages
- Added Japanese documentation files:
  - `ja/readme.txt`
  - `ja/installation_readme.txt`
  (These files follow the same structure as other languages and remain in English,
   as the installer documentation is not required to be translated.)
- Added file copy rule for Japanese documentation in the installer script

The structure follows the existing pattern used for other languages (e.g., Russian, German, French), and does not affect any existing installer behavior.

The installer was successfully built and tested on my environment (Windows), and no issues were observed.

Please let me know if any adjustments or additional changes are required.