### PR TITLE
Charset encoding fix

### DIFF
--- a/src/dsql/dsql.cpp
+++ b/src/dsql/dsql.cpp
@@ -594,8 +594,6 @@ static RefPtr<DsqlStatement> prepareStatement(thread_db* tdbb, dsql_dbb* databas
 
 		const auto charSetId = database->dbb_attachment->att_charset;
 
-		string transformedText;
-
 		{	// scope to delete parser before the scratch pool is gone
 			Jrd::ContextPoolHolder scratchContext(tdbb, scratchPool);
 
@@ -618,41 +616,16 @@ static RefPtr<DsqlStatement> prepareStatement(thread_db* tdbb, dsql_dbb* databas
 			if (parser.isStmtAmbiguous())
 				scratch->flags |= DsqlCompilerScratch::FLAG_AMBIGUOUS_STMT;
 
-			transformedText = parser.getTransformedString();
+			const string& source = parser.getTransformedString();
+			string transformedText(*statementPool);
+
+			// If the attachment charset is NONE, we first try to convert data to UTF8;
+			// and if that fails, replace non-ASCII characters by question marks.
+			static_assert(CS_METADATA == CS_UTF8);
+			const bool isConverted = DataTypeUtil::convertToUTF8(source, transformedText, charSetId, ERRD_post);
+			dsqlStatement->setSqlText(FB_NEW_POOL(*statementPool) RefString(*statementPool,
+				isConverted ? transformedText : source));
 		}
-
-		// If the attachment charset is NONE, replace non-ASCII characters by question marks, so
-		// that engine internals doesn't receive non-mappeable data to UTF8. If an attachment
-		// charset is used, validate the string.
-		if (charSetId == CS_NONE)
-		{
-			for (char* p = transformedText.begin(), *end = transformedText.end(); p < end; ++p)
-			{
-				if (UCHAR(*p) > 0x7F)
-					*p = '?';
-			}
-		}
-		else
-		{
-			CharSet* charSet = INTL_charset_lookup(tdbb, charSetId);
-
-			if (!charSet->wellFormed(transformedText.length(),
-					(const UCHAR*) transformedText.begin(), NULL))
-			{
-				ERRD_post(Arg::Gds(isc_sqlerr) << Arg::Num(-104) <<
-						  Arg::Gds(isc_malformed_string));
-			}
-
-			UCharBuffer temp;
-
-			CsConvert conversor(charSet->getStruct(),
-				INTL_charset_lookup(tdbb, CS_METADATA)->getStruct());
-			conversor.convert(transformedText.length(), (const UCHAR*) transformedText.c_str(), temp);
-
-			transformedText.assign(temp.begin(), temp.getCount());
-		}
-
-		dsqlStatement->setSqlText(FB_NEW_POOL(*statementPool) RefString(*statementPool, transformedText));
 
 		// allocate the send and receive messages
 

--- a/src/dsql/dsql.cpp
+++ b/src/dsql/dsql.cpp
@@ -617,7 +617,7 @@ static RefPtr<DsqlStatement> prepareStatement(thread_db* tdbb, dsql_dbb* databas
 				scratch->flags |= DsqlCompilerScratch::FLAG_AMBIGUOUS_STMT;
 
 			const string& source = parser.getTransformedString();
-			string transformedText(*statementPool);
+			string transformedText(*scratchPool);
 
 			// If the attachment charset is NONE, we first try to convert data to UTF8;
 			// and if that fails, replace non-ASCII characters by question marks.

--- a/src/jrd/DataTypeUtil.cpp
+++ b/src/jrd/DataTypeUtil.cpp
@@ -219,7 +219,10 @@ ULONG DataTypeUtilBase::convertLength(ULONG len, CSetId srcCharSet, CSetId dstCh
 	if (dstCharSet == CS_NONE || dstCharSet == CS_BINARY)
 		return len;
 
-	return (len / maxBytesPerChar(srcCharSet)) * maxBytesPerChar(dstCharSet);
+	const ULONG srcBPC = maxBytesPerChar(srcCharSet);
+	const ULONG dstBPC = maxBytesPerChar(dstCharSet);
+
+	return (ROUNDUP(len, srcBPC) / srcBPC) * dstBPC;
 }
 
 
@@ -390,9 +393,9 @@ bool DataTypeUtil::convertToUTF8(const string& src, string& dst, CSetId charset,
 
 		dst.resize(length);
 	}
-	catch (const status_exception& e)
+	catch (const status_exception& ex)
 	{
-		const Arg::StatusVector v(e);
+		const Arg::StatusVector v(ex);
 
 		if (charset == CS_NONE)
 		{

--- a/src/jrd/DataTypeUtil.cpp
+++ b/src/jrd/DataTypeUtil.cpp
@@ -376,17 +376,9 @@ bool DataTypeUtil::convertToUTF8(const string& src, string& dst, CSetId charset,
 	if (charset == CS_UTF8 || charset == CS_UNICODE_FSS)
 		return false;
 
-	if (charset == CS_NONE)
-	{
-		const FB_SIZE_T length = src.length();
-
-		const char* s = src.c_str();
-		char* p = dst.getBuffer(length);
-
-		for (const char* end = src.end(); s < end; ++p, ++s)
-			*p = (*s < 0 ? '?' : *s);
-	}
-	else // charset != CS_UTF8
+	// We throw a status_exception exception to catch it and check charset again.
+	// If charset is NONE, we re-throw the exception through err().
+	try
 	{
 		DataTypeUtil dtUtil(tdbb);
 		ULONG length = dtUtil.convertLength(src.length(), charset, CS_UTF8);
@@ -394,9 +386,26 @@ bool DataTypeUtil::convertToUTF8(const string& src, string& dst, CSetId charset,
 		length = INTL_convert_bytes(tdbb,
 			CS_UTF8, (UCHAR*) dst.getBuffer(length), length,
 			charset, (const BYTE*) src.begin(), src.length(),
-			err);
+			status_exception::raise);
 
 		dst.resize(length);
+	}
+	catch (const status_exception& e)
+	{
+		const Arg::StatusVector v(e);
+
+		if (charset == CS_NONE)
+		{
+			const FB_SIZE_T length = src.length();
+
+			const char* s = src.c_str();
+			char* p = dst.getBuffer(length);
+
+			for (const char* end = src.end(); s < end; ++p, ++s)
+				*p = (*s < ASCII_SPACE ? '?' : *s);
+		}
+		else
+			err(v);
 	}
 
 	return true;

--- a/src/jrd/intl.h
+++ b/src/jrd/intl.h
@@ -35,8 +35,8 @@ struct IdStorage
 	constexpr explicit IdStorage(USHORT id) : val(id) { }
 
 	constexpr operator USHORT() const { return val; }
-	bool operator==(const IdStorage& id) const { return val == id.val; }
-	bool operator!=(const IdStorage& id) const { return val != id.val; }
+	constexpr bool operator==(const IdStorage& id) const { return val == id.val; }
+	constexpr bool operator!=(const IdStorage& id) const { return val != id.val; }
 
 private:
 	USHORT val;


### PR DESCRIPTION
## Problem
When processing text data without an explicitly set encoding, non-ASCII characters were unconditionally replaced with `'?'`. This caused irreversible data loss — for example, usernames containing Cyrillic or other multibyte characters appeared corrupted in trace output.

### Request
```sql
create user user1 password 'user1' firstname 'Абоба';
```

## Configs
### firebird.conf
```properties
AuditTraceConfigFile = fbtrace.conf
TracePlugin = fbtrace
```
### fbtrace.conf
```properties
database
{
  enabled = true
  log_filename = fbtrace.log
  log_statement_finish = true
  time_threshold = 0
}

```

## Before
```console
create user user1 password 'user1' firstname '??????????'
...
param3 = varchar(128), "??????????"
```

## After
```console
create user user1 password 'user1' firstname 'Абоба'
...
param3 = varchar(128), "Абоба"
```

## Fix
Instead of unconditionally replacing unrecognized characters with `'?'`, the code now first attempts to convert the text to UTF-8. The `'?'` replacement is used only as a fallback if the conversion fails.