### PR TITLE
Refactoring of ModifyIndexNode tree

### DIFF
--- a/src/dsql/DdlNodes.epp
+++ b/src/dsql/DdlNodes.epp
@@ -13527,7 +13527,7 @@ void AlterIndexNode::step2(thread_db* tdbb, Cached::Relation* rel, jrd_tra* tran
 				}
 				END_FOR
 
-				idxId.reset()
+				idxId.reset();
 			}
 		}
 		if (!idxId.has_value())

--- a/src/dsql/DdlNodes.epp
+++ b/src/dsql/DdlNodes.epp
@@ -12159,13 +12159,9 @@ void CreateAlterViewNode::createCheckTrigger(thread_db* tdbb, DsqlCompilerScratc
 
 //----------------------
 
-bool ModifyIndexNode::modify(thread_db* tdbb, Cached::Relation* relation, jrd_tra* transaction)
+void ModifyIndexNode::modify(thread_db* tdbb, Cached::Relation* relation, jrd_tra* transaction)
 {
-/**************************************
- *
- *	m o d i f y _ i n d e x
- *
- **************************************
+ /**************************************
  *
  * Functional description
  *	Create\drop an index or change the state of an index between active/inactive.
@@ -12182,9 +12178,8 @@ bool ModifyIndexNode::modify(thread_db* tdbb, Cached::Relation* relation, jrd_tr
 	if (!relation)
 		fatal_exception::raiseFmt("Relation for creation of index %s not found", indexName.toQuotedString().c_str());
 
-	bool rc = true;
 	if (create)
-		rc = exec(tdbb, relation, transaction);
+		exec(tdbb, relation, transaction);
 
 	if (relation->rel_flags & REL_temp_conn)
 	{
@@ -12196,8 +12191,6 @@ bool ModifyIndexNode::modify(thread_db* tdbb, Cached::Relation* relation, jrd_tr
 
 	if (!create)
 		exec(tdbb, relation, transaction);
-
-	return rc;
 }
 
 string ModifyIndexNode::print(Jrd::NodePrinter& printer) const
@@ -12240,29 +12233,23 @@ Cached::Relation* ModifyIndexNode::getRelByIndex(thread_db* tdbb, const Qualifie
 //----------------------
 
 
-bool ModifyIndexList::exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction)
+void ModifyIndexList::exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction)
 {
 	fb_assert(rel);
 	if (!rel)
-		return false;
+		return;
 
 	AutoSetRestoreFlag dfwFlags(&tdbb->tdbb_flags, TDBB_use_db_page_space, true);
-	bool rc = true;
 
 	for (auto* node : nodes)
 	{
 		if (node)
 		{
-			if (!node->modify(tdbb, rel, transaction))
-			{
-				fb_assert(nodes.getCount() == 1);
-				rc = false;
-			}
+			node->modify(tdbb, rel, transaction);
 		}
 	}
 
 	nodes.clear();
-	return rc;
 }
 
 void ModifyIndexList::erase(thread_db* tdbb, MetaName name)
@@ -12281,13 +12268,11 @@ void ModifyIndexList::erase(thread_db* tdbb, MetaName name)
 //----------------------
 
 
-bool StoreIndexNode::exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction)
+void StoreIndexNode::exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction)
 {
 	auto id = expressionIndex ? createExpression(tdbb, rel, transaction) : create(tdbb, rel, transaction);
 	if (id < tdbb->getDatabase()->dbb_max_idx)
 		rel->newIndexVersion(tdbb, id, CacheFlag::MINISCAN);
-
-	return true;
 }
 
 
@@ -13415,6 +13400,66 @@ void AlterIndexNode::checkPermission(thread_db* tdbb, jrd_tra* transaction)
 	SCL_check_relation(tdbb, relationName, SCL_alter, systemIndex);
 }
 
+bool AlterIndexNode::pass1(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, jrd_tra* transaction)
+{
+	AutoCacheRequest request(tdbb, drq_m_index, DYN_REQUESTS);
+	bool found = false;
+	IndexStatus currentStatus = MET_index_state_unknown;
+	IndexStatus desiredStatus = create ? MET_index_active : MET_index_inactive;
+
+	FOR(REQUEST_HANDLE request TRANSACTION_HANDLE transaction)
+		IDX IN RDB$INDICES
+		WITH IDX.RDB$SCHEMA_NAME EQ indexName.schema.c_str() AND
+		IDX.RDB$INDEX_NAME EQ indexName.object.c_str()
+	{
+		found = true;
+		currentStatus = MetadataCache::getIndexStatus(IDX.RDB$INDEX_INACTIVE.NULL, IDX.RDB$INDEX_INACTIVE);
+
+		if (currentStatus != desiredStatus)
+		{
+			executeDdlTrigger(tdbb, dsqlScratch, transaction, DTW_BEFORE, DDL_TRIGGER_ALTER_INDEX, indexName, {});
+
+			auto relName = QualifiedName(IDX.RDB$RELATION_NAME, IDX.RDB$SCHEMA_NAME);
+			indexRelation = MetadataCache::getPerm<Cached::Relation>(tdbb, relName, CacheFlag::AUTOCREATE);
+			fb_assert(indexRelation);
+
+			expressionIndex = !IDX.RDB$EXPRESSION_BLR.NULL;
+			if (!IDX.RDB$INDEX_ID.NULL)
+			{
+				fb_assert(IDX.RDB$INDEX_ID);
+				idxId = IDX.RDB$INDEX_ID - 1;
+			}
+			if (indexRelation && idxId.has_value())
+			{
+				[[maybe_unused]] auto ret = indexRelation->oldIndexVersion(tdbb, idxId.value(), CacheFlag::OLD_ALTER);
+				fb_assert(ret);
+			}
+
+			MODIFY IDX
+				IDX.RDB$INDEX_INACTIVE.NULL = FALSE;
+				IDX.RDB$INDEX_INACTIVE = desiredStatus;
+				if (create)
+				{
+					IDX.RDB$STATISTICS.NULL = FALSE;
+					IDX.RDB$STATISTICS = -1.0;
+				}
+			END_MODIFY
+		}
+	}
+	END_FOR
+
+	if (!found)
+	{
+		// msg 48: "Index not found"
+		status_exception::raise(Arg::PrivateDyn(48) << Arg::Gds(isc_index_name) << indexName.toQuotedString());
+	}
+
+	if (currentStatus == desiredStatus) // Index is already in desired state, nothing to do
+		return false;
+
+	return currentStatus != MET_index_deferred_active;
+}
+
 void AlterIndexNode::execute(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, jrd_tra* transaction)
 {
 	AutoSetRestoreFlag dfwFlags(&tdbb->tdbb_flags, TDBB_use_db_page_space, true);
@@ -13436,105 +13481,18 @@ void AlterIndexNode::execute(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, 
 	if (tdbb->getDatabase()->readOnly())
 		ERRD_post(Arg::Gds(isc_read_only_database));
 
-	Cached::Relation* relation = nullptr;
-	bool expressionIndex = false;
-
-	AutoCacheRequest request(tdbb, drq_m_index, DYN_REQUESTS);
-	bool found = false;
-	bool active = create;
-	bool deferred = false;
-
-	FOR(REQUEST_HANDLE request TRANSACTION_HANDLE transaction)
-		IDX IN RDB$INDICES
-		WITH IDX.RDB$SCHEMA_NAME EQ indexName.schema.c_str() AND
-			 IDX.RDB$INDEX_NAME EQ indexName.object.c_str()
+	if (pass1(tdbb, dsqlScratch, transaction))
 	{
-		found = true;
-
-		if (IDX.RDB$INDEX_INACTIVE.NULL)
-			active = true;
-		else
-		{
-			active = IDX.RDB$INDEX_INACTIVE == MET_index_active;
-			deferred = IDX.RDB$INDEX_INACTIVE == MET_index_deferred_active;
-		}
-
-		if (active != create)
-		{
-			executeDdlTrigger(tdbb, dsqlScratch, transaction, DTW_BEFORE, DDL_TRIGGER_ALTER_INDEX, indexName, {});
-
-			auto relName = QualifiedName(IDX.RDB$RELATION_NAME, IDX.RDB$SCHEMA_NAME);
-			relation = MetadataCache::getPerm<Cached::Relation>(tdbb, relName, CacheFlag::AUTOCREATE);
-			fb_assert(relation);
-
-			expressionIndex = !IDX.RDB$EXPRESSION_BLR.NULL;
-			if (!IDX.RDB$INDEX_ID.NULL)
-			{
-				fb_assert(IDX.RDB$INDEX_ID);
-				idxId = IDX.RDB$INDEX_ID - 1;
-			}
-			if (relation && idxId.has_value())
-			{
-				auto ret = relation->oldIndexVersion(tdbb, idxId.value(), CacheFlag::OLD_ALTER);
-				fb_assert(ret);
-			}
-
-			MODIFY IDX
-				IDX.RDB$INDEX_INACTIVE.NULL = FALSE;
-				IDX.RDB$INDEX_INACTIVE = create ? MET_index_active : MET_index_inactive;
-				if (create)
-				{
-					IDX.RDB$STATISTICS.NULL = FALSE;
-					IDX.RDB$STATISTICS = -1.0;
-				}
-			END_MODIFY
-		}
-	}
-	END_FOR
-
-	if (!found)
-	{
-		// msg 48: "Index not found"
-		status_exception::raise(Arg::PrivateDyn(48));
-	}
-
-	if (active == create)
-		return;
-
-	if (!deferred)
-	{
-		MemoryPool& pool = *MemoryPool::getContextPool();
-		ModifyIndexList oneItemList(pool);
 		if (idxId.has_value())
 		{
-			oneItemList.push(this);
-			if (!oneItemList.exec(tdbb, relation, transaction))
-			{
-				fb_assert(create);
-
-				idxId.reset();
-
-				AUTO_HANDLE(rq1);
-				FOR(REQUEST_HANDLE rq1 TRANSACTION_HANDLE transaction)
-					IDX IN RDB$INDICES
-					WITH IDX.RDB$SCHEMA_NAME EQ indexName.schema.c_str() AND
-						 IDX.RDB$INDEX_NAME EQ indexName.object.c_str()
-				{
-					MODIFY IDX
-						IDX.RDB$INDEX_INACTIVE.NULL = FALSE;
-						IDX.RDB$INDEX_INACTIVE = MET_index_active;
-						IDX.RDB$STATISTICS.NULL = FALSE;
-						IDX.RDB$STATISTICS = 0.0;
-						IDX.RDB$INDEX_ID.NULL = TRUE;
-					END_MODIFY
-				}
-				END_FOR
-			}
+			// Index existed before
+			modify(tdbb, indexRelation, transaction);
 		}
-		if (!idxId.has_value())
+		else
 		{
-			oneItemList.push(FB_NEW_POOL(pool) StoreIndexNode(indexName, expressionIndex));
-			oneItemList.exec(tdbb, relation, transaction);
+			// Index is a brand new
+			StoreIndexNode storeNode(indexName, expressionIndex);
+			storeNode.modify(tdbb, indexRelation, transaction);
 		}
 	}
 
@@ -13543,18 +13501,39 @@ void AlterIndexNode::execute(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, 
 	savePoint.release();	// system table modified OK
 }
 
-bool AlterIndexNode::exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction)
+void AlterIndexNode::exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction)
 {
 	if (create)
 	{
 		if (! IDX_activate_index(tdbb, rel, idxId.value()))
-			return false;
+		{
+			// No index to restore, create a new one from scratch
+			AUTO_HANDLE(rq1);
+			FOR(REQUEST_HANDLE rq1 TRANSACTION_HANDLE transaction)
+				IDX IN RDB$INDICES
+				WITH IDX.RDB$SCHEMA_NAME EQ indexName.schema.c_str() AND
+					 IDX.RDB$INDEX_NAME EQ indexName.object.c_str()
+			{
+				MODIFY IDX
+					IDX.RDB$INDEX_INACTIVE.NULL = FALSE;
+					IDX.RDB$INDEX_INACTIVE = MET_index_active;
+					IDX.RDB$STATISTICS.NULL = FALSE;
+					IDX.RDB$STATISTICS = 0.0;
+					IDX.RDB$INDEX_ID.NULL = TRUE;
+				END_MODIFY
+			}
+			END_FOR
+
+			StoreIndexNode storeNode(indexName, expressionIndex);
+			storeNode.modify(tdbb, rel, transaction);
+
+			return;
+		}
 	}
 	else
 		IDX_mark_index(tdbb, rel, idxId.value());
 
 	rel->newIndexVersion(tdbb, idxId.value(), CacheFlag::MINISCAN);
-	return true;
 }
 
 // Alter an index on a Local Temporary Table (ACTIVE/INACTIVE).
@@ -13687,7 +13666,7 @@ void SetStatisticsNode::setStatisticsLocalTempIndex(thread_db* tdbb, DsqlCompile
 
 
 DropIndexNode::DropIndexNode(MemoryPool& p, const QualifiedName& name)
-	: ModifyIndexNode(name, false),
+	: ModifyIndexNode(name, false, false),
 	  DdlNode(p)
 { }
 
@@ -13868,7 +13847,7 @@ Cached::Relation* DropIndexNode::drop(thread_db* tdbb, DsqlCompilerScratch* dsql
 }
 
 
-bool DropIndexNode::exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction)
+void DropIndexNode::exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction)
 {
 /**************************************
  *
@@ -13885,7 +13864,7 @@ bool DropIndexNode::exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transa
 	// Look up the relation.  If we can't find the relation,
 	// don't worry about the index.
 	if (!rel)
-		return idxId;
+		return;
 
 	fb_assert(idxId >= 0 && idxId < dbb->dbb_max_idx);
 
@@ -13895,8 +13874,6 @@ bool DropIndexNode::exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transa
 		IDX_mark_index(tdbb, rel, idxId);
 		rel->eraseIndex(tdbb, idxId);
 	}
-
-	return true;
 }
 
 

--- a/src/dsql/DdlNodes.epp
+++ b/src/dsql/DdlNodes.epp
@@ -13506,35 +13506,35 @@ void AlterIndexNode::step2(thread_db* tdbb, Cached::Relation* rel, jrd_tra* tran
 {
 	if (create)
 	{
+		if (idxId.has_value())
+		{
+			if (! IDX_activate_index(tdbb, rel, idxId.value()))
+			{
+				// No index to restore, create a new one from scratch
+				AUTO_HANDLE(rq1);
+				FOR(REQUEST_HANDLE rq1 TRANSACTION_HANDLE transaction)
+					IDX IN RDB$INDICES
+					WITH IDX.RDB$SCHEMA_NAME EQ indexName.schema.c_str() AND
+						 IDX.RDB$INDEX_NAME EQ indexName.object.c_str()
+				{
+					MODIFY IDX
+						IDX.RDB$INDEX_INACTIVE.NULL = FALSE;
+						IDX.RDB$INDEX_INACTIVE = MET_index_active;
+						IDX.RDB$STATISTICS.NULL = FALSE;
+						IDX.RDB$STATISTICS = 0.0;
+						IDX.RDB$INDEX_ID.NULL = TRUE;
+					END_MODIFY
+				}
+				END_FOR
+
+				idxId.reset()
+			}
+		}
 		if (!idxId.has_value())
 		{
-			// Index was just created, finalize it
+			// One way or another the index was just created, finalize it
 			StoreIndexNode storeNode(indexName, expressionIndex);
-			storeNode.modify(tdbb, rel, transaction);
-			return;
-		}
-
-		if (! IDX_activate_index(tdbb, rel, idxId.value()))
-		{
-			// No index to restore, create a new one from scratch
-			AUTO_HANDLE(rq1);
-			FOR(REQUEST_HANDLE rq1 TRANSACTION_HANDLE transaction)
-				IDX IN RDB$INDICES
-				WITH IDX.RDB$SCHEMA_NAME EQ indexName.schema.c_str() AND
-					 IDX.RDB$INDEX_NAME EQ indexName.object.c_str()
-			{
-				MODIFY IDX
-					IDX.RDB$INDEX_INACTIVE.NULL = FALSE;
-					IDX.RDB$INDEX_INACTIVE = MET_index_active;
-					IDX.RDB$STATISTICS.NULL = FALSE;
-					IDX.RDB$STATISTICS = 0.0;
-					IDX.RDB$INDEX_ID.NULL = TRUE;
-				END_MODIFY
-			}
-			END_FOR
-
-			StoreIndexNode storeNode(indexName, expressionIndex);
-			storeNode.modify(tdbb, rel, transaction);
+			storeNode.step2(tdbb, rel, transaction);
 			return;
 		}
 	}

--- a/src/dsql/DdlNodes.epp
+++ b/src/dsql/DdlNodes.epp
@@ -12169,6 +12169,7 @@ void ModifyIndexNode::modify(thread_db* tdbb, Cached::Relation* relation, jrd_tr
  *	change index instance for this temporary table too. For "create index" work
  *	item create base index instance before temp index instance. For index
  *	deletion delete temp index instance first.
+ *
  **************************************/
 
 	SET_TDBB(tdbb);
@@ -12179,18 +12180,18 @@ void ModifyIndexNode::modify(thread_db* tdbb, Cached::Relation* relation, jrd_tr
 		fatal_exception::raiseFmt("Relation for creation of index %s not found", indexName.toQuotedString().c_str());
 
 	if (create)
-		exec(tdbb, relation, transaction);
+		step2(tdbb, relation, transaction);
 
 	if (relation->rel_flags & REL_temp_conn)
 	{
 		AutoSetRestoreFlag preserveFlags(&tdbb->tdbb_flags, TDBB_use_db_page_space, false);
 
 		if (relation->getPages(tdbb, MAX_TRA_NUMBER, false))
-			exec(tdbb, relation, transaction);
+			step2(tdbb, relation, transaction);
 	}
 
 	if (!create)
-		exec(tdbb, relation, transaction);
+		step2(tdbb, relation, transaction);
 }
 
 string ModifyIndexNode::print(Jrd::NodePrinter& printer) const
@@ -12268,7 +12269,7 @@ void ModifyIndexList::erase(thread_db* tdbb, MetaName name)
 //----------------------
 
 
-void StoreIndexNode::exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction)
+void StoreIndexNode::step2(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction)
 {
 	auto id = expressionIndex ? createExpression(tdbb, rel, transaction) : create(tdbb, rel, transaction);
 	if (id < tdbb->getDatabase()->dbb_max_idx)
@@ -13400,7 +13401,7 @@ void AlterIndexNode::checkPermission(thread_db* tdbb, jrd_tra* transaction)
 	SCL_check_relation(tdbb, relationName, SCL_alter, systemIndex);
 }
 
-bool AlterIndexNode::pass1(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, jrd_tra* transaction)
+bool AlterIndexNode::step1(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, jrd_tra* transaction)
 {
 	AutoCacheRequest request(tdbb, drq_m_index, DYN_REQUESTS);
 	bool found = false;
@@ -13481,7 +13482,7 @@ void AlterIndexNode::execute(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, 
 	if (tdbb->getDatabase()->readOnly())
 		ERRD_post(Arg::Gds(isc_read_only_database));
 
-	if (pass1(tdbb, dsqlScratch, transaction))
+	if (step1(tdbb, dsqlScratch, transaction))
 	{
 		if (idxId.has_value())
 		{
@@ -13501,7 +13502,7 @@ void AlterIndexNode::execute(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, 
 	savePoint.release();	// system table modified OK
 }
 
-void AlterIndexNode::exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction)
+void AlterIndexNode::step2(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction)
 {
 	if (create)
 	{
@@ -13847,7 +13848,7 @@ Cached::Relation* DropIndexNode::drop(thread_db* tdbb, DsqlCompilerScratch* dsql
 }
 
 
-void DropIndexNode::exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction)
+void DropIndexNode::step2(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction)
 {
 /**************************************
  *

--- a/src/dsql/DdlNodes.epp
+++ b/src/dsql/DdlNodes.epp
@@ -13506,6 +13506,14 @@ void AlterIndexNode::step2(thread_db* tdbb, Cached::Relation* rel, jrd_tra* tran
 {
 	if (create)
 	{
+		if (!idxId.has_value())
+		{
+			// Index was just created, finalize it
+			StoreIndexNode storeNode(indexName, expressionIndex);
+			storeNode.modify(tdbb, rel, transaction);
+			return;
+		}
+
 		if (! IDX_activate_index(tdbb, rel, idxId.value()))
 		{
 			// No index to restore, create a new one from scratch
@@ -13527,7 +13535,6 @@ void AlterIndexNode::step2(thread_db* tdbb, Cached::Relation* rel, jrd_tra* tran
 
 			StoreIndexNode storeNode(indexName, expressionIndex);
 			storeNode.modify(tdbb, rel, transaction);
-
 			return;
 		}
 	}

--- a/src/dsql/DdlNodes.h
+++ b/src/dsql/DdlNodes.h
@@ -1302,7 +1302,7 @@ class TrigArray;
 class ModifyIndexNode;
 
 
-// Collects indices to be created after table was actuallly created
+// Collects indices for performing second step of index creation after table was actually created
 
 class ModifyIndexList
 {
@@ -1935,7 +1935,7 @@ public:
 };
 
 
-// Performs 2-pass index create/drop
+// Performs 2-step index create/drop/alter
 
 class ModifyIndexNode
 {
@@ -1951,14 +1951,16 @@ public:
 	{
 	}
 
-	void modify(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction);
-
 	bool check(thread_db*, MetaName iName)
 	{
 		return create && (indexName.object == iName);
 	}
 
-	virtual void exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) = 0;
+	// Performs second step by calling step2() (twice for temporary tables)
+	void modify(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction);
+
+private: // to make sure nobody but modify() can call it
+	virtual void step2(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) = 0;
 
 protected:
 	Firebird::string print(NodePrinter& printer) const;
@@ -2052,12 +2054,10 @@ public:
 		: ModifyIndexNode(indexName, true, expression)
 	{ }
 
-public:
-	void exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) override;
-
 private:
 	MetaId create(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction);
 	MetaId createExpression(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction);
+	void step2(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) override;
 };
 
 
@@ -2074,8 +2074,8 @@ public:
 	Firebird::string internalPrint(NodePrinter& printer) const override;
 	void checkPermission(thread_db* tdbb, jrd_tra* transaction) override;
 	void execute(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, jrd_tra* transaction) override;
-	// First pass of index alteration. Returns true if second pass is needed
-	bool pass1(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, jrd_tra* transaction);
+	// First step of index alteration. Returns true if second step is needed
+	bool step1(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, jrd_tra* transaction);
 
 	DdlNode* dsqlPass(DsqlCompilerScratch* dsqlScratch) override
 	{
@@ -2093,8 +2093,8 @@ public:
 private:
 	void alterLocalTempIndex(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch,
 		jrd_tra* transaction, LocalTemporaryTable* ltt, LocalTemporaryTable::Index* lttIndex);
-	// Second pass of index alteration
-	void exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) override;
+	// Second step of index alteration
+	void step2(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) override;
 
 protected:
 	void putErrorPrefix(Firebird::Arg::StatusVector& statusVector) override
@@ -2176,7 +2176,7 @@ public:
 private:
 	void dropLocalTempIndex(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch,
 		jrd_tra* transaction, LocalTemporaryTable* ltt, LocalTemporaryTable::Index* lttIndex);
-	void exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) override;
+	void step2(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) override;
 
 protected:
 	void putErrorPrefix(Firebird::Arg::StatusVector& statusVector) override

--- a/src/dsql/DdlNodes.h
+++ b/src/dsql/DdlNodes.h
@@ -1959,12 +1959,10 @@ public:
 	// Performs second step by calling step2() (twice for temporary tables)
 	void modify(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction);
 
-private: // to make sure nobody but modify() can call it
-	virtual void step2(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) = 0;
-
 protected:
 	Firebird::string print(NodePrinter& printer) const;
 	static Cached::Relation* getRelByIndex(thread_db* tdbb, const QualifiedName& index, jrd_tra* transaction);
+	virtual void step2(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) = 0;
 
 	QualifiedName indexName;
 	Cached::Relation* indexRelation = nullptr;
@@ -2054,10 +2052,11 @@ public:
 		: ModifyIndexNode(indexName, true, expression)
 	{ }
 
+	void step2(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) override;
+
 private:
 	MetaId create(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction);
 	MetaId createExpression(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction);
-	void step2(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) override;
 };
 
 

--- a/src/dsql/DdlNodes.h
+++ b/src/dsql/DdlNodes.h
@@ -1317,7 +1317,7 @@ public:
 		nodes.push(node);
 	}
 
-	bool exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction);
+	void exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction);
 	void erase(thread_db* tdbb, MetaName indexName);
 
 	MemoryPool& getPool()
@@ -1940,9 +1940,10 @@ public:
 class ModifyIndexNode
 {
 public:
-	ModifyIndexNode(const QualifiedName& indexName, bool create)
+	ModifyIndexNode(const QualifiedName& indexName, bool create, bool expression)
 		: indexName(indexName),
-		  create(create)
+		  create(create),
+		  expressionIndex(expression)
 	{
 	}
 
@@ -1950,22 +1951,23 @@ public:
 	{
 	}
 
-	bool modify(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction);
+	void modify(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction);
 
 	bool check(thread_db*, MetaName iName)
 	{
 		return create && (indexName.object == iName);
 	}
 
-	virtual bool exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) = 0;
+	virtual void exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) = 0;
 
 protected:
 	Firebird::string print(NodePrinter& printer) const;
 	static Cached::Relation* getRelByIndex(thread_db* tdbb, const QualifiedName& index, jrd_tra* transaction);
 
-public:
 	QualifiedName indexName;
+	Cached::Relation* indexRelation = nullptr;
 	bool create;
+	bool expressionIndex;
 };
 
 
@@ -2046,20 +2048,16 @@ public:
 class StoreIndexNode final : public ModifyIndexNode
 {
 public:
-	StoreIndexNode(const QualifiedName& indexName, bool expressionIndex)
-		: ModifyIndexNode(indexName, true),
-		  expressionIndex(expressionIndex)
+	StoreIndexNode(const QualifiedName& indexName, bool expression)
+		: ModifyIndexNode(indexName, true, expression)
 	{ }
 
 public:
-	bool exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) override;
+	void exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) override;
 
 private:
 	MetaId create(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction);
 	MetaId createExpression(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction);
-
-private:
-	bool expressionIndex = false;
 };
 
 
@@ -2067,7 +2065,7 @@ class AlterIndexNode final : public ModifyIndexNode, public DdlNode
 {
 public:
 	AlterIndexNode(MemoryPool& p, const QualifiedName& name, bool active)
-		: ModifyIndexNode(name, active),
+		: ModifyIndexNode(name, active, false),
 		  DdlNode(p)
 	{
 	}
@@ -2076,6 +2074,8 @@ public:
 	Firebird::string internalPrint(NodePrinter& printer) const override;
 	void checkPermission(thread_db* tdbb, jrd_tra* transaction) override;
 	void execute(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, jrd_tra* transaction) override;
+	// First pass of index alteration. Returns true if second pass is needed
+	bool pass1(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch, jrd_tra* transaction);
 
 	DdlNode* dsqlPass(DsqlCompilerScratch* dsqlScratch) override
 	{
@@ -2093,7 +2093,8 @@ public:
 private:
 	void alterLocalTempIndex(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch,
 		jrd_tra* transaction, LocalTemporaryTable* ltt, LocalTemporaryTable::Index* lttIndex);
-	bool exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) override;
+	// Second pass of index alteration
+	void exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) override;
 
 protected:
 	void putErrorPrefix(Firebird::Arg::StatusVector& statusVector) override
@@ -2101,7 +2102,6 @@ protected:
 		statusVector << Firebird::Arg::Gds(isc_dsql_alter_index_failed) << indexName.toQuotedString();
 	}
 
-public:
 	std::optional<MetaId> idxId;
 };
 
@@ -2176,7 +2176,7 @@ public:
 private:
 	void dropLocalTempIndex(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch,
 		jrd_tra* transaction, LocalTemporaryTable* ltt, LocalTemporaryTable::Index* lttIndex);
-	bool exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) override;
+	void exec(thread_db* tdbb, Cached::Relation* rel, jrd_tra* transaction) override;
 
 protected:
 	void putErrorPrefix(Firebird::Arg::StatusVector& statusVector) override


### PR DESCRIPTION
1. Code simplification
2. Allow usage of `AlterIndexNode` not only in `ALTER INDEX` query
3. Preparation for further @AlexPeshkoff work

Example of usage of refactored node from other pieces of code:
```
AutoPtr<AlterIndexNode> node(FB_NEW_POOL(indexList.getPool()) AlterIndexNode(indexList.getPool(), indexName, active));
if (node->step1(tdbb, dsqlScratch, transaction))
	indexList.push(node.release());
```
