### PR TITLE
Fix: Needs to be updated non-type template argument to the modern C s…

### DIFF
--- a/extern/libcds/cds/opt/options.h
+++ b/extern/libcds/cds/opt/options.h
@@ -342,7 +342,7 @@ namespace opt {
     //@endcond
 
     /// Special padding constants for \p cds::opt::padding option
-    enum special_padding {
+    enum special_padding : unsigned int {
         no_special_padding = 0,   ///< no special padding
         cache_line_padding = 1,   ///< use cache line size defined in cds/user_setup/cache_line.h
 


### PR DESCRIPTION
…tandard - compilation error: non-type template argument evaluates to -2147483647, which cannot be narrowed to type 'unsigned int' [-Wc++11-narrowing]; struct actual_padding<cache_line_padding| padding_tiny_data_only>

```
[build] /code/extern/libcds\cds/opt/options.h:397:27: error: non-type template argument evaluates to -2147483647, which cannot be narrowed to type 'unsigned int' [-Wc++11-narrowing]
[build]   397 |     struct actual_padding<cache_line_padding| padding_tiny_data_only>
[build]       |                           ^
```