### PR TITLE
Extend tempspace in safe way

### DIFF
--- a/src/include/firebird/impl/msg/jrd.h
+++ b/src/include/firebird/impl/msg/jrd.h
@@ -1015,3 +1015,4 @@ FB_IMPL_MSG(JRD, 1012, bad_constant_type, -901, "2F", "000", "@1 is not supporte
 FB_IMPL_MSG(JRD, 1013, not_defined_constant, -901, "42", "000", "The constant @1 is not defined")
 FB_IMPL_MSG(JRD, 1014, const_name, -901, "42", "000", "CONSTANT @1")
 FB_IMPL_MSG(JRD, 1015, private_table, -901, "42", "000", "Table @1 is private to package @2")
+FB_IMPL_MSG(JRD, 1016, temp_space_invalid_pos, -901, "HY", "000", "Invalid position to read/write in a temporary file (positon: @1, size: @2)")

--- a/src/include/gen/Firebird.pas
+++ b/src/include/gen/Firebird.pas
@@ -5972,6 +5972,7 @@ const
 	 isc_not_defined_constant = 335545333;
 	 isc_const_name = 335545334;
 	 isc_private_table = 335545335;
+	 isc_temp_space_invalid_pos = 335545336;
 	 isc_gfix_db_name = 335740929;
 	 isc_gfix_invalid_sw = 335740930;
 	 isc_gfix_incmp_sw = 335740932;

--- a/src/jrd/TempSpace.cpp
+++ b/src/jrd/TempSpace.cpp
@@ -261,7 +261,7 @@ FB_SIZE_T TempSpace::read(offset_t offset, void* buffer, FB_SIZE_T length)
 	if (offset + length > logicalSize)
 	{
 		status_exception::raise(Arg::Gds(isc_temp_space_invalid_pos) <<
-			Arg::Num(offset + length) << Arg::Num(logicalSize));
+			Arg::Int64(offset + length) << Arg::Int64(logicalSize));
 	}
 
 	if (length)
@@ -297,7 +297,7 @@ FB_SIZE_T TempSpace::write(offset_t offset, const void* buffer, FB_SIZE_T length
 	if (offset > logicalSize)
 	{
 		status_exception::raise(Arg::Gds(isc_temp_space_invalid_pos) <<
-			Arg::Num(offset) << Arg::Num(logicalSize));
+			Arg::Int64(offset) << Arg::Int64(logicalSize));
 	}
 
 	if (offset + length > logicalSize)

--- a/src/jrd/TempSpace.cpp
+++ b/src/jrd/TempSpace.cpp
@@ -328,9 +328,14 @@ FB_SIZE_T TempSpace::write(offset_t offset, const void* buffer, FB_SIZE_T length
 
 void TempSpace::extend(FB_SIZE_T size)
 {
-	logicalSize += size;
+	const auto originalLogicalSize = logicalSize;
+	const auto originalPhysicalSize = physicalSize;
 
-	if (logicalSize > physicalSize)
+	logicalSize += size;
+	if (logicalSize <= physicalSize)
+		return;
+
+	try
 	{
 		const FB_SIZE_T initialSize = initialBuffer.getCount();
 
@@ -399,12 +404,10 @@ void TempSpace::extend(FB_SIZE_T size)
 			}
 		}
 
-		// NS 2014-07-31: FIXME: missing exception handling.
-		// error thrown in block of code below will leave TempSpace in inconsistent state:
-		// logical/physical size already increased while allocation has in fact failed.
 		if (!block)
 		{
 			// allocate block in the temp file
+			// Possible error thrown when not enough physical memory
 			TempFile* const file = setupFile(size);
 			fb_assert(file);
 			if (tail && tail->sameFile(file))
@@ -429,6 +432,13 @@ void TempSpace::extend(FB_SIZE_T size)
 			head = block;
 		}
 		tail = block;
+	}
+	catch (...)
+	{
+		// Restore original state
+		logicalSize = originalLogicalSize;
+		physicalSize = originalPhysicalSize;
+		throw;
 	}
 }
 

--- a/src/jrd/TempSpace.cpp
+++ b/src/jrd/TempSpace.cpp
@@ -331,6 +331,9 @@ void TempSpace::extend(FB_SIZE_T size)
 	const auto originalLogicalSize = logicalSize;
 	const auto originalPhysicalSize = physicalSize;
 
+	AutoPtr<Block> delayDelete; // Restore in case of error
+	Block* originalTail = tail;
+
 	logicalSize += size;
 	if (logicalSize <= physicalSize)
 		return;
@@ -372,7 +375,7 @@ void TempSpace::extend(FB_SIZE_T size)
 		if (initialSize)
 		{
 			fb_assert(head == tail);
-			delete head;
+			delayDelete = head;
 			head = tail = NULL;
 			size = static_cast<FB_SIZE_T>(FB_ALIGN(logicalSize, minBlockSize));
 			physicalSize = size;
@@ -438,6 +441,8 @@ void TempSpace::extend(FB_SIZE_T size)
 		// Restore original state
 		logicalSize = originalLogicalSize;
 		physicalSize = originalPhysicalSize;
+		head = delayDelete.release();
+		tail = originalTail;
 		throw;
 	}
 }

--- a/src/jrd/TempSpace.cpp
+++ b/src/jrd/TempSpace.cpp
@@ -258,7 +258,11 @@ TempSpace::~TempSpace()
 
 FB_SIZE_T TempSpace::read(offset_t offset, void* buffer, FB_SIZE_T length)
 {
-	fb_assert(offset + length <= logicalSize);
+	if (offset + length > logicalSize)
+	{
+		status_exception::raise(Arg::Gds(isc_temp_space_invalid_pos) <<
+			Arg::Num(offset + length) << Arg::Num(logicalSize));
+	}
 
 	if (length)
 	{
@@ -290,7 +294,11 @@ FB_SIZE_T TempSpace::read(offset_t offset, void* buffer, FB_SIZE_T length)
 
 FB_SIZE_T TempSpace::write(offset_t offset, const void* buffer, FB_SIZE_T length)
 {
-	fb_assert(offset <= logicalSize);
+	if (offset > logicalSize)
+	{
+		status_exception::raise(Arg::Gds(isc_temp_space_invalid_pos) <<
+			Arg::Num(offset) << Arg::Num(logicalSize));
+	}
 
 	if (offset + length > logicalSize)
 	{

--- a/src/jrd/TempSpace.cpp
+++ b/src/jrd/TempSpace.cpp
@@ -331,7 +331,7 @@ void TempSpace::extend(FB_SIZE_T size)
 	const auto originalLogicalSize = logicalSize;
 	const auto originalPhysicalSize = physicalSize;
 
-	AutoPtr<Block> delayDelete; // Restore in case of error
+	AutoPtr<Block> originalHead; // Delay deletion and restore in case of error
 	Block* originalTail = tail;
 
 	logicalSize += size;
@@ -375,7 +375,7 @@ void TempSpace::extend(FB_SIZE_T size)
 		if (initialSize)
 		{
 			fb_assert(head == tail);
-			delayDelete = head;
+			originalHead = head;
 			head = tail = NULL;
 			size = static_cast<FB_SIZE_T>(FB_ALIGN(logicalSize, minBlockSize));
 			physicalSize = size;
@@ -441,7 +441,7 @@ void TempSpace::extend(FB_SIZE_T size)
 		// Restore original state
 		logicalSize = originalLogicalSize;
 		physicalSize = originalPhysicalSize;
-		head = delayDelete.release();
+		head = originalHead.release();
 		tail = originalTail;
 		throw;
 	}


### PR DESCRIPTION
There are a FIXME  in the code:
https://github.com/FirebirdSQL/firebird/blob/8eb7bba99c09ed5b4937a12912af23e002ade824/src/jrd/TempSpace.cpp#L402-L404

And seem like it caused a segfault in a prodaction DB due to `TempSpace::head` is nullptr or `TempSpace::tail` is nullptr.

I reproduced this using a synteny test

1) Simulate small storage
```
sudo mount -t tmpfs -o size=1K tmpfs /mnt/ramdisk
sudo mount -t tmpfs -o size=1M tmpfs /mnt/ramdisk 
```
2) Firebird.conf:
```
TempDirectories = /mnt/ramdisk
TempCacheLimit = 1M
```

3) Run the code

First case:
```cpp
BOOST_CHECK_THROW(space.allocateSpace(tdbb, MORE_THEN_FILE_STORAGE), Firebird::Exception); // <- exception 
pos = space.allocateSpace(tdbb, 100); <- tail is nullptr
space.write(tdbb, pos, "123", 3); // <- segfault
```

Second case:
```cpp
const auto MORE_THEN_FILE_STORAGE = 10000024;
BOOST_CHECK_THROW(space.allocateSpace(MORE_THEN_FILE_STORAGE), Firebird::Exception); // <- exception 

pos = space.write(pos, "123", 3); // <- segfault
```