### PR TITLE
Fixed bug #8885 : AV when lock manager settings is misconfigured.

### DIFF
--- a/src/common/isc_s_proto.h
+++ b/src/common/isc_s_proto.h
@@ -280,7 +280,7 @@ public:
 	int eventPost(event_t* event);
 
 	// Used as memory allocation unit and mapping alignment
-	static ULONG getSystemPageSize();
+	static ULONG getSystemPageSize(Firebird::CheckStatusWrapper* status);
 
 public:
 #ifdef UNIX
@@ -299,7 +299,7 @@ public:
 #endif
 
 	ULONG	sh_mem_length_mapped;
-	const ULONG	sh_mem_increment;			// Suggested growth increment
+	ULONG	sh_mem_increment;				// Suggested growth increment
 #ifdef WIN_NT
 	HANDLE	sh_mem_handle;					// file handle
 	HANDLE	sh_mem_object;					// file mapping

--- a/src/common/isc_s_proto.h
+++ b/src/common/isc_s_proto.h
@@ -279,6 +279,9 @@ public:
 	int eventWait(event_t* event, const SLONG value, const SLONG micro_seconds);
 	int eventPost(event_t* event);
 
+	// Used as memory allocation unit and mapping alignment
+	static ULONG getSystemPageSize();
+
 public:
 #ifdef UNIX
 	Firebird::AutoPtr<FileLock> mainLock;
@@ -296,6 +299,7 @@ public:
 #endif
 
 	ULONG	sh_mem_length_mapped;
+	const ULONG	sh_mem_increment;			// Suggested growth increment
 #ifdef WIN_NT
 	HANDLE	sh_mem_handle;					// file handle
 	HANDLE	sh_mem_object;					// file mapping

--- a/src/common/isc_sync.cpp
+++ b/src/common/isc_sync.cpp
@@ -1250,12 +1250,38 @@ void SharedMemoryBase::internalUnmap()
 	}
 }
 
+
+ULONG SharedMemoryBase::getSystemPageSize()
+{
+	// Get system page size as this is the unit of mapping.
+
+#ifdef SOLARIS
+	const long ps = sysconf(_SC_PAGESIZE);
+	if (ps == -1)
+	{
+		error(statusVector, "sysconf", errno);
+		return 0;
+	}
+#else
+	const int ps = getpagesize();
+	if (ps == -1)
+	{
+		error(statusVector, "getpagesize", errno);
+		return 0;
+	}
+#endif
+	return ps;
+}
+
+
 SharedMemoryBase::SharedMemoryBase(const TEXT* filename, ULONG length, IpcObject* callback, bool skipLock)
 	:
 #ifdef HAVE_SHARED_MUTEX_SECTION
 	sh_mem_mutex(0),
 #endif
-	sh_mem_length_mapped(0), sh_mem_header(NULL),
+	sh_mem_length_mapped(0),
+	sh_mem_increment(FB_ALIGN(length, getSystemPageSize())),
+	sh_mem_header(NULL),
 	sh_mem_callback(callback)
 {
 /**************************************
@@ -1285,6 +1311,9 @@ SharedMemoryBase::SharedMemoryBase(const TEXT* filename, ULONG length, IpcObject
 
 	TEXT init_filename[MAXPATHLEN];
 	iscPrefixLock(init_filename, INIT_FILE, true);
+
+	if (length && length < sh_mem_increment)
+		length = sh_mem_increment;
 
 	const bool trunc_flag = (length != 0);
 
@@ -1569,8 +1598,18 @@ void SharedMemoryBase::internalUnmap()
 		unlinkFile();
 }
 
+
+ULONG SharedMemoryBase::getSystemPageSize()
+{
+	SYSTEM_INFO sys_info;
+	GetSystemInfo(&sys_info);
+	return sys_info.dwAllocationGranularity;
+}
+
+
 SharedMemoryBase::SharedMemoryBase(const TEXT* filename, ULONG length, IpcObject* cb, bool /*skipLock*/)
   :	sh_mem_mutex(0), sh_mem_length_mapped(0),
+	sh_mem_increment(FB_ALIGN(length, getSystemPageSize())),
 	sh_mem_handle(INVALID_HANDLE_VALUE), sh_mem_object(0), sh_mem_interest(0), sh_mem_hdr_object(0),
 	sh_mem_hdr_address(0), sh_mem_header(NULL), sh_mem_callback(cb), sh_mem_unlink(false)
 {
@@ -1597,6 +1636,9 @@ SharedMemoryBase::SharedMemoryBase(const TEXT* filename, ULONG length, IpcObject
 
 	bool init_flag = false;
 	DWORD err = 0;
+
+	if (length && length < sh_mem_increment)
+		length = sh_mem_increment;
 
 	// retry to attach to mmapped file if the process initializing dies during initialization.
 
@@ -1925,24 +1967,9 @@ UCHAR* SharedMemoryBase::mapObject(CheckStatusWrapper* statusVector, ULONG objec
  *
  **************************************/
 
-	// Get system page size as this is the unit of mapping.
-
-#ifdef SOLARIS
-	const long ps = sysconf(_SC_PAGESIZE);
-	if (ps == -1)
-	{
-		error(statusVector, "sysconf", errno);
+	const ULONG page_size = getSystemPageSize();
+	if (!page_size)
 		return NULL;
-	}
-#else
-	const int ps = getpagesize();
-	if (ps == -1)
-	{
-		error(statusVector, "getpagesize", errno);
-		return NULL;
-	}
-#endif
-	const ULONG page_size = (ULONG) ps;
 
 	// Compute the start and end page-aligned offsets which contain the object being mapped.
 
@@ -1980,24 +2007,9 @@ void SharedMemoryBase::unmapObject(CheckStatusWrapper* statusVector, UCHAR** obj
  *	Zero the object pointer after a successful unmap.
  *
  **************************************/
-	// Get system page size as this is the unit of mapping.
-
-#ifdef SOLARIS
-	const long ps = sysconf(_SC_PAGESIZE);
-	if (ps == -1)
-	{
-		error(statusVector, "sysconf", errno);
+	const size_t page_size = getSystemPageSize();
+	if (!page_size)
 		return;
-	}
-#else
-	const int ps = getpagesize();
-	if (ps == -1)
-	{
-		error(statusVector, "getpagesize", errno);
-		return;
-	}
-#endif
-	const size_t page_size = (ULONG) ps;
 
 	// Compute the start and end page-aligned addresses which contain the mapped object.
 
@@ -2035,9 +2047,7 @@ UCHAR* SharedMemoryBase::mapObject(CheckStatusWrapper* statusVector,
  *
  **************************************/
 
-	SYSTEM_INFO sys_info;
-	GetSystemInfo(&sys_info);
-	const ULONG page_size = sys_info.dwAllocationGranularity;
+	const ULONG page_size = getSystemPageSize();
 
 	// Compute the start and end page-aligned offsets which
 	// contain the object being mapped.
@@ -2046,6 +2056,8 @@ UCHAR* SharedMemoryBase::mapObject(CheckStatusWrapper* statusVector,
 	const ULONG end = FB_ALIGN(object_offset + object_length, page_size);
 	const ULONG length = end - start;
 	const HANDLE handle = sh_mem_object;
+
+	fb_assert(end <= sh_mem_length_mapped);
 
 	UCHAR* address = (UCHAR*) MapViewOfFile(handle, FILE_MAP_WRITE, 0, start, length);
 
@@ -2075,9 +2087,7 @@ void SharedMemoryBase::unmapObject(CheckStatusWrapper* statusVector,
  *	Zero the object pointer after a successful unmap.
  *
  **************************************/
-	SYSTEM_INFO sys_info;
-	GetSystemInfo(&sys_info);
-	const size_t page_size = sys_info.dwAllocationGranularity;
+	const size_t page_size = getSystemPageSize();
 
 	// Compute the start and end page-aligned offsets which
 	// contain the object being mapped.

--- a/src/common/isc_sync.cpp
+++ b/src/common/isc_sync.cpp
@@ -1314,13 +1314,10 @@ SharedMemoryBase::SharedMemoryBase(const TEXT* filename, ULONG length, IpcObject
 
 	if (length)
 	{
-		sh_mem_increment = FB_ALIGN(length, getSystemPageSize(&statusVector));
+		sh_mem_increment = length = FB_ALIGN(length, getSystemPageSize(&statusVector));
 
 		if (statusVector.hasData())
 			status_exception::raise(&statusVector);
-
-		if (length < sh_mem_increment)
-			length = sh_mem_increment;
 	}
 
 	const bool trunc_flag = (length != 0);
@@ -1649,13 +1646,10 @@ SharedMemoryBase::SharedMemoryBase(const TEXT* filename, ULONG length, IpcObject
 		LocalStatus ls;
 		CheckStatusWrapper statusVector(&ls);
 
-		sh_mem_increment = FB_ALIGN(length, getSystemPageSize(&statusVector));
+		sh_mem_increment = length = FB_ALIGN(length, getSystemPageSize(&statusVector));
 
 		if (statusVector.hasData())
 			status_exception::raise(&statusVector);
-
-		if (length < sh_mem_increment)
-			length = sh_mem_increment;
 	}
 
 	// retry to attach to mmapped file if the process initializing dies during initialization.
@@ -2525,6 +2519,8 @@ bool SharedMemoryBase::remapFile(CheckStatusWrapper* statusVector, ULONG new_len
 
 	if (flag)
 	{
+		new_length = FB_ALIGN(new_length, getSystemPageSize(statusVector));
+
 		FB_UNUSED(os_utils::ftruncate(mainLock->getFd(), new_length));
 
 		if (new_length > sh_mem_length_mapped)
@@ -2581,6 +2577,8 @@ bool SharedMemoryBase::remapFile(CheckStatusWrapper* statusVector,
 
 	if (flag)
 	{
+		new_length = FB_ALIGN(new_length, getSystemPageSize(statusVector));
+
 		LARGE_INTEGER offset;
 		offset.QuadPart = new_length;
 

--- a/src/jrd/event.cpp
+++ b/src/jrd/event.cpp
@@ -534,8 +534,10 @@ frb* EventManager::alloc_global(UCHAR type, ULONG length, bool recurse)
 #ifdef HAVE_OBJECT_MAP
 	if (!best && !recurse)
 	{
+		fb_assert(length <= m_sharedMemory->sh_mem_increment);
+
 		const ULONG old_length = m_sharedMemory->sh_mem_length_mapped;
-		const ULONG ev_length = old_length + m_config->getEventMemSize();
+		const ULONG ev_length = old_length + m_sharedMemory->sh_mem_increment;
 
 		LocalStatus ls;
 		CheckStatusWrapper localStatus(&ls);

--- a/src/lock/lock_proto.h
+++ b/src/lock/lock_proto.h
@@ -507,7 +507,8 @@ private:
 
 	// configurations parameters - cached values
 	const ULONG m_acquireSpins;
-	const ULONG m_memorySize;
+	ULONG m_memorySize;
+	USHORT m_hashSlots;
 	const bool m_useBlockingThread;
 
 #ifdef USE_SHMEM_EXT


### PR DESCRIPTION
Ensure shared memory size is multiply of system page size - it guarantees mapObject() will not access area after the end of file. 
It could fix #5860 : operating system directive MapViewOfFile failed access denied [CORE5594]