### PR TITLE
Fix: Add support build lib CDS with MSYS2 on win (not only MINGW). Wi…

### DIFF
--- a/extern/libcds/cds/compiler/gcc/compiler_macro.h
+++ b/extern/libcds/cds/compiler/gcc/compiler_macro.h
@@ -148,7 +148,7 @@
 #   endif
 #endif
 
-#if CDS_OS_TYPE == CDS_OS_MINGW
+#if CDS_OS_TYPE == CDS_OS_MINGW || CDS_OS_TYPE == CDS_OS_WIN64 || CDS_OS_TYPE == CDS_OS_WIN32
 #   ifdef CDS_BUILD_LIB
 #       define CDS_EXPORT_API          __declspec(dllexport)
 #   elif !defined(CDS_BUILD_STATIC_LIB)


### PR DESCRIPTION
…thout it cause a non-obvious error : "-Standard plugin entrypoint does not exist in module \src\plugins\Engine14 -The specified procedure could not be found."

```
[build] can't format message 17:0 -- message file /build/code/src\firebird.msg not found
[build] Error loading plugin Engine14
[build] -Standard plugin entrypoint does not exist in module \src\plugins\Engine14
[build] -The specified procedure could not be found.
[build] can't format message 17:120 -- message file /build/code/src\firebird.msg not found
[build] make[2]: *** [code/src/CMakeFiles/msg_fdb.dir/build.make:79: code/src/msg.fdb] Error 1
[build] make[1]: *** [CMakeFiles/Makefile2:888: code/src/CMakeFiles/msg_fdb.dir/all] Error 2
[build] make: *** [Makefile:136: all] Error 2
```