### PR TITLE
Prohibit inheritance of interface with versioned methods

### DIFF
--- a/extern/cloop/src/cloop/Parser.cpp
+++ b/extern/cloop/src/cloop/Parser.cpp
@@ -116,6 +116,12 @@ void Parser::parse()
 	}
 }
 
+static bool hasVersionedMethods(const Interface& interface)
+{
+	auto& methods = interface.methods;
+	return methods.size() >= 2 && methods.front()->version != methods.back()->version;
+}
+
 void Parser::parseInterface(bool exception)
 {
 	auto newInterface = std::make_shared<Interface>();
@@ -140,6 +146,9 @@ void Parser::parseInterface(bool exception)
 			error(token, string("Super interface '") + superName + "' not found.");
 
 		interface->super = static_cast<Interface*>(superIt->second.get());
+		if (hasVersionedMethods(*interface->super))
+			error(token, string("Inheriting from the interface '" + superName + "' is not possible because it contains versioned methods."));
+
 		interface->version = interface->super->version + 1;
 	}
 	else

--- a/extern/cloop/src/cloop/Parser.cpp
+++ b/extern/cloop/src/cloop/Parser.cpp
@@ -118,7 +118,7 @@ void Parser::parse()
 
 static bool hasVersionedMethods(const Interface& interface)
 {
-	auto& methods = interface.methods;
+	const auto& methods = interface.methods;
 	return methods.size() >= 2 && methods.front()->version != methods.back()->version;
 }
 

--- a/src/include/firebird/FirebirdInterface.idl
+++ b/src/include/firebird/FirebirdInterface.idl
@@ -1391,6 +1391,7 @@ interface TraceSQLStatement : TraceStatement
 	TraceParams getInputs();
 	const string getTextUTF8();
 	const string getExplainedPlan();
+
 version: // 5.0 -> 6.0
 	PerformanceStats getPerfStats();
 }
@@ -1400,6 +1401,7 @@ interface TraceBLRStatement : TraceStatement
 	const uchar* getData();
 	uint getDataLength();
 	const string getText();
+
 version: // 5.0 -> 6.0
 	PerformanceStats getPerfStats();
 }

--- a/src/include/firebird/FirebirdInterface.idl
+++ b/src/include/firebird/FirebirdInterface.idl
@@ -1382,9 +1382,6 @@ interface TraceStatement : Versioned
 {
 	int64 getStmtID();
 	PerformanceInfo* getPerf();
-
-version: // 5.0 -> 6.0
-	PerformanceStats getPerfStats();
 }
 
 interface TraceSQLStatement : TraceStatement
@@ -1394,6 +1391,8 @@ interface TraceSQLStatement : TraceStatement
 	TraceParams getInputs();
 	const string getTextUTF8();
 	const string getExplainedPlan();
+version: // 5.0 -> 6.0
+	PerformanceStats getPerfStats();
 }
 
 interface TraceBLRStatement : TraceStatement
@@ -1401,6 +1400,8 @@ interface TraceBLRStatement : TraceStatement
 	const uchar* getData();
 	uint getDataLength();
 	const string getText();
+version: // 5.0 -> 6.0
+	PerformanceStats getPerfStats();
 }
 
 interface TraceDYNRequest : Versioned

--- a/src/include/firebird/IdlFbInterfaces.h
+++ b/src/include/firebird/IdlFbInterfaces.h
@@ -5609,7 +5609,7 @@ namespace Firebird
 		}
 	};
 
-#define FIREBIRD_ITRACE_STATEMENT_VERSION 3u
+#define FIREBIRD_ITRACE_STATEMENT_VERSION 2u
 
 	class ITraceStatement : public IVersioned
 	{
@@ -5618,7 +5618,6 @@ namespace Firebird
 		{
 			ISC_INT64 (CLOOP_CARG *getStmtID)(ITraceStatement* self) CLOOP_NOEXCEPT;
 			PerformanceInfo* (CLOOP_CARG *getPerf)(ITraceStatement* self) CLOOP_NOEXCEPT;
-			IPerformanceStats* (CLOOP_CARG *getPerfStats)(ITraceStatement* self) CLOOP_NOEXCEPT;
 		};
 
 	protected:
@@ -5645,16 +5644,6 @@ namespace Firebird
 			PerformanceInfo* ret = static_cast<VTable*>(this->cloopVTable)->getPerf(this);
 			return ret;
 		}
-
-		IPerformanceStats* getPerfStats()
-		{
-			if (cloopVTable->version < 3)
-			{
-				return 0;
-			}
-			IPerformanceStats* ret = static_cast<VTable*>(this->cloopVTable)->getPerfStats(this);
-			return ret;
-		}
 	};
 
 #define FIREBIRD_ITRACE_SQLSTATEMENT_VERSION 4u
@@ -5669,6 +5658,7 @@ namespace Firebird
 			ITraceParams* (CLOOP_CARG *getInputs)(ITraceSQLStatement* self) CLOOP_NOEXCEPT;
 			const char* (CLOOP_CARG *getTextUTF8)(ITraceSQLStatement* self) CLOOP_NOEXCEPT;
 			const char* (CLOOP_CARG *getExplainedPlan)(ITraceSQLStatement* self) CLOOP_NOEXCEPT;
+			IPerformanceStats* (CLOOP_CARG *getPerfStats)(ITraceSQLStatement* self) CLOOP_NOEXCEPT;
 		};
 
 	protected:
@@ -5713,6 +5703,16 @@ namespace Firebird
 			const char* ret = static_cast<VTable*>(this->cloopVTable)->getExplainedPlan(this);
 			return ret;
 		}
+
+		IPerformanceStats* getPerfStats()
+		{
+			if (cloopVTable->version < 4)
+			{
+				return 0;
+			}
+			IPerformanceStats* ret = static_cast<VTable*>(this->cloopVTable)->getPerfStats(this);
+			return ret;
+		}
 	};
 
 #define FIREBIRD_ITRACE_BLRSTATEMENT_VERSION 4u
@@ -5725,6 +5725,7 @@ namespace Firebird
 			const unsigned char* (CLOOP_CARG *getData)(ITraceBLRStatement* self) CLOOP_NOEXCEPT;
 			unsigned (CLOOP_CARG *getDataLength)(ITraceBLRStatement* self) CLOOP_NOEXCEPT;
 			const char* (CLOOP_CARG *getText)(ITraceBLRStatement* self) CLOOP_NOEXCEPT;
+			IPerformanceStats* (CLOOP_CARG *getPerfStats)(ITraceBLRStatement* self) CLOOP_NOEXCEPT;
 		};
 
 	protected:
@@ -5755,6 +5756,16 @@ namespace Firebird
 		const char* getText()
 		{
 			const char* ret = static_cast<VTable*>(this->cloopVTable)->getText(this);
+			return ret;
+		}
+
+		IPerformanceStats* getPerfStats()
+		{
+			if (cloopVTable->version < 4)
+			{
+				return 0;
+			}
+			IPerformanceStats* ret = static_cast<VTable*>(this->cloopVTable)->getPerfStats(this);
 			return ret;
 		}
 	};
@@ -18062,7 +18073,6 @@ namespace Firebird
 					this->version = Base::VERSION;
 					this->getStmtID = &Name::cloopgetStmtIDDispatcher;
 					this->getPerf = &Name::cloopgetPerfDispatcher;
-					this->getPerfStats = &Name::cloopgetPerfStatsDispatcher;
 				}
 			} vTable;
 
@@ -18094,19 +18104,6 @@ namespace Firebird
 				return static_cast<PerformanceInfo*>(0);
 			}
 		}
-
-		static IPerformanceStats* CLOOP_CARG cloopgetPerfStatsDispatcher(ITraceStatement* self) CLOOP_NOEXCEPT
-		{
-			try
-			{
-				return static_cast<Name*>(self)->Name::getPerfStats();
-			}
-			catch (...)
-			{
-				StatusType::catchException(0);
-				return static_cast<IPerformanceStats*>(0);
-			}
-		}
 	};
 
 	template <typename Name, typename StatusType, typename Base = IVersionedImpl<Name, StatusType, Inherit<ITraceStatement> > >
@@ -18124,7 +18121,6 @@ namespace Firebird
 
 		virtual ISC_INT64 getStmtID() = 0;
 		virtual PerformanceInfo* getPerf() = 0;
-		virtual IPerformanceStats* getPerfStats() = 0;
 	};
 
 	template <typename Name, typename StatusType, typename Base>
@@ -18142,12 +18138,12 @@ namespace Firebird
 					this->version = Base::VERSION;
 					this->getStmtID = &Name::cloopgetStmtIDDispatcher;
 					this->getPerf = &Name::cloopgetPerfDispatcher;
-					this->getPerfStats = &Name::cloopgetPerfStatsDispatcher;
 					this->getText = &Name::cloopgetTextDispatcher;
 					this->getPlan = &Name::cloopgetPlanDispatcher;
 					this->getInputs = &Name::cloopgetInputsDispatcher;
 					this->getTextUTF8 = &Name::cloopgetTextUTF8Dispatcher;
 					this->getExplainedPlan = &Name::cloopgetExplainedPlanDispatcher;
+					this->getPerfStats = &Name::cloopgetPerfStatsDispatcher;
 				}
 			} vTable;
 
@@ -18219,6 +18215,19 @@ namespace Firebird
 			}
 		}
 
+		static IPerformanceStats* CLOOP_CARG cloopgetPerfStatsDispatcher(ITraceSQLStatement* self) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getPerfStats();
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<IPerformanceStats*>(0);
+			}
+		}
+
 		static ISC_INT64 CLOOP_CARG cloopgetStmtIDDispatcher(ITraceStatement* self) CLOOP_NOEXCEPT
 		{
 			try
@@ -18244,19 +18253,6 @@ namespace Firebird
 				return static_cast<PerformanceInfo*>(0);
 			}
 		}
-
-		static IPerformanceStats* CLOOP_CARG cloopgetPerfStatsDispatcher(ITraceStatement* self) CLOOP_NOEXCEPT
-		{
-			try
-			{
-				return static_cast<Name*>(self)->Name::getPerfStats();
-			}
-			catch (...)
-			{
-				StatusType::catchException(0);
-				return static_cast<IPerformanceStats*>(0);
-			}
-		}
 	};
 
 	template <typename Name, typename StatusType, typename Base = ITraceStatementImpl<Name, StatusType, Inherit<IVersionedImpl<Name, StatusType, Inherit<ITraceSQLStatement> > > > >
@@ -18277,6 +18273,7 @@ namespace Firebird
 		virtual ITraceParams* getInputs() = 0;
 		virtual const char* getTextUTF8() = 0;
 		virtual const char* getExplainedPlan() = 0;
+		virtual IPerformanceStats* getPerfStats() = 0;
 	};
 
 	template <typename Name, typename StatusType, typename Base>
@@ -18294,10 +18291,10 @@ namespace Firebird
 					this->version = Base::VERSION;
 					this->getStmtID = &Name::cloopgetStmtIDDispatcher;
 					this->getPerf = &Name::cloopgetPerfDispatcher;
-					this->getPerfStats = &Name::cloopgetPerfStatsDispatcher;
 					this->getData = &Name::cloopgetDataDispatcher;
 					this->getDataLength = &Name::cloopgetDataLengthDispatcher;
 					this->getText = &Name::cloopgetTextDispatcher;
+					this->getPerfStats = &Name::cloopgetPerfStatsDispatcher;
 				}
 			} vTable;
 
@@ -18343,6 +18340,19 @@ namespace Firebird
 			}
 		}
 
+		static IPerformanceStats* CLOOP_CARG cloopgetPerfStatsDispatcher(ITraceBLRStatement* self) CLOOP_NOEXCEPT
+		{
+			try
+			{
+				return static_cast<Name*>(self)->Name::getPerfStats();
+			}
+			catch (...)
+			{
+				StatusType::catchException(0);
+				return static_cast<IPerformanceStats*>(0);
+			}
+		}
+
 		static ISC_INT64 CLOOP_CARG cloopgetStmtIDDispatcher(ITraceStatement* self) CLOOP_NOEXCEPT
 		{
 			try
@@ -18368,19 +18378,6 @@ namespace Firebird
 				return static_cast<PerformanceInfo*>(0);
 			}
 		}
-
-		static IPerformanceStats* CLOOP_CARG cloopgetPerfStatsDispatcher(ITraceStatement* self) CLOOP_NOEXCEPT
-		{
-			try
-			{
-				return static_cast<Name*>(self)->Name::getPerfStats();
-			}
-			catch (...)
-			{
-				StatusType::catchException(0);
-				return static_cast<IPerformanceStats*>(0);
-			}
-		}
 	};
 
 	template <typename Name, typename StatusType, typename Base = ITraceStatementImpl<Name, StatusType, Inherit<IVersionedImpl<Name, StatusType, Inherit<ITraceBLRStatement> > > > >
@@ -18399,6 +18396,7 @@ namespace Firebird
 		virtual const unsigned char* getData() = 0;
 		virtual unsigned getDataLength() = 0;
 		virtual const char* getText() = 0;
+		virtual IPerformanceStats* getPerfStats() = 0;
 	};
 
 	template <typename Name, typename StatusType, typename Base>

--- a/src/include/gen/Firebird.pas
+++ b/src/include/gen/Firebird.pas
@@ -619,15 +619,16 @@ type
 	ITraceParams_getTextUTF8Ptr = function(this: ITraceParams; status: IStatus; idx: Cardinal): PAnsiChar; cdecl;
 	ITraceStatement_getStmtIDPtr = function(this: ITraceStatement): Int64; cdecl;
 	ITraceStatement_getPerfPtr = function(this: ITraceStatement): PerformanceInfoPtr; cdecl;
-	ITraceStatement_getPerfStatsPtr = function(this: ITraceStatement): IPerformanceStats; cdecl;
 	ITraceSQLStatement_getTextPtr = function(this: ITraceSQLStatement): PAnsiChar; cdecl;
 	ITraceSQLStatement_getPlanPtr = function(this: ITraceSQLStatement): PAnsiChar; cdecl;
 	ITraceSQLStatement_getInputsPtr = function(this: ITraceSQLStatement): ITraceParams; cdecl;
 	ITraceSQLStatement_getTextUTF8Ptr = function(this: ITraceSQLStatement): PAnsiChar; cdecl;
 	ITraceSQLStatement_getExplainedPlanPtr = function(this: ITraceSQLStatement): PAnsiChar; cdecl;
+	ITraceSQLStatement_getPerfStatsPtr = function(this: ITraceSQLStatement): IPerformanceStats; cdecl;
 	ITraceBLRStatement_getDataPtr = function(this: ITraceBLRStatement): BytePtr; cdecl;
 	ITraceBLRStatement_getDataLengthPtr = function(this: ITraceBLRStatement): Cardinal; cdecl;
 	ITraceBLRStatement_getTextPtr = function(this: ITraceBLRStatement): PAnsiChar; cdecl;
+	ITraceBLRStatement_getPerfStatsPtr = function(this: ITraceBLRStatement): IPerformanceStats; cdecl;
 	ITraceDYNRequest_getDataPtr = function(this: ITraceDYNRequest): BytePtr; cdecl;
 	ITraceDYNRequest_getDataLengthPtr = function(this: ITraceDYNRequest): Cardinal; cdecl;
 	ITraceDYNRequest_getTextPtr = function(this: ITraceDYNRequest): PAnsiChar; cdecl;
@@ -3127,15 +3128,13 @@ type
 	TraceStatementVTable = class(VersionedVTable)
 		getStmtID: ITraceStatement_getStmtIDPtr;
 		getPerf: ITraceStatement_getPerfPtr;
-		getPerfStats: ITraceStatement_getPerfStatsPtr;
 	end;
 
 	ITraceStatement = class(IVersioned)
-		const VERSION = 3;
+		const VERSION = 2;
 
 		function getStmtID(): Int64;
 		function getPerf(): PerformanceInfoPtr;
-		function getPerfStats(): IPerformanceStats;
 	end;
 
 	ITraceStatementImpl = class(ITraceStatement)
@@ -3143,7 +3142,6 @@ type
 
 		function getStmtID(): Int64; virtual; abstract;
 		function getPerf(): PerformanceInfoPtr; virtual; abstract;
-		function getPerfStats(): IPerformanceStats; virtual; abstract;
 	end;
 
 	TraceSQLStatementVTable = class(TraceStatementVTable)
@@ -3152,6 +3150,7 @@ type
 		getInputs: ITraceSQLStatement_getInputsPtr;
 		getTextUTF8: ITraceSQLStatement_getTextUTF8Ptr;
 		getExplainedPlan: ITraceSQLStatement_getExplainedPlanPtr;
+		getPerfStats: ITraceSQLStatement_getPerfStatsPtr;
 	end;
 
 	ITraceSQLStatement = class(ITraceStatement)
@@ -3162,6 +3161,7 @@ type
 		function getInputs(): ITraceParams;
 		function getTextUTF8(): PAnsiChar;
 		function getExplainedPlan(): PAnsiChar;
+		function getPerfStats(): IPerformanceStats;
 	end;
 
 	ITraceSQLStatementImpl = class(ITraceSQLStatement)
@@ -3169,18 +3169,19 @@ type
 
 		function getStmtID(): Int64; virtual; abstract;
 		function getPerf(): PerformanceInfoPtr; virtual; abstract;
-		function getPerfStats(): IPerformanceStats; virtual; abstract;
 		function getText(): PAnsiChar; virtual; abstract;
 		function getPlan(): PAnsiChar; virtual; abstract;
 		function getInputs(): ITraceParams; virtual; abstract;
 		function getTextUTF8(): PAnsiChar; virtual; abstract;
 		function getExplainedPlan(): PAnsiChar; virtual; abstract;
+		function getPerfStats(): IPerformanceStats; virtual; abstract;
 	end;
 
 	TraceBLRStatementVTable = class(TraceStatementVTable)
 		getData: ITraceBLRStatement_getDataPtr;
 		getDataLength: ITraceBLRStatement_getDataLengthPtr;
 		getText: ITraceBLRStatement_getTextPtr;
+		getPerfStats: ITraceBLRStatement_getPerfStatsPtr;
 	end;
 
 	ITraceBLRStatement = class(ITraceStatement)
@@ -3189,6 +3190,7 @@ type
 		function getData(): BytePtr;
 		function getDataLength(): Cardinal;
 		function getText(): PAnsiChar;
+		function getPerfStats(): IPerformanceStats;
 	end;
 
 	ITraceBLRStatementImpl = class(ITraceBLRStatement)
@@ -3196,10 +3198,10 @@ type
 
 		function getStmtID(): Int64; virtual; abstract;
 		function getPerf(): PerformanceInfoPtr; virtual; abstract;
-		function getPerfStats(): IPerformanceStats; virtual; abstract;
 		function getData(): BytePtr; virtual; abstract;
 		function getDataLength(): Cardinal; virtual; abstract;
 		function getText(): PAnsiChar; virtual; abstract;
+		function getPerfStats(): IPerformanceStats; virtual; abstract;
 	end;
 
 	TraceDYNRequestVTable = class(VersionedVTable)
@@ -9256,16 +9258,6 @@ begin
 	Result := TraceStatementVTable(vTable).getPerf(Self);
 end;
 
-function ITraceStatement.getPerfStats(): IPerformanceStats;
-begin
-	if (vTable.version < 3) then begin
-		Result := nil;
-	end
-	else begin
-		Result := TraceStatementVTable(vTable).getPerfStats(Self);
-	end;
-end;
-
 function ITraceSQLStatement.getText(): PAnsiChar;
 begin
 	Result := TraceSQLStatementVTable(vTable).getText(Self);
@@ -9291,6 +9283,16 @@ begin
 	Result := TraceSQLStatementVTable(vTable).getExplainedPlan(Self);
 end;
 
+function ITraceSQLStatement.getPerfStats(): IPerformanceStats;
+begin
+	if (vTable.version < 4) then begin
+		Result := nil;
+	end
+	else begin
+		Result := TraceSQLStatementVTable(vTable).getPerfStats(Self);
+	end;
+end;
+
 function ITraceBLRStatement.getData(): BytePtr;
 begin
 	Result := TraceBLRStatementVTable(vTable).getData(Self);
@@ -9304,6 +9306,16 @@ end;
 function ITraceBLRStatement.getText(): PAnsiChar;
 begin
 	Result := TraceBLRStatementVTable(vTable).getText(Self);
+end;
+
+function ITraceBLRStatement.getPerfStats(): IPerformanceStats;
+begin
+	if (vTable.version < 4) then begin
+		Result := nil;
+	end
+	else begin
+		Result := TraceBLRStatementVTable(vTable).getPerfStats(Self);
+	end;
 end;
 
 function ITraceDYNRequest.getData(): BytePtr;
@@ -15718,16 +15730,6 @@ begin
 	end
 end;
 
-function ITraceStatementImpl_getPerfStatsDispatcher(this: ITraceStatement): IPerformanceStats; cdecl;
-begin
-	Result := nil;
-	try
-		Result := ITraceStatementImpl(this).getPerfStats();
-	except
-		on e: Exception do FbException.catchException(nil, e);
-	end
-end;
-
 var
 	ITraceStatementImpl_vTable: TraceStatementVTable;
 
@@ -15751,16 +15753,6 @@ begin
 	Result := nil;
 	try
 		Result := ITraceSQLStatementImpl(this).getPerf();
-	except
-		on e: Exception do FbException.catchException(nil, e);
-	end
-end;
-
-function ITraceSQLStatementImpl_getPerfStatsDispatcher(this: ITraceSQLStatement): IPerformanceStats; cdecl;
-begin
-	Result := nil;
-	try
-		Result := ITraceSQLStatementImpl(this).getPerfStats();
 	except
 		on e: Exception do FbException.catchException(nil, e);
 	end
@@ -15816,6 +15808,16 @@ begin
 	end
 end;
 
+function ITraceSQLStatementImpl_getPerfStatsDispatcher(this: ITraceSQLStatement): IPerformanceStats; cdecl;
+begin
+	Result := nil;
+	try
+		Result := ITraceSQLStatementImpl(this).getPerfStats();
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
 var
 	ITraceSQLStatementImpl_vTable: TraceSQLStatementVTable;
 
@@ -15839,16 +15841,6 @@ begin
 	Result := nil;
 	try
 		Result := ITraceBLRStatementImpl(this).getPerf();
-	except
-		on e: Exception do FbException.catchException(nil, e);
-	end
-end;
-
-function ITraceBLRStatementImpl_getPerfStatsDispatcher(this: ITraceBLRStatement): IPerformanceStats; cdecl;
-begin
-	Result := nil;
-	try
-		Result := ITraceBLRStatementImpl(this).getPerfStats();
 	except
 		on e: Exception do FbException.catchException(nil, e);
 	end
@@ -15879,6 +15871,16 @@ begin
 	Result := nil;
 	try
 		Result := ITraceBLRStatementImpl(this).getText();
+	except
+		on e: Exception do FbException.catchException(nil, e);
+	end
+end;
+
+function ITraceBLRStatementImpl_getPerfStatsDispatcher(this: ITraceBLRStatement): IPerformanceStats; cdecl;
+begin
+	Result := nil;
+	try
+		Result := ITraceBLRStatementImpl(this).getPerfStats();
 	except
 		on e: Exception do FbException.catchException(nil, e);
 	end
@@ -18715,30 +18717,29 @@ initialization
 	ITraceParamsImpl_vTable.getTextUTF8 := @ITraceParamsImpl_getTextUTF8Dispatcher;
 
 	ITraceStatementImpl_vTable := TraceStatementVTable.create;
-	ITraceStatementImpl_vTable.version := 3;
+	ITraceStatementImpl_vTable.version := 2;
 	ITraceStatementImpl_vTable.getStmtID := @ITraceStatementImpl_getStmtIDDispatcher;
 	ITraceStatementImpl_vTable.getPerf := @ITraceStatementImpl_getPerfDispatcher;
-	ITraceStatementImpl_vTable.getPerfStats := @ITraceStatementImpl_getPerfStatsDispatcher;
 
 	ITraceSQLStatementImpl_vTable := TraceSQLStatementVTable.create;
 	ITraceSQLStatementImpl_vTable.version := 4;
 	ITraceSQLStatementImpl_vTable.getStmtID := @ITraceSQLStatementImpl_getStmtIDDispatcher;
 	ITraceSQLStatementImpl_vTable.getPerf := @ITraceSQLStatementImpl_getPerfDispatcher;
-	ITraceSQLStatementImpl_vTable.getPerfStats := @ITraceSQLStatementImpl_getPerfStatsDispatcher;
 	ITraceSQLStatementImpl_vTable.getText := @ITraceSQLStatementImpl_getTextDispatcher;
 	ITraceSQLStatementImpl_vTable.getPlan := @ITraceSQLStatementImpl_getPlanDispatcher;
 	ITraceSQLStatementImpl_vTable.getInputs := @ITraceSQLStatementImpl_getInputsDispatcher;
 	ITraceSQLStatementImpl_vTable.getTextUTF8 := @ITraceSQLStatementImpl_getTextUTF8Dispatcher;
 	ITraceSQLStatementImpl_vTable.getExplainedPlan := @ITraceSQLStatementImpl_getExplainedPlanDispatcher;
+	ITraceSQLStatementImpl_vTable.getPerfStats := @ITraceSQLStatementImpl_getPerfStatsDispatcher;
 
 	ITraceBLRStatementImpl_vTable := TraceBLRStatementVTable.create;
 	ITraceBLRStatementImpl_vTable.version := 4;
 	ITraceBLRStatementImpl_vTable.getStmtID := @ITraceBLRStatementImpl_getStmtIDDispatcher;
 	ITraceBLRStatementImpl_vTable.getPerf := @ITraceBLRStatementImpl_getPerfDispatcher;
-	ITraceBLRStatementImpl_vTable.getPerfStats := @ITraceBLRStatementImpl_getPerfStatsDispatcher;
 	ITraceBLRStatementImpl_vTable.getData := @ITraceBLRStatementImpl_getDataDispatcher;
 	ITraceBLRStatementImpl_vTable.getDataLength := @ITraceBLRStatementImpl_getDataLengthDispatcher;
 	ITraceBLRStatementImpl_vTable.getText := @ITraceBLRStatementImpl_getTextDispatcher;
+	ITraceBLRStatementImpl_vTable.getPerfStats := @ITraceBLRStatementImpl_getPerfStatsDispatcher;
 
 	ITraceDYNRequestImpl_vTable := TraceDYNRequestVTable.create;
 	ITraceDYNRequestImpl_vTable.version := 2;


### PR DESCRIPTION
This is a fix for: https://github.com/FirebirdSQL/firebird/issues/8980
