### PR TITLE
Fix calling reload twice for package constants and improve hash calculation

### DIFF
--- a/src/dsql/PackageNodes.epp
+++ b/src/dsql/PackageNodes.epp
@@ -558,7 +558,11 @@ dsc* PackageReferenceNode::execute(thread_db* tdbb, Request* request) const
 			Package* package = m_package(request->getResources());
 			package->checkReload(tdbb);
 
-			EVL_make_value(tdbb, package->findConstant(m_fullName)->makeValue(tdbb, request), outputImpure);
+			auto* constant = package->findConstant(m_fullName);
+			if (constant == nullptr) // Cloud be possible in case of mixing DDL and DML
+				return nullptr;
+
+			EVL_make_value(tdbb, constant->makeValue(tdbb, request), outputImpure);
 			return &outputImpure->vlu_desc;
 		}
 	default:

--- a/src/jrd/Package.epp
+++ b/src/jrd/Package.epp
@@ -49,11 +49,19 @@ DATABASE DB = FILENAME "ODS.RDB";
 //----------------------
 
 
+// Exclude address from the hash calculation due to it possible change
+constexpr inline ULONG DSC_SIZE_TO_HASH = sizeof(dsc) - offsetof(dsc, dsc_address);
 
 bool ConstantValue::hash(thread_db* tdbb, Firebird::sha512& digest) const
 {
-	fb_assert(m_value.vlu_desc.dsc_dtype != 0);
-	digest.process(sizeof(m_value.vlu_desc), &m_value.vlu_desc);
+	fb_assert(m_value.vlu_desc.dsc_dtype != dtype_unknown);
+	digest.process(DSC_SIZE_TO_HASH, &m_value.vlu_desc);
+	if (!m_value.vlu_desc.isNull())
+	{
+		fb_assert(m_value.vlu_desc.dsc_length > 0);
+		fb_assert(m_value.vlu_desc.dsc_address != nullptr);
+		digest.process(m_value.vlu_desc.dsc_length, m_value.vlu_desc.dsc_address);
+	}
 
 	return true;
 }
@@ -328,10 +336,7 @@ ScanResult Package::scan(thread_db* tdbb, ObjectBase::Flag flags)
 void Package::checkReload(thread_db* tdbb)
 {
 	if (m_callReload)
-	{
 		reload(tdbb, 0);
-		m_callReload = false;
-	}
 }
 
 ScanResult Package::reload(thread_db* tdbb, ObjectBase::Flag fl)
@@ -359,6 +364,7 @@ ScanResult Package::reload(thread_db* tdbb, ObjectBase::Flag fl)
 	}
 	END_FOR
 
+	m_callReload = false;
 	return ScanResult::COMPLETE;
 }
 

--- a/src/jrd/Package.epp
+++ b/src/jrd/Package.epp
@@ -50,7 +50,7 @@ DATABASE DB = FILENAME "ODS.RDB";
 
 
 // Exclude address from the hash calculation due to it possible change
-constexpr inline ULONG DSC_SIZE_TO_HASH = sizeof(dsc) - offsetof(dsc, dsc_address);
+constexpr inline ULONG DSC_SIZE_TO_HASH = offsetof(dsc, dsc_address);
 
 bool ConstantValue::hash(thread_db* tdbb, Firebird::sha512& digest) const
 {

--- a/src/jrd/Package.epp
+++ b/src/jrd/Package.epp
@@ -56,12 +56,17 @@ bool ConstantValue::hash(thread_db* tdbb, Firebird::sha512& digest) const
 {
 	fb_assert(m_value.vlu_desc.dsc_dtype != dtype_unknown);
 	digest.process(DSC_SIZE_TO_HASH, &m_value.vlu_desc);
-	if (!m_value.vlu_desc.isNull())
+
+	// The value hashing is unneccecery as Alex Peshkoff explained
+	// See https://groups.google.com/g/firebird-devel/c/xIxhL_QAjEg/m/9RGT47ugAwAJ
+	// Keep it just in case
+	/* if (!m_value.vlu_desc.isNull())
 	{
 		fb_assert(m_value.vlu_desc.dsc_length > 0);
 		fb_assert(m_value.vlu_desc.dsc_address != nullptr);
 		digest.process(m_value.vlu_desc.dsc_length, m_value.vlu_desc.dsc_address);
 	}
+	*/
 
 	return true;
 }

--- a/src/jrd/Package.epp
+++ b/src/jrd/Package.epp
@@ -51,6 +51,7 @@ DATABASE DB = FILENAME "ODS.RDB";
 
 // Exclude address from the hash calculation due to it possible change
 constexpr inline ULONG DSC_SIZE_TO_HASH = offsetof(dsc, dsc_address);
+static_assert(DSC_SIZE_TO_HASH - offsetof(dsc, dsc_flags) == sizeof(dsc::dsc_flags), "There should be no padding");
 
 bool ConstantValue::hash(thread_db* tdbb, Firebird::sha512& digest) const
 {


### PR DESCRIPTION
Fixes for the issue described in https://groups.google.com/g/firebird-devel/c/xIxhL_QAjEg : wierd error message when using a consatnt.

To reproduce:
```SQL
set term ^;
CREATE PACKAGE TEST
AS
BEGIN
    CONSTANT C1 INTEGER = 10;
END^

CREATE PROCEDURE P1(I INT) RETURNS (PROCEDURE_OUTPUT INT)
AS
BEGIN
    PROCEDURE_OUTPUT = TEST.C1;
    SUSPEND;
END^

set term ;^
commit;

select TEST.C1 from rdb$database ;
select * from P1(0);
commit;
``` 