### PR TITLE
Fix a possible use-after-free in EDS transaction rollback

### DIFF
--- a/src/jrd/extds/ExtDS.cpp
+++ b/src/jrd/extds/ExtDS.cpp
@@ -1639,15 +1639,30 @@ void Transaction::rollback(thread_db* tdbb, bool retain)
 	doRollback(&status, tdbb, retain);
 
 	Connection& conn = m_connection;
-	if (!retain)
+	const bool hasErrors = status->getState() & IStatus::STATE_ERRORS;
+
+	const auto cleanup = [&]()
 	{
-		detachFromJrdTran();
-		m_connection.deleteTransaction(tdbb, this);
+		if (!retain)
+		{
+			detachFromJrdTran();
+			m_connection.deleteTransaction(tdbb, this);
+		}
+	};
+
+	try
+	{
+		if (hasErrors) {
+			conn.raise(&status, tdbb, "transaction rollback");
+		}
+	}
+	catch (const Exception&)
+	{
+		cleanup();
+		throw;
 	}
 
-	if (status->getState() & IStatus::STATE_ERRORS) {
-		conn.raise(&status, tdbb, "transaction rollback");
-	}
+	cleanup();
 }
 
 Transaction* Transaction::getTransaction(thread_db* tdbb, Connection* conn, TraScope tra_scope)


### PR DESCRIPTION
`EDS::Transaction::rollback()` used to call `m_connection.deleteTransaction()` before reporting rollback errors. This cleanup may release or delete the owning `EDS::Connection`.

If rollback returned an error, the code then called `conn.raise()`, which uses `getDataSourceName()` and reads `m_dbName` from the potentially deleted connection. This could lead to a crash while building the error message.

The fix raises the rollback error while the connection is still alive and uses a catch/rethrow block to guarantee external transaction cleanup before propagating the original exception.
