### PR TITLE
New setting AllowUpdateOverwrite : defines how UPDATE should handle the case when a record was updated by trigger.

### DIFF
--- a/builds/install/misc/firebird.conf
+++ b/builds/install/misc/firebird.conf
@@ -523,6 +523,23 @@
 #SubQueryConversion = false
 
 
+# ----------------------------
+# Defines how UPDATE should handle the case when a record was updated by trigger.
+#
+# It is possible that BEFORE or AFTER UPDATE trigger was fired previously by the
+# current UPDATE statement for the other record and has already changed the
+# current record being updated. Due to cursor stability, UPDATE should not see
+# such changes, and could silently overwrite them.
+#
+# If set to 0 (default), trigger changes will be overwritten by the	UPDATE.
+# If set to 1, error "UPDATE will overwrite changes made by trigger" will be raised.
+#
+# Per-database configurable.
+#
+# Type: integer
+#
+#UpdateOverwriteMode = 0
+
 # ============================
 # Plugin settings
 # ============================

--- a/builds/install/misc/firebird.conf
+++ b/builds/install/misc/firebird.conf
@@ -534,6 +534,10 @@
 # If set to 0 (default), trigger changes will be overwritten by the	UPDATE.
 # If set to 1, error "UPDATE will overwrite changes made by trigger" will be raised.
 #
+# CAUTION!
+# There is no guarantee that this setting will be available in future Firebird
+# versions.
+#
 # Per-database configurable.
 #
 # Type: integer

--- a/builds/install/misc/firebird.conf
+++ b/builds/install/misc/firebird.conf
@@ -524,15 +524,18 @@
 
 
 # ----------------------------
-# Defines how UPDATE should handle the case when a record was updated by trigger.
+# Defines how UPDATE should handle the case when a record was already updated by 
+# trigger or by the another positional UPDATE in the same cursor.
 #
 # It is possible that BEFORE or AFTER UPDATE trigger was fired previously by the
 # current UPDATE statement for the other record and has already changed the
 # current record being updated. Due to cursor stability, UPDATE should not see
 # such changes, and could silently overwrite them.
 #
-# If set to 0 (default), trigger changes will be overwritten by the	UPDATE.
-# If set to 1, error "UPDATE will overwrite changes made by trigger" will be raised.
+# Setting AllowUpdateOverwrite manage how engine should handle such cases:
+# - if set to true (default), prior changes will be overwritten,
+# - if set to false, error "UPDATE will overwrite changes made by the trigger or 
+#	by the another UPDATE in the same cursor" will be raised.
 #
 # CAUTION!
 # There is no guarantee that this setting will be available in future Firebird
@@ -542,7 +545,8 @@
 #
 # Type: integer
 #
-#UpdateOverwriteMode = 0
+#AllowUpdateOverwrite = true
+
 
 # ============================
 # Plugin settings

--- a/src/common/config/config.cpp
+++ b/src/common/config/config.cpp
@@ -434,6 +434,9 @@ void Config::checkValues()
 
 	checkIntForLoBound(KEY_PARALLEL_WORKERS, 1, true);
 	checkIntForHiBound(KEY_PARALLEL_WORKERS, values[KEY_MAX_PARALLEL_WORKERS].intVal, false);
+
+	checkIntForLoBound(KEY_UPDATE_OVERWRITE_MODE, 0, true);
+	checkIntForHiBound(KEY_UPDATE_OVERWRITE_MODE, 1, false);
 }
 
 

--- a/src/common/config/config.cpp
+++ b/src/common/config/config.cpp
@@ -434,9 +434,6 @@ void Config::checkValues()
 
 	checkIntForLoBound(KEY_PARALLEL_WORKERS, 1, true);
 	checkIntForHiBound(KEY_PARALLEL_WORKERS, values[KEY_MAX_PARALLEL_WORKERS].intVal, false);
-
-	checkIntForLoBound(KEY_UPDATE_OVERWRITE_MODE, 0, true);
-	checkIntForHiBound(KEY_UPDATE_OVERWRITE_MODE, 1, false);
 }
 
 

--- a/src/common/config/config.h
+++ b/src/common/config/config.h
@@ -194,6 +194,7 @@ enum ConfigKey
 	KEY_OPTIMIZE_FOR_FIRST_ROWS,
 	KEY_OUTER_JOIN_CONVERSION,
 	KEY_SUBQUERY_CONVERSION,
+	KEY_UPDATE_OVERWRITE_MODE,
 	MAX_CONFIG_KEY		// keep it last
 };
 
@@ -314,7 +315,8 @@ constexpr ConfigEntry entries[MAX_CONFIG_KEY] =
 	{TYPE_INTEGER,	"MaxParallelWorkers",		true,	1},
 	{TYPE_BOOLEAN,	"OptimizeForFirstRows",		false,	false},
 	{TYPE_BOOLEAN,	"OuterJoinConversion",		false,	true},
-	{TYPE_BOOLEAN,	"SubQueryConversion",		false,	false}
+	{TYPE_BOOLEAN,	"SubQueryConversion",		false,	false},
+	{TYPE_INTEGER,	"UpdateOverwriteMode",		false,	0}
 };
 
 
@@ -652,6 +654,8 @@ public:
 	CONFIG_GET_PER_DB_BOOL(getOuterJoinConversion, KEY_OUTER_JOIN_CONVERSION);
 
 	CONFIG_GET_PER_DB_BOOL(getSubQueryConversion, KEY_SUBQUERY_CONVERSION);
+
+	CONFIG_GET_PER_DB_INT(getUpdateOverwriteMode, KEY_UPDATE_OVERWRITE_MODE);
 };
 
 // Implementation of interface to access master configuration file

--- a/src/common/config/config.h
+++ b/src/common/config/config.h
@@ -194,7 +194,7 @@ enum ConfigKey
 	KEY_OPTIMIZE_FOR_FIRST_ROWS,
 	KEY_OUTER_JOIN_CONVERSION,
 	KEY_SUBQUERY_CONVERSION,
-	KEY_UPDATE_OVERWRITE_MODE,
+	KEY_ALLOW_UPDATE_OVERWRITE,
 	MAX_CONFIG_KEY		// keep it last
 };
 
@@ -316,7 +316,7 @@ constexpr ConfigEntry entries[MAX_CONFIG_KEY] =
 	{TYPE_BOOLEAN,	"OptimizeForFirstRows",		false,	false},
 	{TYPE_BOOLEAN,	"OuterJoinConversion",		false,	true},
 	{TYPE_BOOLEAN,	"SubQueryConversion",		false,	false},
-	{TYPE_INTEGER,	"UpdateOverwriteMode",		false,	0}
+	{TYPE_BOOLEAN,	"AllowUpdateOverwrite",		false,	true}
 };
 
 
@@ -655,7 +655,7 @@ public:
 
 	CONFIG_GET_PER_DB_BOOL(getSubQueryConversion, KEY_SUBQUERY_CONVERSION);
 
-	CONFIG_GET_PER_DB_INT(getUpdateOverwriteMode, KEY_UPDATE_OVERWRITE_MODE);
+	CONFIG_GET_PER_DB_BOOL(getAllowUpdateOverwrite, KEY_ALLOW_UPDATE_OVERWRITE);
 };
 
 // Implementation of interface to access master configuration file

--- a/src/include/firebird/impl/msg/jrd.h
+++ b/src/include/firebird/impl/msg/jrd.h
@@ -975,3 +975,5 @@ FB_IMPL_MSG(JRD, 990, sweep_read_only, -901, "42", "000", "Database in read only
 FB_IMPL_MSG(JRD, 991, sweep_attach_no_cleanup, -901, "42", "000", "Attachment has no cleanup flag set")
 // Codes 992..997 are used in v6
 FB_IMPL_MSG(JRD, 998, no_user_att_while_restore, -901, "HY", "000", "User attachments are not allowed for the database being restored")
+// Codes 999..1004 are used in v6
+FB_IMPL_MSG(JRD, 1005, update_overwrite_trigger, -901, "27", "000", "UPDATE will overwrite changes made by trigger")

--- a/src/include/firebird/impl/msg/jrd.h
+++ b/src/include/firebird/impl/msg/jrd.h
@@ -976,4 +976,4 @@ FB_IMPL_MSG(JRD, 991, sweep_attach_no_cleanup, -901, "42", "000", "Attachment ha
 // Codes 992..997 are used in v6
 FB_IMPL_MSG(JRD, 998, no_user_att_while_restore, -901, "HY", "000", "User attachments are not allowed for the database being restored")
 // Codes 999..1004 are used in v6
-FB_IMPL_MSG(JRD, 1005, update_overwrite_trigger, -901, "27", "000", "UPDATE will overwrite changes made by trigger")
+FB_IMPL_MSG(JRD, 1005, update_overwrite, -901, "27", "000", "UPDATE will overwrite changes made by the trigger or by the another UPDATE in the same cursor")

--- a/src/jrd/vio.cpp
+++ b/src/jrd/vio.cpp
@@ -6617,31 +6617,31 @@ static void refresh_fk_fields(thread_db* tdbb, Record* old_rec, record_param* cu
  * Functional description
  *	Update new_rpb with foreign key fields values changed by cascade triggers.
  *  Consider self-referenced foreign keys only.
+ *  Also, if UpdateOverwriteMode is set to 1, raise error when foreign key fields
+ *  were changed by user triggers.
  *
  *  old_rec - old record before modify
- *  cur_rpb - just read record with possibly changed FK fields
+ *  cur_rpb - just read record with possibly changed fields
  *  new_rpb - new record evaluated by modify statement and before-triggers
  *
  **************************************/
+	const Database* dbb = tdbb->getDatabase();
+	const auto overwriteMode = dbb->dbb_config->getUpdateOverwriteMode();
+
 	jrd_rel* relation = cur_rpb->rpb_relation;
 
 	MET_scan_partners(tdbb, relation);
 
-	if (!(relation->rel_foreign_refs.frgn_relations))
-		return;
-
-	const FB_SIZE_T frgnCount = relation->rel_foreign_refs.frgn_relations->count();
-	if (!frgnCount)
-		return;
+	const FB_SIZE_T frgnCount = relation->rel_foreign_refs.frgn_relations ?
+		relation->rel_foreign_refs.frgn_relations->count() : 0;
 
 	RelationPages* relPages = cur_rpb->rpb_relation->getPages(tdbb);
 
-	// Collect all fields of all foreign keys
+	// Collect all fields of self-referenced foreign keys
 	SortedArray<int, InlineStorage<int, 16> > fields;
 
 	for (FB_SIZE_T i = 0; i < frgnCount; i++)
 	{
-		// We need self-referenced FK's only
 		if ((*relation->rel_foreign_refs.frgn_relations)[i] == relation->rel_id)
 		{
 			index_desc idx;
@@ -6663,26 +6663,63 @@ static void refresh_fk_fields(thread_db* tdbb, Record* old_rec, record_param* cu
 	}
 
 	if (fields.isEmpty())
-		return;
-
-	DSC desc1, desc2;
-	for (FB_SIZE_T idx = 0; idx < fields.getCount(); idx++)
 	{
-		// Detect if user changed FK field by himself.
-		const int fld = fields[idx];
-		const bool flag_old = EVL_field(relation, old_rec, fld, &desc1);
-		const bool flag_new = EVL_field(relation, new_rpb->rpb_record, fld, &desc2);
+		if (overwriteMode == 0)
+			return;
 
-		// If field was not changed by user - pick up possible modification by
-		// system cascade trigger
-		if (flag_old == flag_new &&
-			(!flag_old || (flag_old && !MOV_compare(tdbb, &desc1, &desc2))))
+		if (cur_rpb->rpb_record->getFormat() == old_rec->getFormat())
 		{
-			const bool flag_tmp = EVL_field(relation, cur_rpb->rpb_record, fld, &desc1);
-			if (flag_tmp)
-				MOV_move(tdbb, &desc1, &desc2);
-			else
-				new_rpb->rpb_record->setNull(fld);
+			if (memcmp(cur_rpb->rpb_address, old_rec->getData(), cur_rpb->rpb_length) == 0)
+				return;
+
+			fb_assert(overwriteMode == 1);
+			ERR_post(Arg::Gds(isc_random) << "UPDATE will overwrite changes made by trigger");
+		}
+		// Else compare field-by-field
+	}
+
+	for (FB_SIZE_T fld = 0, frn = 0; fld < relation->rel_current_format->fmt_count; fld++)
+	{
+		dsc dsc_old;
+		const bool flag_old = EVL_field(relation, old_rec, fld, &dsc_old);
+
+		const bool is_fk = (frn < fields.getCount() && fields[frn] == fld);
+		if (!is_fk)
+		{
+			if (overwriteMode == 0)
+				continue;
+
+			dsc dsc_cur;
+			const bool flag_cur = EVL_field(relation, cur_rpb->rpb_record, fld, &dsc_cur);
+
+			// Check if current record differs from old record
+			if ((flag_cur != flag_old) ||
+				(flag_cur && flag_old && MOV_compare(tdbb, &dsc_old, &dsc_cur) != 0))
+			{
+				// Record was modified by trigger.
+				fb_assert(overwriteMode == 1);
+				ERR_post(Arg::Gds(isc_random) << "UPDATE will overwrite changes made by trigger");
+			}
+		}
+		else
+		{
+			dsc dsc_new;
+			const bool flag_new = EVL_field(relation, new_rpb->rpb_record, fld, &dsc_new);
+
+			// If field was not changed by user - pick up possible modification by
+			// system cascade trigger
+			if (flag_old == flag_new &&
+				(!flag_old || (flag_old && !MOV_compare(tdbb, &dsc_old, &dsc_new))))
+			{
+				dsc dsc_cur;
+				const bool flag_cur = EVL_field(relation, cur_rpb->rpb_record, fld, &dsc_cur);
+				if (flag_cur)
+					MOV_move(tdbb, &dsc_cur, &dsc_new);
+				else
+					new_rpb->rpb_record->setNull(fld);
+			}
+
+			frn++;
 		}
 	}
 }

--- a/src/jrd/vio.cpp
+++ b/src/jrd/vio.cpp
@@ -6617,8 +6617,8 @@ static void refresh_changed_fields(thread_db* tdbb, Record* old_rec, record_para
  * Functional description
  *	Update new_rpb with foreign key fields values changed by cascade triggers.
  *  Consider self-referenced foreign keys only.
- *  Also, if UpdateOverwriteMode is set to 1, raise error when non self-referenced
- *  foreign key fields were changed by user triggers.
+ *  Also, if AllowUpdateOverwrite is set to false, raise error when non
+ *  self-referenced foreign key fields were changed by user triggers.
  *
  *  old_rec - old record before modify
  *  cur_rpb - just read record with possibly changed fields
@@ -6626,7 +6626,7 @@ static void refresh_changed_fields(thread_db* tdbb, Record* old_rec, record_para
  *
  **************************************/
 	const Database* dbb = tdbb->getDatabase();
-	const auto overwriteMode = dbb->dbb_config->getUpdateOverwriteMode();
+	const auto allowOverwrite = dbb->dbb_config->getAllowUpdateOverwrite();
 
 	jrd_rel* relation = cur_rpb->rpb_relation;
 
@@ -6664,7 +6664,7 @@ static void refresh_changed_fields(thread_db* tdbb, Record* old_rec, record_para
 
 	if (fields.isEmpty())
 	{
-		if (overwriteMode == 0)
+		if (allowOverwrite)
 			return;
 
 		if (cur_rpb->rpb_record->getFormat()->fmt_version == old_rec->getFormat()->fmt_version)
@@ -6672,8 +6672,7 @@ static void refresh_changed_fields(thread_db* tdbb, Record* old_rec, record_para
 			if (memcmp(cur_rpb->rpb_address, old_rec->getData(), cur_rpb->rpb_length) == 0)
 				return;
 
-			fb_assert(overwriteMode == 1);
-			ERR_post(Arg::Gds(isc_update_overwrite_trigger));		// UPDATE will overwrite changes made by trigger
+			ERR_post(Arg::Gds(isc_update_overwrite));		// UPDATE will overwrite changes made by the trigger or by another UPDATE in the same cursor
 		}
 		// Else compare field-by-field
 	}
@@ -6686,7 +6685,7 @@ static void refresh_changed_fields(thread_db* tdbb, Record* old_rec, record_para
 		const bool is_fk = (frn < fields.getCount() && fields[frn] == fld);
 		if (!is_fk)
 		{
-			if (overwriteMode == 0)
+			if (allowOverwrite)
 				continue;
 
 			dsc dsc_cur;
@@ -6697,8 +6696,7 @@ static void refresh_changed_fields(thread_db* tdbb, Record* old_rec, record_para
 				(flag_cur && flag_old && MOV_compare(tdbb, &dsc_old, &dsc_cur) != 0))
 			{
 				// Record was modified by trigger.
-				fb_assert(overwriteMode == 1);
-				ERR_post(Arg::Gds(isc_update_overwrite_trigger));	// UPDATE will overwrite changes made by trigger
+				ERR_post(Arg::Gds(isc_update_overwrite));		// UPDATE will overwrite changes made by the trigger or by another UPDATE in the same cursor
 			}
 		}
 		else

--- a/src/jrd/vio.cpp
+++ b/src/jrd/vio.cpp
@@ -174,7 +174,7 @@ static void protect_system_table_delupd(thread_db* tdbb, const jrd_rel* relation
 	bool force_flag = false);
 static void purge(thread_db*, record_param*);
 static void replace_record(thread_db*, record_param*, PageStack*, const jrd_tra*);
-static void refresh_fk_fields(thread_db*, Record*, record_param*, record_param*);
+static void refresh_changed_fields(thread_db*, Record*, record_param*, record_param*);
 static SSHORT set_metadata_id(thread_db*, Record*, USHORT, drq_type_t, const char*);
 static void set_nbackup_id(thread_db*, Record*, USHORT, drq_type_t, const char*);
 static void set_owner_name(thread_db*, Record*, USHORT);
@@ -3329,7 +3329,7 @@ bool VIO_modify(thread_db* tdbb, record_param* org_rpb, record_param* new_rpb, j
 		fb_assert(!(org_rpb->rpb_runtime_flags & RPB_undo_read));
 
 		if (undo_read)
-			refresh_fk_fields(tdbb, old_record, org_rpb, new_rpb);
+			refresh_changed_fields(tdbb, old_record, org_rpb, new_rpb);
 	}
 
 	// If we're the system transaction, modify stuff in place.  This saves
@@ -6605,20 +6605,20 @@ static void replace_record(thread_db*		tdbb,
 }
 
 
-static void refresh_fk_fields(thread_db* tdbb, Record* old_rec, record_param* cur_rpb,
+static void refresh_changed_fields(thread_db* tdbb, Record* old_rec, record_param* cur_rpb,
 	record_param* new_rpb)
 {
 /**************************************
  *
- *	r e f r e s h _ f k _ f i e l d s
+ *	r e f r e s h _ c h a n g e d _ f i e l d s
  *
  **************************************
  *
  * Functional description
  *	Update new_rpb with foreign key fields values changed by cascade triggers.
  *  Consider self-referenced foreign keys only.
- *  Also, if UpdateOverwriteMode is set to 1, raise error when foreign key fields
- *  were changed by user triggers.
+ *  Also, if UpdateOverwriteMode is set to 1, raise error when non self-referenced
+ *  foreign key fields were changed by user triggers.
  *
  *  old_rec - old record before modify
  *  cur_rpb - just read record with possibly changed fields
@@ -6667,13 +6667,13 @@ static void refresh_fk_fields(thread_db* tdbb, Record* old_rec, record_param* cu
 		if (overwriteMode == 0)
 			return;
 
-		if (cur_rpb->rpb_record->getFormat() == old_rec->getFormat())
+		if (cur_rpb->rpb_record->getFormat()->fmt_version == old_rec->getFormat()->fmt_version)
 		{
 			if (memcmp(cur_rpb->rpb_address, old_rec->getData(), cur_rpb->rpb_length) == 0)
 				return;
 
 			fb_assert(overwriteMode == 1);
-			ERR_post(Arg::Gds(isc_random) << "UPDATE will overwrite changes made by trigger");
+			ERR_post(Arg::Gds(isc_update_overwrite_trigger));		// UPDATE will overwrite changes made by trigger
 		}
 		// Else compare field-by-field
 	}
@@ -6698,7 +6698,7 @@ static void refresh_fk_fields(thread_db* tdbb, Record* old_rec, record_param* cu
 			{
 				// Record was modified by trigger.
 				fb_assert(overwriteMode == 1);
-				ERR_post(Arg::Gds(isc_random) << "UPDATE will overwrite changes made by trigger");
+				ERR_post(Arg::Gds(isc_update_overwrite_trigger));	// UPDATE will overwrite changes made by trigger
 			}
 		}
 		else


### PR DESCRIPTION
After #8538 there was long private discussion with customer (big sponsor of Firebird). 
The root of the issue is the way Firebird implements per-row triggers - it is far from SQL standard in regards of consistency. 
There is well-known historical reasons for it and I don't want to repeat it here.
By my opinion, the best way to fix the issue would be to re-implement per-row triggers according to SQL standard - to fire before and after whole statement processing. But this is not quick nor easy task.
Finally this patch was implemented and customer uses it to prepare own migration to v5.
Now it is time to decide if it could be accepted into codebase.