### PR TITLE
UDF compact div overflow fix

### DIFF
--- a/src/extlib/UdfBackwardCompatibility.cpp
+++ b/src/extlib/UdfBackwardCompatibility.cpp
@@ -96,7 +96,7 @@ FB_UDR_BEGIN_FUNCTION(UC_div)
 		{
 			out->resultNull = FB_FALSE;
 			if (in->n2)
-				out->result = div((long long)in->n1, (long long)in->n2).quot;
+				out->result = div((long long) in->n1, (long long) in->n2).quot;
 			else
 			{
 				out->result = std::numeric_limits<double>::infinity();

--- a/src/extlib/UdfBackwardCompatibility.cpp
+++ b/src/extlib/UdfBackwardCompatibility.cpp
@@ -96,7 +96,7 @@ FB_UDR_BEGIN_FUNCTION(UC_div)
 		{
 			out->resultNull = FB_FALSE;
 			if (in->n2)
-				out->result = div(in->n1, in->n2).quot;
+				out->result = div((long long)in->n1, (long long)in->n2).quot;
 			else
 			{
 				out->result = std::numeric_limits<double>::infinity();


### PR DESCRIPTION
If you create a function that uses `udf_compat!UC_div`, then when it is called with parameters `-2147483648` and `-1`, it will crash due to overflow. The problem is that the upper bound of int is `2147483647`, so changing the sign causes a crash. `n1` and `n2` in `in` are `int`, so as a solution during the function call, you can cast them to `long long`.