### PR TITLE
Improvement #8895 : 'invalid request BLR' puts actual error (and procedure where it happened) at the end where it is truncated by ISC API

### DIFF
--- a/src/jrd/Function.epp
+++ b/src/jrd/Function.epp
@@ -470,8 +470,8 @@ Function* Function::loadMetadata(thread_db* tdbb, USHORT id, bool noscan, USHORT
 						{
 							StaticStatusVector temp_status;
 							ex.stuffException(temp_status);
-							(Arg::Gds(isc_bad_fun_BLR) << Arg::Str(name)
-								<< Arg::StatusVector(temp_status.begin())).raise();
+							(Arg::StatusVector(temp_status.begin()) <<
+								Arg::Gds(isc_bad_fun_BLR) << Arg::Str(name)).raise();
 						}
 					}
 				}
@@ -609,8 +609,8 @@ bool Function::reload(thread_db* tdbb)
 				ex.stuffException(temp_status);
 
 				const string name = this->getName().toString();
-				(Arg::Gds(isc_bad_fun_BLR) << Arg::Str(name)
-					<< Arg::StatusVector(temp_status.begin())).raise();
+				(Arg::StatusVector(temp_status.begin()) <<
+					Arg::Gds(isc_bad_fun_BLR) << Arg::Str(name)).raise();
 			}
 		}
 		catch (const Exception&)

--- a/src/jrd/met.epp
+++ b/src/jrd/met.epp
@@ -3732,8 +3732,8 @@ jrd_prc* MET_procedure(thread_db* tdbb, USHORT id, bool noscan, USHORT flags)
 						{
 							StaticStatusVector temp_status;
 							ex.stuffException(temp_status);
-							(Arg::Gds(isc_bad_proc_BLR) << Arg::Str(name)
-								<< Arg::StatusVector(temp_status.begin())).raise();
+							(Arg::StatusVector(temp_status.begin()) <<
+								Arg::Gds(isc_bad_proc_BLR) << Arg::Str(name)).raise();
 						}
 					}
 				}
@@ -3842,8 +3842,8 @@ bool jrd_prc::reload(thread_db* tdbb)
 				ex.stuffException(temp_status);
 
 				const string name = this->getName().toString();
-				(Arg::Gds(isc_bad_proc_BLR) << Arg::Str(name)
-					<< Arg::StatusVector(temp_status.begin())).raise();
+				(Arg::StatusVector(temp_status.begin()) <<
+					Arg::Gds(isc_bad_proc_BLR) << Arg::Str(name)).raise();
 			}
 		}
 		catch (const Exception&)


### PR DESCRIPTION
Revert order of entires in status-vector so that original error is put on the top, not at the bottom
