### PR TITLE
Fix: Needs to be removed workaround "Until the fb_assert could be con…

### DIFF
--- a/src/utilities/install/services.cpp
+++ b/src/utilities/install/services.cpp
@@ -558,21 +558,3 @@ USHORT SERVICES_grant_access_rights(const char* service_name, const TEXT* accoun
 
 	return FB_SUCCESS;
 }
-
-//
-// Until the fb_assert could be converted to a function/object linked with each module
-// we need this ugly workaround.
-//
-extern "C" void API_ROUTINE gds__log(const TEXT* text, ...)
-{
-	va_list ptr;
-
-	va_start(ptr, text);
-	vprintf(text, ptr);
-	va_end(ptr);
-	printf("\n\n");
-}
-
-//
-// EOF
-//


### PR DESCRIPTION
…verted to a function/object linked with each module we need this ugly workaround. ... gds__log ..." in services.cpp  - lld-link: error: duplicate symbol: gds__log; Defined at "yvalve_common.dir/yvalve/gds.cpp.obj" and src\utilities\install\services.cpp:567

```
[build] [ 70%] Linking CXX executable ../../firebird/instsvc.exe
[build] lld-link: error: duplicate symbol: gds__log
[build] >>> defined at \src\utilities\install\services.cpp:567
[build] >>>            CMakeFiles/instsvc.dir/install/services.cpp.obj
[build] >>> defined at ../CMakeFiles/yvalve_common.dir/yvalve/gds.cpp.obj
[build] clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```