### PR TITLE
Fixes a gbak restore crash for backups created with `-e`

### DIFF
--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -13919,7 +13919,10 @@ bool RestoreRelationTask::fileReader(Item& item)
 		const FB_SSIZE_T attLen = 1 + (tdgbl->gbl_sw_transportable ? 12 : 6);
 		const FB_SSIZE_T overhead = tdgbl->gbl_sw_compress ? (len / 127 + 1) : 0;
 
-		if (static_cast<FB_SSIZE_T>(len) + attLen + overhead > space)
+		// Reserve space for the after payload rec_* marker: rec_data or rec_relation_end.
+		const FB_SSIZE_T nextRecordMarker = 1;
+
+		if ((static_cast<FB_SSIZE_T>(len) + attLen + overhead + nextRecordMarker) > space)
 		{
 			if (ioBuf)
 			{


### PR DESCRIPTION
The bug was reproduced on a real production database backup (5.0 ver.). The restore reader now reserves one extra byte in `IOBuffer` for the next `rec_*` marker after a data record. A record could exactly fill the buffer and trip `fb_assert(space > 0)` before writing `rec_data` or `rec_relation_end`.