### PR TITLE
Race condition between VIO_update_in_place and the garbage collector

### DIFF
--- a/src/jrd/vio.cpp
+++ b/src/jrd/vio.cpp
@@ -7321,6 +7321,9 @@ void VIO_update_in_place(thread_db* tdbb,
 
 	AutoTempRecord gc_rec;
 
+	if (!DPM_get(tdbb, org_rpb, LCK_write))
+		BUGCHECK(186);	// msg 186 record disappeared
+
 	record_param temp2;
 	const Record* prior = org_rpb->rpb_prior;
 	if (prior)
@@ -7346,9 +7349,6 @@ void VIO_update_in_place(thread_db* tdbb,
 		const USHORT pageSpaceID = temp2.getWindow(tdbb).win_page.getPageSpaceID();
 		stack->push(PageNumber(pageSpaceID, temp2.rpb_page));
 	}
-
-	if (!DPM_get(tdbb, org_rpb, LCK_write))
-		BUGCHECK(186);	// msg 186 record disappeared
 
 	if (prior)
 	{

--- a/src/jrd/vio.cpp
+++ b/src/jrd/vio.cpp
@@ -7330,10 +7330,8 @@ void VIO_update_in_place(thread_db* tdbb,
 	{
 		temp2 = *org_rpb;
 		temp2.rpb_record = gc_rec = relation->getGCRecord(tdbb);
-		temp2.rpb_page = org_rpb->rpb_b_page;
-		temp2.rpb_line = org_rpb->rpb_b_line;
 
-		if (!DPM_fetch(tdbb, &temp2, LCK_read))
+		if (!DPM_fetch_back(tdbb, &temp2, LCK_read, -1))
 			BUGCHECK(291);	 // msg 291 cannot find record back version
 
 		VIO_data(tdbb, &temp2, relation->rel_pool);
@@ -7343,11 +7341,13 @@ void VIO_update_in_place(thread_db* tdbb,
 		if (temp2.rpb_prior)
 			temp2.rpb_flags |= rpb_delta;
 
-		temp2.rpb_number = org_rpb->rpb_number;
 		DPM_store(tdbb, &temp2, *stack, DPM_secondary);
 
 		const USHORT pageSpaceID = temp2.getWindow(tdbb).win_page.getPageSpaceID();
 		stack->push(PageNumber(pageSpaceID, temp2.rpb_page));
+
+		if (!DPM_get(tdbb, org_rpb, LCK_write))
+			BUGCHECK(186);	// msg 186 record disappeared
 	}
 
 	if (prior)


### PR DESCRIPTION
Hello,
I have discovered a race condition between the garbage collector and `VIO_update_in_place`, which is invoked in the system transaction during restore.

A race condition occurs when the record has a delta and `VIO_update_in_place` needs to read the back version to unpack it. However, if the garbage collector is active, it may delete that back version before it is fetched for reading, because it is not protected by anything at that point. This leads to `BUGCHECK(291)`.

My proposal is to acquire the write lock on the record before fetching the back version. This would prevent the background garbage collector from deleting its back versions within `VIO_chase_record_version`.

The issue is intermittent and was reproduced only on our fork using the firebird-qa test `./tests/functional/tabloid/test_eqc_136030.py`. I was unable to create a reproducible case for Firebird itself because the background garbage collector is triggered less frequently there. However, even from analysis alone, this potential problem is evident.

Thanks,
Alexey Mochalov.