### PR TITLE
Build process chash when btyacc parse file was created in windows with end of line mark as \r\n

### DIFF
--- a/extern/btyacc/reader.c
+++ b/extern/btyacc/reader.c
@@ -147,10 +147,13 @@ char *get_line() {
   /* VM: Process %include line */
   if(strncmp(&line[0], "%include ", 9)==0) {
     int ii=0;
-    for(i=9; line[i]!='\n' && line[i]!=' '; i++, ii++) {
-      inc_file_name[ii] = line[i];
-    }
-    inc_file_name[ii] = 0;
+
+    char *inc_file_name = line+9;
+    while (isspace(*inc_file_name)) inc_file_name++;
+    i = strlen(inc_file_name);
+    while (i > 0 && isspace(inc_file_name[i-1])) --i;
+    inc_file_name[i] = 0;
+
     if(inc_file) {
       error(lineno, 0, 0, "Nested include lines are not allowed");
     }

--- a/src/remote/inet.cpp
+++ b/src/remote/inet.cpp
@@ -3121,7 +3121,9 @@ static bool packet_receive(rem_port* port, UCHAR* buffer, SSHORT buffer_length, 
 			INET_force_error = 1;
 			try
 			{
-				inet_error(false, port, "simulated error - read", isc_net_read_err);
+				// function  inet_error as 5 parameters
+				// inet_error(bool releasePort, rem_port* port, const TEXT* function, ISC_STATUS operation, int status)
+				inet_error(false, port, "simulated error - read", isc_net_read_err, 0);
 			}
 			catch (const Exception&) { }
 			return false;

--- a/src/remote/inet.cpp
+++ b/src/remote/inet.cpp
@@ -3121,8 +3121,6 @@ static bool packet_receive(rem_port* port, UCHAR* buffer, SSHORT buffer_length, 
 			INET_force_error = 1;
 			try
 			{
-				// function  inet_error as 5 parameters
-				// inet_error(bool releasePort, rem_port* port, const TEXT* function, ISC_STATUS operation, int status)
 				inet_error(false, port, "simulated error - read", isc_net_read_err, 0);
 			}
 			catch (const Exception&) { }


### PR DESCRIPTION
	if btyacc parsing file was created in windows but processing on linux we need  delete windows end of line mark as \r\n (CR + LF) Otherwise, the file will not be found.
	more info: https://github.com/ChrisDodd/btyacc/pull/32