### PR TITLE
Add 'ja' to installer language resource list in BuildExecutableInstal…

### DIFF
--- a/builds/install/arch-specific/win32/BuildExecutableInstall.bat
+++ b/builds/install/arch-specific/win32/BuildExecutableInstall.bat
@@ -193,7 +193,7 @@ if "%FB2_SNAPSHOT%"=="1" (
   echo   Processing version strings in %%f
   %SED_COMMAND% %%f > %FB_GEN_DIR%\readmes\%%f
 )
-@for %%d in (ba cz de es fr hu it pl pt ru si ) do (
+@for %%d in (ba cz de es fr hu it pl pt ru si ja ) do (
   if not exist %FB_GEN_DIR%\readmes\%%d ( mkdir %FB_GEN_DIR%\readmes\%%d )
   for %%f in ( %%d\*.txt  ) do (
     echo   Processing version strings in %%f


### PR DESCRIPTION
This patch adds "ja" to the language list in BuildExecutableInstall.bat.

The Japanese installer resources were added previously, but the build script
did not include "ja" in the loop that processes localized readme files.
As a result, the Japanese readme directory was not generated during the
installer build.

This update ensures that the installer correctly includes Japanese resources.