### PR TITLE
Refactor `class Thread` and relatives

### DIFF
--- a/src/common/Task.cpp
+++ b/src/common/Task.cpp
@@ -42,7 +42,7 @@ WorkerThread* WorkerThread::start(Coordinator* coordinator)
 {
 	AutoPtr<WorkerThread> thd = FB_NEW WorkerThread(coordinator);
 
-	Thread::start(workerThreadRoutine, thd, THREAD_medium, &thd->m_thdHandle);
+	Thread::start(workerThreadRoutine, thd, THREAD_medium, &thd->m_thread);
 
 	return thd.release();
 }
@@ -122,7 +122,7 @@ void WorkerThread::shutdown(bool wait)
 
 	if (wait)
 	{
-		Thread::waitForCompletion(m_thdHandle);
+		m_thread.waitForCompletion();
 		m_state = SHUTDOWN;
 	}
 }

--- a/src/common/Task.h
+++ b/src/common/Task.h
@@ -168,11 +168,6 @@ public:
 	~WorkerThread()
 	{
 		shutdown(true);
-
-#ifdef WIN_NT
-		if (m_thdHandle != INVALID_HANDLE_VALUE)
-			CloseHandle(m_thdHandle);
-#endif
 	}
 
 	static WorkerThread* start(Coordinator*);
@@ -196,7 +191,7 @@ private:
 	Semaphore m_waitSem;		// idle thread waits on this semaphore to start work or go out
 	Semaphore m_signalSem;	// semaphore is released when thread going idle
 	STATE m_state;
-	Thread::Handle m_thdHandle;
+	Thread m_thread;
 };
 
 } // namespace Jrd

--- a/src/common/ThreadStart.cpp
+++ b/src/common/ThreadStart.cpp
@@ -196,6 +196,7 @@ void Thread::waitForCompletion()
 		int state = pthread_join(m_handle, NULL);
 		if (state)
 			Firebird::system_call_failed::raise("pthread_join", state);
+		m_handle = INVALID_HANDLE;
 	}
 }
 

--- a/src/common/ThreadStart.cpp
+++ b/src/common/ThreadStart.cpp
@@ -104,7 +104,7 @@ THREAD_ENTRY_DECLARE threadStart(THREAD_ENTRY_PARAM arg)
 
 #ifdef USE_POSIX_THREADS
 #define START_THREAD
-Thread Thread::start(ThreadEntryPoint* routine, void* arg, int priority_arg, Handle* p_handle)
+void Thread::start(ThreadEntryPoint* routine, void* arg, int priority_arg, Thread* pThread)
 {
 /**************************************
  *
@@ -117,17 +117,18 @@ Thread Thread::start(ThreadEntryPoint* routine, void* arg, int priority_arg, Han
  *	status if not.
  *
  **************************************/
-	pthread_t thread;
-	pthread_t* p_thread = p_handle ? p_handle : &thread;
+	Thread thread;
+	if (!pThread)
+		pThread = &thread;
 	int state;
 
 #if defined (LINUX) || defined (FREEBSD)
-	if ((state = pthread_create(p_thread, NULL, THREAD_ENTRYPOINT, THREAD_ARG)))
+	if ((state = pthread_create(&pThread->m_handle, NULL, THREAD_ENTRYPOINT, THREAD_ARG)))
 		Firebird::system_call_failed::raise("pthread_create", state);
 
-	if (!p_handle)
+	if (pThread == &thread)
 	{
-		if ((state = pthread_detach(*p_thread)))
+		if ((state = pthread_detach(pThread->m_handle)))
 			Firebird::system_call_failed::raise("pthread_detach", state);
 	}
 #else
@@ -162,13 +163,13 @@ Thread Thread::start(ThreadEntryPoint* routine, void* arg, int priority_arg, Han
 	if (state)
 		Firebird::system_call_failed::raise("pthread_attr_setscope", state);
 
-	if (!p_handle)
+	if (pThread == &thread)
 	{
 		state = pthread_attr_setdetachstate(&pattr, PTHREAD_CREATE_DETACHED);
 		if (state)
 			Firebird::system_call_failed::raise("pthread_attr_setdetachstate", state);
 	}
-	state = pthread_create(p_thread, &pattr, THREAD_ENTRYPOINT, THREAD_ARG);
+	state = pthread_create(&pThread->m_handle, &pattr, THREAD_ENTRYPOINT, THREAD_ARG);
 	int state2 = pthread_attr_destroy(&pattr);
 	if (state)
 		Firebird::system_call_failed::raise("pthread_create", state);
@@ -177,37 +178,44 @@ Thread Thread::start(ThreadEntryPoint* routine, void* arg, int priority_arg, Han
 
 #endif
 
-	if (p_handle)
-	{
 #ifdef HAVE_PTHREAD_CANCEL
+	if (pThread != &thread)
+	{
 		int dummy;		// We do not want to know old cancel type
 		state = pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, &dummy);
 		if (state)
 			 Firebird::system_call_failed::raise("pthread_setcanceltype", state);
-#endif
 	}
-
-	return Thread(*p_thread);
+#endif
 }
 
-void Thread::waitForCompletion(Handle& thread)
+void Thread::waitForCompletion()
 {
-	int state = pthread_join(thread, NULL);
-	if (state)
-		Firebird::system_call_failed::raise("pthread_join", state);
+	if (isValid())
+	{
+		int state = pthread_join(m_handle, NULL);
+		if (state)
+			Firebird::system_call_failed::raise("pthread_join", state);
+	}
 }
 
-void Thread::kill(Handle& thread)
+// ignore errors - this is abnormal completion call
+void Thread::kill() noexcept
 {
 #ifdef HAVE_PTHREAD_CANCEL
-	int state = pthread_cancel(thread);
-	if (state)
-		Firebird::system_call_failed::raise("pthread_cancel", state);
-	waitForCompletion(thread);
+	if (isValid())
+	{
+		pthread_cancel(m_handle);
+		try
+		{
+			waitForCompletion();
+		}
+		catch(...) { }
+	}
 #endif
 }
 
-ThreadId Thread::getId()
+ThreadId Thread::getCurrentThreadId()
 {
 #ifdef USE_LWP_AS_THREAD_ID
 	static __thread int tid = 0;
@@ -219,15 +227,9 @@ ThreadId Thread::getId()
 #endif
 }
 
-bool Thread::isCurrent(Handle threadHandle)
+bool Thread::isCurrent() const noexcept
 {
-	static_assert(std::is_same<Handle, InternalId>().value, "type mismatch");
-	return pthread_equal(threadHandle, pthread_self());
-}
-
-bool Thread::isCurrent()
-{
-	return pthread_equal(internalId, pthread_self());
+	return isValid() && pthread_equal(m_handle, pthread_self());
 }
 
 void Thread::sleep(unsigned milliseconds)
@@ -274,7 +276,7 @@ void Thread::yield()
 
 #ifdef WIN_NT
 #define START_THREAD
-Thread Thread::start(ThreadEntryPoint* routine, void* arg, int priority_arg, Handle* p_handle)
+void Thread::start(ThreadEntryPoint* routine, void* arg, int priority_arg, Thread* pThread)
 {
 /**************************************
  *
@@ -331,9 +333,9 @@ Thread Thread::start(ThreadEntryPoint* routine, void* arg, int priority_arg, Han
 
 	SetThreadPriority(handle, priority);
 
-	if (p_handle)
+	if (pThread)
 	{
-		*p_handle = handle;
+		*pThread = Thread(handle, thread_id);
 		ResumeThread(handle);
 	}
 	else
@@ -341,42 +343,47 @@ Thread Thread::start(ThreadEntryPoint* routine, void* arg, int priority_arg, Han
 		ResumeThread(handle);
 		CloseHandle(handle);
 	}
-
-	return Thread(thread_id);
 }
 
-void Thread::waitForCompletion(Handle& handle)
+bool Thread::waitFor(unsigned milliseconds) const noexcept
 {
+	if (!isValid())
+		return true;
+
+	return WaitForSingleObject(m_handle, milliseconds) != WAIT_TIMEOUT;
+}
+
+void Thread::waitForCompletion()
+{
+	if (!isValid())
+		return;
+
 	// When current DLL is unloading, OS loader holds loader lock. When thread is
 	// exiting, OS notifies every DLL about it, and acquires loader lock. In such
 	// scenario waiting on thread handle will never succeed.
 	if (!Firebird::dDllUnloadTID) {
-		WaitForSingleObject(handle, 10000);
+		WaitForSingleObject(m_handle, 10000);		// error handler ????????????
 	}
-	CloseHandle(handle);
-	handle = 0;
+	detach();
 }
 
-void Thread::kill(Handle& handle)
+void Thread::kill() noexcept
 {
-	TerminateThread(handle, -1);
-	CloseHandle(handle);
-	handle = 0;
+	if (isValid())
+	{
+		TerminateThread(m_handle, -1);
+		detach();
+	}
 }
 
-ThreadId Thread::getId()
+ThreadId Thread::getCurrentThreadId()
 {
 	return GetCurrentThreadId();
 }
 
-bool Thread::isCurrent(Handle threadHandle)
+bool Thread::isCurrent() const noexcept
 {
-	return GetCurrentThreadId() == GetThreadId(threadHandle);
-}
-
-bool Thread::isCurrent()
-{
-	return GetCurrentThreadId() == internalId;
+	return isValid() && (GetCurrentThreadId() == m_Id);
 }
 
 void Thread::sleep(unsigned milliseconds)
@@ -390,43 +397,3 @@ void Thread::yield()
 }
 
 #endif  // WIN_NT
-
-
-#ifndef START_THREAD
-ThreadId Thread::start(ThreadEntryPoint* routine, void* arg, int priority_arg, Handle* p_handle)
-{
-/**************************************
- *
- *	t h r e a d _ s t a r t		( G e n e r i c )
- *
- **************************************
- *
- * Functional description
- *	Wrong attempt to start a new thread.
- *
- **************************************/
-	fb_assert(false);
-	return 0;
-}
-
-void Thread::waitForCompletion(Handle&)
-{
-}
-
-void Thread::kill(Handle&)
-{
-}
-
-Thread::Handle Thread::getId()
-{
-}
-
-void Thread::sleep(unsigned milliseconds)
-{
-}
-
-void Thread::yield()
-{
-}
-
-#endif  // START_THREAD

--- a/src/common/ThreadStart.cpp
+++ b/src/common/ThreadStart.cpp
@@ -193,6 +193,8 @@ void Thread::waitForCompletion()
 {
 	if (isValid())
 	{
+		fb_assert(!isCurrent());
+
 		int state = pthread_join(m_handle, NULL);
 		if (state)
 			Firebird::system_call_failed::raise("pthread_join", state);
@@ -206,12 +208,15 @@ void Thread::kill() noexcept
 #ifdef HAVE_PTHREAD_CANCEL
 	if (isValid())
 	{
+		fb_assert(!isCurrent());
+
 		pthread_cancel(m_handle);
 		try
 		{
 			waitForCompletion();
 		}
 		catch(...) { }
+		m_handle = INVALID_HANDLE;
 	}
 #endif
 }
@@ -351,6 +356,8 @@ bool Thread::waitFor(unsigned milliseconds) const noexcept
 	if (!isValid())
 		return true;
 
+	fb_assert(!isCurrent());
+
 	return WaitForSingleObject(m_handle, milliseconds) != WAIT_TIMEOUT;
 }
 
@@ -358,6 +365,8 @@ void Thread::waitForCompletion()
 {
 	if (!isValid())
 		return;
+
+	fb_assert(!isCurrent());
 
 	// When current DLL is unloading, OS loader holds loader lock. When thread is
 	// exiting, OS notifies every DLL about it, and acquires loader lock. In such
@@ -372,6 +381,8 @@ void Thread::kill() noexcept
 {
 	if (isValid())
 	{
+		fb_assert(!isCurrent());
+
 		TerminateThread(m_handle, -1);
 		detach();
 	}

--- a/src/common/classes/Synchronize.cpp
+++ b/src/common/classes/Synchronize.cpp
@@ -221,7 +221,7 @@ private:
 TLS_DECLARE(ThreadSync*, threadIndex);
 
 ThreadSync::ThreadSync(const char* desc)
-	: threadId(getCurrentThreadId()), nextWaiting(NULL), prevWaiting(NULL),
+	: threadId(getThreadId()), nextWaiting(NULL), prevWaiting(NULL),
 	  lockType(SYNC_NONE), lockGranted(false), lockPending(NULL), locks(NULL),
 	  description(desc)
 {
@@ -261,11 +261,6 @@ void ThreadSync::setThread(ThreadSync* thread)
 	}
 
 	TLS_SET(threadIndex, thread);
-}
-
-ThreadId ThreadSync::getCurrentThreadId()
-{
-	return getThreadId();
 }
 
 const char* ThreadSync::getWhere() const

--- a/src/common/classes/Synchronize.h
+++ b/src/common/classes/Synchronize.h
@@ -84,7 +84,6 @@ public:
 
 	static ThreadSync* findThread();
 	static ThreadSync* getThread(const char* desc);
-	static ThreadId getCurrentThreadId();
 
 	const char* getWhere() const;
 

--- a/src/common/classes/TimerImpl.cpp
+++ b/src/common/classes/TimerImpl.cpp
@@ -53,7 +53,7 @@ void TimerImpl::handler()
 		m_expTime = 0;
 
 		if (m_onTimer)
-			m_handlerTid = Thread::getId();
+			m_handlerTid = Thread::getCurrentThreadId();
 	}
 
 	if (!m_onTimer)
@@ -108,7 +108,7 @@ void TimerImpl::stop()
 	MutexLockGuard guard(m_mutex, FB_FUNCTION);
 
 	// Allow handler() to call stop()
-	if (m_handlerTid == Thread::getId())
+	if (m_handlerTid == Thread::getCurrentThreadId())
 		return;
 
 	// hvlad: it could be replaced by condition variable when we have good one for Windows

--- a/src/common/isc_sync.cpp
+++ b/src/common/isc_sync.cpp
@@ -328,7 +328,7 @@ public:
 		else if (!guard.tryEnter())
 			return -1;
 
-		DEB_FLOCK("%d lock %p %c%c\n", Thread::getId(), this, shared ? 's' : 'X', wait ? 'W' : 't');
+		DEB_FLOCK("%d lock %p %c%c\n", Thread::getCurrentThreadId(), this, shared ? 's' : 'X', wait ? 'W' : 't');
 
 		while (counter != 0)	// file lock belongs to our process
 		{
@@ -337,14 +337,14 @@ public:
 			{
 				// one more shared lock
 				++counter;
-				DEB_FLOCK("%d fast %p c=%d\n", Thread::getId(), this, counter);
+				DEB_FLOCK("%d fast %p c=%d\n", Thread::getCurrentThreadId(), this, counter);
 				return 0;
 			}
-			if ((!shared) && counter < 0 && threadId == Thread::getId())
+			if ((!shared) && counter < 0 && threadId == Thread::getCurrentThreadId())
 			{
 				// recursive excl lock
 				--counter;
-				DEB_FLOCK("%d fast %p c=%d\n", Thread::getId(), this, counter);
+				DEB_FLOCK("%d fast %p c=%d\n", Thread::getCurrentThreadId(), this, counter);
 				return 0;
 			}
 
@@ -352,11 +352,11 @@ public:
 			// wait for another thread to release a lock
 			if (!wait)
 			{
-				DEB_FLOCK("%d failed internally %p c=%d rc -1\n", Thread::getId(), this, counter);
+				DEB_FLOCK("%d failed internally %p c=%d rc -1\n", Thread::getCurrentThreadId(), this, counter);
 				return -1;
 			}
 
-			DEB_FLOCK("%d wait %p c=%d\n", Thread::getId(), this, counter);
+			DEB_FLOCK("%d wait %p c=%d\n", Thread::getCurrentThreadId(), this, counter);
 			waitOn.wait(mutex);
 		}
 
@@ -380,13 +380,13 @@ public:
 			if (!wait && (rc == EWOULDBLOCK))
 				rc = -1;
 #endif
-			DEB_FLOCK("%d failed on file %p c=%d rc %d\n", Thread::getId(), this, counter, rc);
+			DEB_FLOCK("%d failed on file %p c=%d rc %d\n", Thread::getCurrentThreadId(), this, counter, rc);
 			return rc;
 		}
 
 		if (!shared)
 		{
-			threadId = Thread::getId();
+			threadId = Thread::getCurrentThreadId();
 
 			// call init() when needed
 			if (init && !shared)
@@ -395,7 +395,7 @@ public:
 
 		// mark lock as taken
 		counter = shared ? 1 : -1;
-		DEB_FLOCK("%d filelock %p c=%d\n", Thread::getId(), this, counter);
+		DEB_FLOCK("%d filelock %p c=%d\n", Thread::getCurrentThreadId(), this, counter);
 		return 0;
 	}
 
@@ -406,7 +406,7 @@ public:
 		MutexEnsureUnlock guard(mutex, FB_FUNCTION);
 		guard.enter();
 
-		DEB_FLOCK("%d UNlock %p c=%d\n", Thread::getId(), this, counter);
+		DEB_FLOCK("%d UNlock %p c=%d\n", Thread::getCurrentThreadId(), this, counter);
 
 		if (counter < 0)
 			++counter;
@@ -415,7 +415,7 @@ public:
 
 		if (counter != 0)
 		{
-			DEB_FLOCK("%d done %p c=%d\n", Thread::getId(), this, counter);
+			DEB_FLOCK("%d done %p c=%d\n", Thread::getCurrentThreadId(), this, counter);
 			return;
 		}
 
@@ -439,7 +439,7 @@ public:
 			iscLogStatus("Unlock error", &local);
 		}
 
-		DEB_FLOCK("%d file-done %p\n", Thread::getId(), this);
+		DEB_FLOCK("%d file-done %p\n", Thread::getCurrentThreadId(), this);
 		waitOn.notifyAll();
 	}
 

--- a/src/jrd/CryptoManager.h
+++ b/src/jrd/CryptoManager.h
@@ -292,7 +292,7 @@ public:
 	bool read(thread_db* tdbb, FbStatusVector* sv, Ods::pag* page, IOCallback* io);
 	bool write(thread_db* tdbb, FbStatusVector* sv, Ods::pag* page, IOCallback* io);
 
-	void cryptThread();
+	void cryptThreadRoutine();
 
 	bool checkValidation(Firebird::IDbCryptPlugin* crypt);
 	void setDbInfo(Firebird::IDbCryptPlugin* cp);
@@ -301,9 +301,10 @@ public:
 	UCHAR getCurrentState(thread_db* tdbb) const;
 	const char* getKeyName() const;
 	const char* getPluginName() const;
-	Thread::Handle getCryptThreadHandle() const
+
+	bool isCryptThreadCurrent()
 	{
-		return cryptThreadHandle;
+		return cryptThread.isCurrent();
 	}
 
 private:
@@ -382,7 +383,7 @@ private:
 	AttachmentsRefHolder keyProviders, keyConsumers;
 	Firebird::string hash;
 	Firebird::RefPtr<DbInfo> dbInfo;
-	Thread::Handle cryptThreadHandle;
+	Thread cryptThread;
 	Firebird::IDbCryptPlugin* cryptPlugin;
 	Factory* checkFactory;
 	Database& dbb;

--- a/src/jrd/jrd.cpp
+++ b/src/jrd/jrd.cpp
@@ -488,7 +488,7 @@ namespace
 	struct AttShutParams
 	{
 		Semaphore thdStartedSem, startCallCompleteSem;
-		Thread::Handle thrHandle;
+		Thread thread;
 		AttachmentsRefHolder* attachments;
 	};
 
@@ -4774,13 +4774,13 @@ void JProvider::shutdown(CheckStatusWrapper* status, unsigned int timeout, const
 			{
 				Semaphore shutdown_semaphore;
 
-				Thread::Handle h;
-				Thread::start(shutdown_thread, &shutdown_semaphore, THREAD_medium, &h);
+				Thread shutThd;
+				Thread::start(shutdown_thread, &shutdown_semaphore, THREAD_medium, &shutThd);
 
 				if (!shutdown_semaphore.tryEnter(0, timeout))
 					waitForShutdown(shutdown_semaphore);
 
-				Thread::waitForCompletion(h);
+				shutThd.waitForCompletion();
 			}
 			else
 			{
@@ -6876,7 +6876,7 @@ static void check_database(thread_db* tdbb, bool async)
 	}
 
 	if ((attachment->att_flags & ATT_shutdown) &&
-		(attachment->att_purge_tid != Thread::getId()) ||
+		(attachment->att_purge_tid != Thread::getCurrentThreadId()) ||
 			(dbb->isShutdown() &&
 				(dbb->isShutdown(shut_mode_full) ||
 				!attachment->locksmith(tdbb, ACCESS_SHUTDOWN_DATABASE))))
@@ -7953,15 +7953,11 @@ void release_attachment(thread_db* tdbb, Jrd::Attachment* attachment, XThreadEns
 	XThreadEnsureUnlock* activeThreadGuard = dropGuard;
 	if (!activeThreadGuard)
 	{
-		if (dbb->dbb_crypto_manager &&
-			Thread::isCurrent(dbb->dbb_crypto_manager->getCryptThreadHandle()))
-		{
+		if (dbb->dbb_crypto_manager && dbb->dbb_crypto_manager->isCryptThreadCurrent())
 			activeThreadGuard = &dummyGuard;
-		}
 		else
-		{
 			activeThreadGuard = &threadGuard;
-		}
+
 		activeThreadGuard->enter();
 	}
 
@@ -8470,7 +8466,7 @@ static void purge_attachment(thread_db* tdbb, StableAttachmentPart* sAtt, unsign
 
 	Jrd::Attachment* attachment = sAtt->getHandle();
 
-	if (attachment && attachment->att_purge_tid == Thread::getId())
+	if (attachment && attachment->att_purge_tid == Thread::getCurrentThreadId())
 	{
 //		fb_assert(false); // recursive call - impossible ?
 		return;
@@ -8499,7 +8495,7 @@ static void purge_attachment(thread_db* tdbb, StableAttachmentPart* sAtt, unsign
 		return;
 
 	fb_assert(attachment->att_flags & ATT_shutdown);
-	attachment->att_purge_tid = Thread::getId();
+	attachment->att_purge_tid = Thread::getCurrentThreadId();
 
 	fb_assert(attachment->att_use_count > 0);
 	attachment = sAtt->getHandle();
@@ -9098,12 +9094,12 @@ namespace
 			return 0;
 		}
 
-		Thread::Handle th = params->thrHandle;
-		fb_assert(th);
+		fb_assert(params->thread.isCurrent());
+		Thread::Mark mark(params->thread);
 
 		try
 		{
-			shutThreadCollect->running(th);
+			shutThreadCollect->running(std::move(params->thread));
 			params->thdStartedSem.release();
 
 			MutexLockGuard guard(shutdownMutex, FB_FUNCTION);
@@ -9115,7 +9111,7 @@ namespace
 			iscLogException("attachmentShutdownThread", ex);
 		}
 
-		shutThreadCollect->ending(th);
+		shutThreadCollect->ending(mark);
 		return 0;
 	}
 } // anonymous namespace
@@ -9400,7 +9396,7 @@ ISC_STATUS thread_db::getCancelState(ISC_STATUS* secondary)
 	if (tdbb_flags & (TDBB_verb_cleanup | TDBB_dfw_cleanup | TDBB_detaching | TDBB_wait_cancel_disable))
 		return FB_SUCCESS;
 
-	if (attachment && attachment->att_purge_tid != Thread::getId())
+	if (attachment && attachment->att_purge_tid != Thread::getCurrentThreadId())
 	{
 		if (attachment->att_flags & ATT_shutdown)
 		{
@@ -9910,7 +9906,7 @@ void JRD_shutdown_attachment(Attachment* attachment)
 
 		AttShutParams params;
 		params.attachments = queue;
-		Thread::start(attachmentShutdownThread, &params, THREAD_high, &params.thrHandle);
+		Thread::start(attachmentShutdownThread, &params, THREAD_high, &params.thread);
 		params.startCallCompleteSem.release();
 
 		queue.release();
@@ -9967,7 +9963,7 @@ void JRD_shutdown_attachments(Database* dbb)
 		{
 			AttShutParams params;
 			params.attachments = queue;
-			Thread::start(attachmentShutdownThread, &params, THREAD_high, &params.thrHandle);
+			Thread::start(attachmentShutdownThread, &params, THREAD_high, &params.thread);
 			params.startCallCompleteSem.release();
 
 			queue.release();

--- a/src/jrd/replication/ChangeLog.cpp
+++ b/src/jrd/replication/ChangeLog.cpp
@@ -380,7 +380,7 @@ ChangeLog::ChangeLog(MemoryPool& pool,
 		linkSelf();
 	}
 
-	Thread::start(archiver_thread, this, THREAD_medium, 0);
+	Thread::start(archiver_thread, this, THREAD_medium);
 	m_startupSemaphore.enter();
 	m_workingSemaphore.release();
 }

--- a/src/jrd/replication/Manager.cpp
+++ b/src/jrd/replication/Manager.cpp
@@ -198,7 +198,7 @@ Manager::Manager(const string& dbId,
 		m_replicas.add(FB_NEW_POOL(getPool()) SyncReplica(getPool(), attachment, replicator));
 	}
 
-	Thread::start(writer_thread, this, THREAD_medium, 0);
+	Thread::start(writer_thread, this, THREAD_medium);
 	m_startupSemaphore.enter();
 }
 

--- a/src/jrd/svc.cpp
+++ b/src/jrd/svc.cpp
@@ -703,7 +703,7 @@ Service::Service(const TEXT* service_name, USHORT spb_length, const UCHAR* spb_d
 	svc_remote_pid(0), svc_trace_manager(NULL), svc_crypt_callback(crypt_callback),
 	svc_existence(FB_NEW_POOL(*getDefaultMemoryPool()) SvcMutex(this)),
 	svc_stdin_size_requested(0), svc_stdin_buffer(NULL), svc_stdin_size_preload(0),
-	svc_stdin_preload_requested(0), svc_stdin_user_size(0), svc_thread(0)
+	svc_stdin_preload_requested(0), svc_stdin_user_size(0)
 #ifdef DEV_BUILD
 	, svc_debug(false)
 #endif
@@ -1946,12 +1946,11 @@ THREAD_ENTRY_DECLARE Service::run(THREAD_ENTRY_PARAM arg)
 		RefPtr<SvcMutex> ref(svc->svc_existence);
 		exit_code = svc->svc_service_run->serv_thd(svc);
 
-		Thread::Handle thrHandle = svc->svc_thread;
 		svc->started();
 		svc->unblockQueryGet();
 		svc->finish(SVC_finished);
 
-		threadCollect->ending(thrHandle);
+		threadCollect->ending(std::move(svc->svc_thread));
 	}
 	catch (const Exception& ex)
 	{

--- a/src/jrd/svc.h
+++ b/src/jrd/svc.h
@@ -420,8 +420,8 @@ private:
 	// Size of data, placed into svc_stdin_buffer (set in put)
 	ULONG svc_stdin_user_size;
 	static inline constexpr ULONG PRELOAD_BUFFER_SIZE = SVC_IO_BUFFER_SIZE;
-	// Handle of a thread to wait for when closing
-	Thread::Handle svc_thread;
+	// Thread to wait for when closing
+	Thread svc_thread;
 
 #ifdef DEV_BUILD
 	bool svc_debug;

--- a/src/jrd/tra.cpp
+++ b/src/jrd/tra.cpp
@@ -1713,7 +1713,7 @@ jrd_tra* TRA_start(thread_db* tdbb, ULONG flags, SSHORT lock_timeout, Jrd::jrd_t
 	// are running purge_attachment() because it's needed for
 	// ON DISCONNECT triggers
 	if (dbb->dbb_ast_flags & DBB_shut_tran &&
-		attachment->att_purge_tid != Thread::getId())
+		attachment->att_purge_tid != Thread::getCurrentThreadId())
 	{
 		ERR_post(Arg::Gds(isc_shutinprog) << Arg::Str(attachment->att_filename));
 	}
@@ -1770,7 +1770,7 @@ jrd_tra* TRA_start(thread_db* tdbb, int tpb_length, const UCHAR* tpb, Jrd::jrd_t
 	// are running purge_attachment() because it's needed for
 	// ON DISCONNECT triggers
 	if (dbb->dbb_ast_flags & DBB_shut_tran &&
-		attachment->att_purge_tid != Thread::getId())
+		attachment->att_purge_tid != Thread::getCurrentThreadId())
 	{
 		ERR_post(Arg::Gds(isc_shutinprog) << Arg::Str(attachment->att_filename));
 	}

--- a/src/remote/client/interface.cpp
+++ b/src/remote/client/interface.cpp
@@ -6311,8 +6311,7 @@ IEvents* Attachment::queEvents(CheckStatusWrapper* status, IEventCallback* callb
 			port->connect(packet);
 
 			rem_port* port_async = port->port_async;
-			port_async->port_events_threadId =
-				Thread::start(event_thread, port_async, THREAD_high, &port_async->port_events_thread);
+			Thread::start(event_thread, port_async, THREAD_high, &port_async->port_events_thread);
 
 			port_async->port_context = rdb;
 		}

--- a/src/remote/inet.cpp
+++ b/src/remote/inet.cpp
@@ -1804,8 +1804,8 @@ static void disconnect(rem_port* port)
 		SOCLOSE(port->port_channel);
 	}
 
-	if (port->port_thread_guard && port->port_events_thread && !port->port_events_threadId.isCurrent())
-		port->port_thread_guard->setWait(port->port_events_thread);
+	if (port->port_thread_guard && port->port_events_thread.isCurrent())
+		port->port_thread_guard->setWait(std::move(port->port_events_thread));
 	else
 		port->releasePort();
 

--- a/src/remote/os/win32/xnet.cpp
+++ b/src/remote/os/win32/xnet.cpp
@@ -1071,12 +1071,12 @@ static void cleanup_port(rem_port* port)
  *
  **************************************/
 
-	if (port->port_thread_guard && port->port_events_thread && !port->port_events_threadId.isCurrent())
+	if (port->port_thread_guard && port->port_events_thread.isCurrent())
 	{
 		//port->port_thread_guard->setWait(port->port_events_thread);
 
 		// Do not release XNET structures while event's thread working
-		Thread::waitForCompletion(port->port_events_thread);
+		port->port_events_thread.waitForCompletion();
 	}
 
 	if (port->port_xcc)

--- a/src/remote/remote.h
+++ b/src/remote/remote.h
@@ -1320,8 +1320,7 @@ struct rem_port : public Firebird::GlobalStorage, public Firebird::RefCounted
 	SOCKET			port_channel;		// handle for connection (from by OS)
 	struct linger	port_linger;		// linger value as defined by SO_LINGER
 	Rdb*			port_context;
-	Thread::Handle	port_events_thread;	// handle of thread, handling incoming events
-	Thread			port_events_threadId;
+	Thread			port_events_thread;	// thread handling incoming events
 	RemotePortGuard* port_thread_guard;	// will close port_events_thread in safe way
 #ifdef WIN_NT
 	HANDLE			port_pipe;			// port pipe handle
@@ -1485,7 +1484,7 @@ public:
 		port_flags(0), port_partial_data(false), port_z_data(false),
 		port_connect_timeout(0), port_dummy_packet_interval(0),
 		port_dummy_timeout(0), port_handle(INVALID_SOCKET), port_channel(INVALID_SOCKET), port_context(0),
-		port_events_thread(0), port_thread_guard(0),
+		port_thread_guard(0),
 #ifdef WIN_NT
 		port_pipe(INVALID_HANDLE_VALUE), port_event(INVALID_HANDLE_VALUE),
 #endif
@@ -1769,7 +1768,7 @@ private:
 		{
 			if (waitFlag)
 			{
-				Thread::waitForCompletion(waitHandle);
+				thread.waitForCompletion();
 
 				fb_assert(asyncPort);
 
@@ -1781,7 +1780,7 @@ private:
 		}
 
 		rem_port* asyncPort;
-		Thread::Handle waitHandle{};
+		Thread thread{};
 		bool waitFlag;
 	};
 
@@ -1794,9 +1793,9 @@ public:
 			wThr.asyncPort->port_thread_guard = this;
 	}
 
-	void setWait(Thread::Handle& handle) noexcept
+	void setWait(Thread&& handle) noexcept
 	{
-		wThr.waitHandle = handle;
+		wThr.thread = std::move(handle);
 		wThr.waitFlag = true;
 		fb_assert(wThr.asyncPort);
 		wThr.asyncPort->port_thread_guard = nullptr;

--- a/src/remote/server/ReplServer.cpp
+++ b/src/remote/server/ReplServer.cpp
@@ -1054,7 +1054,7 @@ bool REPL_server(CheckStatusWrapper* status, const Replication::Config::ReplicaL
 		for (const auto replica : replicas)
 		{
 			const auto target = FB_NEW Target(replica);
-			Thread::start(process_thread, target, THREAD_medium, NULL);
+			Thread::start(process_thread, target, THREAD_medium);
 			++activeThreads;
 		}
 

--- a/src/yvalve/MasterImplementation.cpp
+++ b/src/yvalve/MasterImplementation.cpp
@@ -137,7 +137,7 @@ void abortShutdown()
 	abortShutdownFlag = true;
 }
 
-Thread::Handle timerThreadHandle = 0;
+Thread timerThread;
 
 FB_BOOLEAN MasterImplementation::getProcessExiting()
 {
@@ -149,7 +149,7 @@ FB_BOOLEAN MasterImplementation::getProcessExiting()
 	// be terminated already, wait for its handle with zero timeout returns WAIT_TIMEOUT.
 	// Usage of small non-zero timeout seems fixed such cases.
 
-	if (timerThreadHandle && WaitForSingleObject(timerThreadHandle, 10) != WAIT_TIMEOUT)
+	if (timerThread.waitFor(10))
 		return true;
 #endif
 
@@ -180,7 +180,7 @@ struct TimerEntry
 
 	static void init()
 	{
-		Thread::start(timeThread, 0, THREAD_high, &timerThreadHandle);
+		Thread::start(timeThread, 0, THREAD_high, &timerThread);
 	}
 
 	static void cleanup();
@@ -201,7 +201,7 @@ void TimerEntry::cleanup()
 	}
 
 	timerCleanup->tryEnter(5);
-	Thread::waitForCompletion(timerThreadHandle);
+	timerThread.waitForCompletion();
 
 	while (timerQueue->hasData())
 	{

--- a/src/yvalve/utl.cpp
+++ b/src/yvalve/utl.cpp
@@ -2973,7 +2973,14 @@ int API_ROUTINE gds__thread_start(FPTR_INT_VOID_PTR* entrypoint,
 	int rc = 0;
 	try
 	{
-		Thread::start((ThreadEntryPoint*) entrypoint, arg, priority, (Thread::Handle*) thd_id);
+		Thread thread;
+		Thread::start((ThreadEntryPoint*) entrypoint, arg, priority, &thread);
+
+		if (thd_id)
+		{
+			*static_cast<Thread::Handle*>(thd_id) = thread.getHandle();
+			thread.detach(false);
+		}
 	}
 	catch (const status_exception& status)
 	{

--- a/src/yvalve/why.cpp
+++ b/src/yvalve/why.cpp
@@ -836,7 +836,7 @@ private:
 			: ShutdownInit(p)
 		{
 			shutdownSemaphore = &semaphore;
-			Thread::start(shutdownThread, 0, 0, &handle);
+			Thread::start(shutdownThread, 0, 0, &thread);
 
 			procInt = ISC_signal(SIGINT, handlerInt, 0);
 			procTerm = ISC_signal(SIGTERM, handlerTerm, 0);
@@ -852,11 +852,11 @@ private:
 				// Must be done to let shutdownThread close.
 				shutdownSemaphore->release();
 				shutdownSemaphore = NULL;
-				Thread::waitForCompletion(handle);
+				thread.waitForCompletion();
 			}
 		}
 	private:
-		Thread::Handle handle;
+		Thread thread;
 	};
 #endif // UNIX
 


### PR DESCRIPTION
Refactor `class Thread` and relatives:
- ensure correct and one-time release of thread-related resources, such as thread handle on Windows,
- hide OS-related internals. 

Thanks to @AlexPeshkoff.

