### PR TITLE
Use pre-built Windows builder image and move CI runner to windows-2025

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -300,6 +300,34 @@ jobs:
       - name: Get Release Notes
         uses: ./.github/actions/get-release-notes
 
+      # firebirdsql/firebird-builder-windows image is private
+      - name: Login to Docker Hub
+        id: dockerhub-login
+        uses: docker/login-action@v3
+        continue-on-error: true
+        with:
+          username: firebirdsql
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker pull firebirdsql/firebird-builder-windows
+        shell: cmd
+        if: ${{ steps.dockerhub-login.outcome == 'success' }}
+        run: |
+          docker pull firebirdsql/firebird-builder-windows:fb6-x86-x64-windows-v1
+
+      - name: Reclaim disk space in the runner to build the image
+        if: ${{ runner.environment == 'github-hosted' && steps.dockerhub-login.outcome != 'success' }}
+        shell: cmd
+        run: |
+          rd "C:\Program Files\Microsoft Visual Studio\2022" /s /q
+
+      - name: Build firebird-builder-windows image (fallback)
+        shell: cmd
+        if: ${{ steps.dockerhub-login.outcome != 'success' }}
+        run: |
+          cd builds\docker\windows
+          call build.bat
+
       - name: Build x86 for client package in x64
         id: build-x86
         shell: cmd
@@ -307,7 +335,6 @@ jobs:
         run: |
           mkdir builds\install_images
           cd builds\docker\windows
-          call build.bat
           call run.bat C:\fbscripts\build-x86.bat
 
       - name: Build
@@ -318,7 +345,6 @@ jobs:
         run: |
           mkdir builds\install_images
           cd builds\docker\windows
-          call build.bat
           call run.bat C:\fbscripts\build-%PLATFORM%.bat
 
       - name: Upload zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -281,7 +281,7 @@ jobs:
             builds/install_images/Firebird-*-windows-arm64*.zip
 
   build-windows-docker:
-    runs-on: windows-2022
+    runs-on: windows-2025
 
     strategy:
       fail-fast: false

--- a/builds/docker/windows/build.bat
+++ b/builds/docker/windows/build.bat
@@ -1,2 +1,2 @@
 @echo off
-docker build -t asfernandes/firebird-builder:5 -m 2GB .
+docker build -t firebirdsql/firebird-builder-windows:fb6-x86-x64-windows-v1 -m 2GB .

--- a/builds/docker/windows/push.bat
+++ b/builds/docker/windows/push.bat
@@ -1,0 +1,2 @@
+@echo off
+docker push firebirdsql/firebird-builder-windows:fb6-x86-x64-windows-v1

--- a/builds/docker/windows/run.bat
+++ b/builds/docker/windows/run.bat
@@ -1,2 +1,2 @@
 @echo off
-docker run --rm -v %cd%\..\..\..:C:\firebird asfernandes/firebird-builder:5 %1
+docker run --rm -v %cd%\..\..\..:C:\firebird firebirdsql/firebird-builder-windows:fb6-x86-x64-windows-v1 %1


### PR DESCRIPTION
This updates the Windows Docker build workflow to pull a pre-built private image from Docker Hub, with a fallback to build locally if login fails. This speeds up a bit the CI run by avoiding a full image build on every job.

It also upgrades the Windows CI runner to windows-2025.

The firebird-builder-windows docker image was put as a private image to the firebirdsql org.