### PR TITLE
Support VARCHAR/VARBINARY without explicit length

### DIFF
--- a/src/dsql/parse.y
+++ b/src/dsql/parse.y
@@ -5452,7 +5452,7 @@ national_character_type
 		{
 			$$ = newNode<dsql_fld>();
 			$$->dtype = dtype_text;
-			$$->charLength = 1;
+			$$->charLength = DEFAULT_CHAR_LENGTH;
 			$$->flags |= FLD_national;
 		}
 	| national_character_keyword VARYING '(' pos_short_integer ')'
@@ -5466,7 +5466,7 @@ national_character_type
 		{
 			$$ = newNode<dsql_fld>();
 			$$->dtype = dtype_varying;
-			$$->charLength = 255;
+			$$->charLength = DEFAULT_VARCHAR_LENGTH;
 			$$->flags |= FLD_national;
 		}
 	;
@@ -5488,8 +5488,8 @@ binary_character_type
 		{
 			$$ = newNode<dsql_fld>();
 			$$->dtype = dtype_text;
-			$$->charLength = 1;
-			$$->length = 1;
+			$$->charLength = DEFAULT_BINARY_LENGTH;
+			$$->length = DEFAULT_BINARY_LENGTH;
 			$$->textType = ttype_binary;
 			$$->charSetId = CS_BINARY;
 			$$->subType = fb_text_subtype_binary;
@@ -5510,8 +5510,8 @@ binary_character_type
 		{
 			$$ = newNode<dsql_fld>();
 			$$->dtype = dtype_varying;
-			$$->charLength = 255;
-			$$->length = 255 + sizeof(USHORT);
+			$$->charLength = DEFAULT_VARBINARY_LENGTH;
+			$$->length = DEFAULT_VARBINARY_LENGTH + sizeof(USHORT);
 			$$->textType = ttype_binary;
 			$$->charSetId = CS_BINARY;
 			$$->subType = fb_text_subtype_binary;
@@ -5532,7 +5532,7 @@ character_type
 		{
 			$$ = newNode<dsql_fld>();
 			$$->dtype = dtype_text;
-			$$->charLength = 1;
+			$$->charLength = DEFAULT_CHAR_LENGTH;
 		}
 	| varying_keyword '(' pos_short_integer ')'
 		{
@@ -5545,7 +5545,7 @@ character_type
 		{
 			$$ = newNode<dsql_fld>();
 			$$->dtype = dtype_varying;
-			$$->charLength = 255;
+			$$->charLength = DEFAULT_VARCHAR_LENGTH;
 		}
 	;
 

--- a/src/dsql/parse.y
+++ b/src/dsql/parse.y
@@ -5462,6 +5462,13 @@ national_character_type
 			$$->charLength = (USHORT) $4;
 			$$->flags |= (FLD_national | FLD_has_len);
 		}
+	| national_character_keyword VARYING
+		{
+			$$ = newNode<dsql_fld>();
+			$$->dtype = dtype_varying;
+			$$->charLength = 255;
+			$$->flags |= FLD_national;
+		}
 	;
 
 %type <legacyField> binary_character_type
@@ -5499,6 +5506,17 @@ binary_character_type
 			$$->subType = fb_text_subtype_binary;
 			$$->flags |= (FLD_has_len | FLD_has_chset);
 		}
+	| varbinary_character_keyword
+		{
+			$$ = newNode<dsql_fld>();
+			$$->dtype = dtype_varying;
+			$$->charLength = 255;
+			$$->length = 255 + sizeof(USHORT);
+			$$->textType = ttype_binary;
+			$$->charSetId = CS_BINARY;
+			$$->subType = fb_text_subtype_binary;
+			$$->flags |= FLD_has_chset;
+		}
 	;
 
 %type <legacyField> character_type
@@ -5522,6 +5540,12 @@ character_type
 			$$->dtype = dtype_varying;
 			$$->charLength = (USHORT) $3;
 			$$->flags |= FLD_has_len;
+		}
+	| varying_keyword
+		{
+			$$ = newNode<dsql_fld>();
+			$$->dtype = dtype_varying;
+			$$->charLength = 255;
 		}
 	;
 
@@ -5902,7 +5926,7 @@ set_bind
 
 %type <legacyField> set_bind_from
 set_bind_from
-	: bind_type
+	: non_array_type
 	| TIME ZONE
 		{
 			$$ = newNode<dsql_fld>();
@@ -5911,20 +5935,9 @@ set_bind_from
 		}
 	;
 
-%type <legacyField> bind_type
-bind_type
-	: non_array_type
-	| varying_keyword
-		{
-			$$ = newNode<dsql_fld>();
-			$$->dtype = dtype_varying;
-			$$->charLength = 0;
-		}
-	;
-
 %type <legacyField> set_bind_to
 set_bind_to
-	: bind_type
+	: non_array_type
 		{
 			$$ = $1;
 		}

--- a/src/jrd/constants.h
+++ b/src/jrd/constants.h
@@ -220,6 +220,14 @@ inline constexpr size_t DEFAULT_TIME_PRECISION		= 0;
 // Should be 6 as per SQL spec
 inline constexpr size_t DEFAULT_TIMESTAMP_PRECISION	= 3;
 
+// SQL spec requires an implementation-specific default (6.1 <data type>, syntax rules 6 (VARBINARY) and 7 (VARCHAR))
+inline constexpr size_t DEFAULT_VARCHAR_LENGTH = 255;
+inline constexpr size_t DEFAULT_VARBINARY_LENGTH = 255;
+
+// SQL spec requires a default length of 1 (6.1 <data type>, syntax rule 5)
+inline constexpr size_t DEFAULT_CHAR_LENGTH = 1;
+inline constexpr size_t DEFAULT_BINARY_LENGTH = 1;
+
 inline constexpr size_t MAX_ARRAY_DIMENSIONS = 16;
 
 inline constexpr size_t MAX_SORT_ITEMS = 255; // ORDER BY f1,...,f255


### PR DESCRIPTION
Currently, Firebird doesn't have a default length for VARCHAR/CHARACTER VARYING, { NCHAR | NATIONAL {CHAR|CHARACTER} } VARYING, and VARBINARY/BINARY VARYING.

This PR adds a default length of 255 for all these types.

Why 255:

- Big enough for common use cases
- Big enough to cast from other (non-string) scalar types without truncation
- Small enough to not be excessive in storage use, and fits in an index on page size 8192 with UTF8, with some room to spare (e.g. for compound indices)
- 0xFF ;)

Why at all:

- Required by the SQL standard (see below)
- Allows things like `CAST(something as VARCHAR)` (see also second point under "Why 255"), which can be a simplification for query generators
- Can result in simpler code for ad-hoc queries and such 

For reference, the SQL:2023 standard requires such a default, as 6.1 \<data type> defines:

> ```
> <character string type> ::=
>     [...]
>   | CHARACTER VARYING [ <left paren> <character maximum length> <right paren> ]
>   | CHAR VARYING [ <left paren> <character maximum length> <right paren> ]
>   | VARCHAR [ <left paren> <character maximum length> <right paren> ]
>   | [...]
> 
> [...]
> 
> <binary string type> ::=
>     [..]
>   | BINARY VARYING [ <left paren> <maximum length> <right paren> ]
>   | VARBINARY [ <left paren> <maximum length> <right paren> ]
>   | [...]
> 
> [...]
> 
> <national character string type> ::=
>     [...]
>   | NATIONAL CHARACTER VARYING [ <left paren> <character maximum length> <right paren> ]
>   | NATIONAL CHAR VARYING [ <left paren> <character maximum length> <right paren> ]
>   | NCHAR VARYING [ <left paren> <character maximum length> <right paren> ]
>   | [...]
> ```

With syntax rule 6 (for BINARY) and 7 (for VARCHAR/NCHAR VARYING) specifying:

> 6\) If \<maximum length> is omitted, then an implementation-defined (IL007) \<maximum length> is implicit.
> 
> 7\) If \<character maximum length> is omitted, then an implementation-defined (ID069) \<character maximum length> is implicit.

See also thread [Introducing a default VARCHAR length](https://groups.google.com/g/firebird-devel/c/4ewVpoWqA4I) on firebird-devel.