### PR TITLE
Build process chash when btyacc parse file was created in windows with end of line mark as \r\n

### DIFF
--- a/extern/btyacc/reader.c
+++ b/extern/btyacc/reader.c
@@ -146,13 +146,11 @@ char *get_line() {
 
   /* VM: Process %include line */
   if(strncmp(&line[0], "%include ", 9)==0) {
-
-    char *inc_file_name = line+9;
-    while (isspace(*inc_file_name)) inc_file_name++;
-    i = strlen(inc_file_name);
-    while (i > 0 && isspace(inc_file_name[i-1])) --i;
-    inc_file_name[i] = 0;
-
+    int ii=0;
+    for(i=9; line[i]!='\n' && line[i]!=' ' && !(line[i] =='\r' && line[i+1]=='\n'); i++, ii++) {
+      inc_file_name[ii] = line[i];
+    }
+    inc_file_name[ii] = 0;
     if(inc_file) {
       error(lineno, 0, 0, "Nested include lines are not allowed");
     }

--- a/extern/btyacc/reader.c
+++ b/extern/btyacc/reader.c
@@ -147,10 +147,13 @@ char *get_line() {
   /* VM: Process %include line */
   if(strncmp(&line[0], "%include ", 9)==0) {
     int ii=0;
-    for(i=9; line[i]!='\n' && line[i]!=' '; i++, ii++) {
-      inc_file_name[ii] = line[i];
-    }
-    inc_file_name[ii] = 0;
+
+    char *inc_file_name = line+9;
+    while (isspace(*inc_file_name)) inc_file_name++;
+    i = strlen(inc_file_name);
+    while (i > 0 && isspace(inc_file_name[i-1])) --i;
+    inc_file_name[i] = 0;
+
     if(inc_file) {
       error(lineno, 0, 0, "Nested include lines are not allowed");
     }

--- a/extern/btyacc/reader.c
+++ b/extern/btyacc/reader.c
@@ -146,7 +146,6 @@ char *get_line() {
 
   /* VM: Process %include line */
   if(strncmp(&line[0], "%include ", 9)==0) {
-    int ii=0;
 
     char *inc_file_name = line+9;
     while (isspace(*inc_file_name)) inc_file_name++;


### PR DESCRIPTION
	if parsing file was created in windows but processing on linux we need  delete windows end of line mark as \r\n (CR + LF) Otherwise, the file will not be found.

	more info: https://github.com/ChrisDodd/btyacc/pull/32
