### PR TITLE
Port initialization fixes to prevent uninitialized memory access

### DIFF
--- a/src/common/cvt.cpp
+++ b/src/common/cvt.cpp
@@ -1406,7 +1406,7 @@ double CVT_get_double(const dsc* desc, DecimalStatus decSt, ErrorFunction err, b
  *      Convert something arbitrary to a double precision number
  *
  **************************************/
-	double value;
+	double value = 0.0;
 
 	switch (desc->dsc_dtype)
 	{

--- a/src/common/unicode_util.cpp
+++ b/src/common/unicode_util.cpp
@@ -1853,7 +1853,7 @@ USHORT UnicodeUtil::Utf16Collation::stringToKey(USHORT srcLen, const USHORT* src
 				if (keys)
 				{
 					UCHAR lastCharKey[BUFFER_TINY];	// sort key for a single character
-					ULONG prefixLen, lastCharKeyLen;
+					ULONG prefixLen = 0, lastCharKeyLen = 0;
 
 					srcLenLong -= i;
 
@@ -1877,8 +1877,6 @@ USHORT UnicodeUtil::Utf16Collation::stringToKey(USHORT srcLen, const USHORT* src
 						fb_assert(lastCharKey[lastCharKeyLen - 1] == '\0');
 						--lastCharKeyLen;
 					}
-					else
-						prefixLen = 0;
 
 					bool fallbackToPrefixKey = false;
 

--- a/src/gpre/pat.cpp
+++ b/src/gpre/pat.cpp
@@ -179,9 +179,9 @@ void PATTERN_expand( USHORT column, const TEXT* pattern, PAT* args)
 	bool sw_gen = true;
 	p += align(p, column);
 
-	SSHORT value;				// value needs to be signed since some of the
-								// values printed out are signed.
-	SLONG long_value;
+	SSHORT value = 0;				// value needs to be signed since some of the
+	SLONG long_value = 0;			// values printed out are signed.
+
 	TEXT c;
 	while ((c = *pattern++))
 	{

--- a/src/jrd/btr.cpp
+++ b/src/jrd/btr.cpp
@@ -2315,15 +2315,13 @@ void BTR_reserve_slot(thread_db* tdbb, IndexCreation& creation)
 	}
 
 	UCHAR* desc = 0;
-	USHORT len, space;
+	const USHORT len = idx->idx_count * sizeof(irtd);
+	USHORT space = dbb->dbb_page_size;
 	index_root_page::irt_repeat* slot = NULL;
 	index_root_page::irt_repeat* end = NULL;
 
 	for (int retry = 0; retry < 2; ++retry)
 	{
-		len = idx->idx_count * sizeof(irtd);
-
-		space = dbb->dbb_page_size;
 		slot = NULL;
 
 		end = root->irt_rpt + root->irt_count;
@@ -2358,6 +2356,8 @@ void BTR_reserve_slot(thread_db* tdbb, IndexCreation& creation)
 		}
 		else
 			break;
+
+		space = dbb->dbb_page_size;
 	}
 
 	// If we didn't pick up an empty slot, allocate a new one
@@ -2816,8 +2816,8 @@ static void compress(thread_db* tdbb,
 	const Database* dbb = tdbb->getDatabase();
 	bool first_key = true;
 	VaryStr<MAX_KEY * 4> buffer;
-	size_t multiKeyLength;
-	UCHAR* ptr;
+	size_t multiKeyLength = 0;
+	UCHAR* ptr = nullptr;
 	UCHAR* p = key->key_data;
 	SSHORT scale = matchScale ? matchScale : desc->dsc_scale;
 
@@ -2829,7 +2829,7 @@ static void compress(thread_db* tdbb,
 
 		do
 		{
-			size_t length;
+			size_t length = 0;
 
 			has_next = false;
 

--- a/src/jrd/exe.cpp
+++ b/src/jrd/exe.cpp
@@ -555,7 +555,7 @@ void EXE_assignment(thread_db* tdbb, const ValueExprNode* to, dsc* from_desc, bo
 
 		if (null && to_desc->dsc_dtype <= dtype_varying)
 		{
-			USHORT minlen;
+			USHORT minlen = 0;
 
 			switch (to_desc->dsc_dtype)
 			{

--- a/src/jrd/filters.cpp
+++ b/src/jrd/filters.cpp
@@ -1044,22 +1044,14 @@ ISC_STATUS filter_transliterate_text(USHORT action, BlobControl* control)
 
 	// Do we already have enough bytes in temp buffer to fill output buffer?
 
-	bool can_use_more;
+	bool can_use_more = true;
 	USHORT length = aux->ctlaux_buffer1_unused;
-	if (length)
+	// Always keep a minimal count of bytes in the input buffer
+	// to prevent the case of truncated characters.
+	if (length >= 4 && control->ctl_buffer_length < (length * aux->ctlaux_expansion_factor / EXP_SCALE))
 	{
-		if (control->ctl_buffer_length < (length * aux->ctlaux_expansion_factor / EXP_SCALE))
-		{
-			// No need to fetch more bytes, we have enough pending
-			can_use_more = false;
-		}
-		else
-			can_use_more = true;
-
-		// Always keep a minimal count of bytes in the input buffer,
-		// to prevent the case of truncated characters.
-		if (length < 4)
-			can_use_more = true;
+		// No need to fetch more bytes, we have enough pending
+		can_use_more = false;
 	}
 
 	/* Load data into the temporary buffer if,
@@ -1071,8 +1063,7 @@ ISC_STATUS filter_transliterate_text(USHORT action, BlobControl* control)
 
 	USHORT bytes_read_from_source = 0;
 
-	///if (!length || (can_use_more && (aux->ctlaux_source_blob_status == isc_segment)))
-	if (!length || can_use_more)
+	if (can_use_more)
 	{
 		// Get a segment, or partial segment, from the source
 		// into the temporary buffer

--- a/src/jrd/recsrc/FilteredStream.cpp
+++ b/src/jrd/recsrc/FilteredStream.cpp
@@ -187,7 +187,7 @@ bool FilteredStream::evaluateBoolean(thread_db* tdbb) const
 	// on the right.
 
 	// ANY/ALL select node pointer
-	const BoolExprNode* select_node;
+	const BoolExprNode* select_node = nullptr;
 
 	// ANY/ALL column node pointer
 	const BoolExprNode* column_node = m_anyBoolean;
@@ -203,8 +203,6 @@ bool FilteredStream::evaluateBoolean(thread_db* tdbb) const
 			select_node = booleanNode->arg1;
 			column_node = booleanNode->arg2;
 		}
-		else
-			select_node = NULL;
 	}
 
 	if (column_node && m_ansiAny)

--- a/src/utilities/guard/guard.cpp
+++ b/src/utilities/guard/guard.cpp
@@ -183,7 +183,6 @@ int CLIB_ROUTINE main( int argc, char **argv)
 	time_t timer = 0;
 
 	do {
-		int ret_code;
 
 		if (shutting_down)
 		{
@@ -226,6 +225,7 @@ int CLIB_ROUTINE main( int argc, char **argv)
 		}
 
 		// wait for child to die, and evaluate exit status
+		int ret_code = NORMAL_EXIT;
 		bool shutdown_child = true;
 		if (!shutting_down)
 		{

--- a/src/yvalve/gds.cpp
+++ b/src/yvalve/gds.cpp
@@ -3173,7 +3173,7 @@ static int blr_print_dtype(gds_ctl* control)
  *	data described.
  *
  **************************************/
-	SSHORT length;
+	SSHORT length = 0;
 
 	const USHORT dtype = control->ctl_blr_reader.getByte();
 
@@ -3537,7 +3537,7 @@ static void blr_print_verb(gds_ctl* control, SSHORT level)
 	blr_print_blr(control, blr_operator);
 	level++;
 	const UCHAR* ops = blr_print_table[blr_operator].blr_operators;
-	SSHORT n;
+	SSHORT n = 0;
 
 	while (*ops)
 	{


### PR DESCRIPTION
This PR adds default initialization (= 0, = nullptr) to local variables in several core modules (Common, JRD, GPRE, Utilities). This fixes potential garbage value issues and uninitialized memory access warnings.


This PR is part of the closed parent PR https://github.com/FirebirdSQL/firebird/pull/8938, which was split into smaller, focused pull requests.