### PR TITLE
Postfix for #8752

### DIFF
--- a/src/alice/exe.cpp
+++ b/src/alice/exe.cpp
@@ -130,11 +130,13 @@ int EXE_action(const TEXT* database, const SINT64 switches)
 		}
 	}
 
-	// It takes longer to print errors, so don't call the started() method
-	if (!error)
-		tdgbl->uSvc->started();
+	// It takes longer to print errors, so don't call the started() method and just return
+	if (error)
+		return FINI_ERROR;
 
-	return error ? FINI_ERROR : FINI_OK;
+	tdgbl->uSvc->started();
+
+	return FINI_OK;
 }
 
 
@@ -188,10 +190,12 @@ int EXE_two_phase(const TEXT* database, const SINT64 switches)
 		}
 	}
 
-	if (!error)
-		tdgbl->uSvc->started();
+	if (error)
+		return FINI_ERROR;
 
-	return (error ? FINI_ERROR : FINI_OK);
+	tdgbl->uSvc->started();
+
+	return FINI_OK;
 }
 
 //____________________________________________________________

--- a/src/alice/exe.cpp
+++ b/src/alice/exe.cpp
@@ -130,7 +130,9 @@ int EXE_action(const TEXT* database, const SINT64 switches)
 		}
 	}
 
-	tdgbl->uSvc->started();
+	// It takes longer to print errors, so don't call the started() method
+	if (!error)
+		tdgbl->uSvc->started();
 
 	return error ? FINI_ERROR : FINI_OK;
 }
@@ -186,7 +188,8 @@ int EXE_two_phase(const TEXT* database, const SINT64 switches)
 		}
 	}
 
-	tdgbl->uSvc->started();
+	if (!error)
+		tdgbl->uSvc->started();
 
 	return (error ? FINI_ERROR : FINI_OK);
 }


### PR DESCRIPTION
## Problem
When invoking fbsvcmgr with operations requiring the USE_GFIX_UTILITY system privilege, the utility exited silently — no error was printed to stdout or stderr.

Root cause: a timing issue introduced by the started() call left insufficient time for the error response to be received and displayed before the process exited.

## Before / After

Before:
```sh
$ ./fbsvcmgr localhost:service_mgr -user user1 -password user1 -action_properties -dbname employee prp_page_buffers 4096
```

After:
```sh
$ ./fbsvcmgr localhost:service_mgr -user user1 -password user1 -action_properties -dbname employee prp_page_buffers 4096
Unable to perform operation
-System privilege USE_GFIX_UTILITY is missing
```

## Fix
Resolved a race condition between the started() call and the service response. Error messages are now correctly delivered and printed before the utility exits.