### PR TITLE
Fix:  Under Clang compilation constexpr variable 'INVALID_HANDLE' must be initialized by a constant expression

### DIFF
--- a/src/common/ThreadStart.h
+++ b/src/common/ThreadStart.h
@@ -74,6 +74,14 @@ class Thread
 public:
 #ifdef WIN_NT
 	typedef HANDLE Handle;
+	   /*
+		* "constexpr" not applicable for Handle INVALID_HANDLE = INVALID_HANDLE_VALUE 
+		*  because in Windows INVALID_HANDLE_VALUE define in handleapi.h as:
+		* "#define INVALID_HANDLE_VALUE ((HANDLE)(LONG_PTR)-1)"
+		*  but C-cast & reinterpret_cast<>() are prohibited in constexpr.
+		*  The Clang++ compiler does not consider it`s as a constant expression and raise compilation error: 
+		* "constexpr variable 'INVALID_HANDLE' must be initialized by a constant expression" 
+		*/ 
         inline static const Handle INVALID_HANDLE = INVALID_HANDLE_VALUE;
 #endif
 #ifdef USE_POSIX_THREADS

--- a/src/common/ThreadStart.h
+++ b/src/common/ThreadStart.h
@@ -74,7 +74,7 @@ class Thread
 public:
 #ifdef WIN_NT
 	typedef HANDLE Handle;
-	constexpr static Handle INVALID_HANDLE = INVALID_HANDLE_VALUE;
+        inline static const Handle INVALID_HANDLE = INVALID_HANDLE_VALUE;
 #endif
 #ifdef USE_POSIX_THREADS
 	typedef pthread_t Handle;


### PR DESCRIPTION
The compiler does not consider "#define INVALID_HANDLE_VALUE ((HANDLE)(LONG_PTR)-1)" as a constant - compilation error: constexpr variable 'INVALID_HANDLE' must be initialized by a constant expression

In Windows  10.0.26100.0 INVALID_HANDLE_VALUE define C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\handleapi.h as  
#define INVALID_HANDLE_VALUE ((HANDLE)(LONG_PTR)-1)

clang  interpret  "((HANDLE)(.."  as  reinterpret_cast operation and raise error:

```
[build]    77 |         constexpr static Handle INVALID_HANDLE = INVALID_HANDLE_VALUE;
[build] /code/src/remote\../remote\../common/ThreadStart.h:77:26: error: constexpr variable 'INVALID_HANDLE' must be initialized by a constant expression
[build]    77 |         constexpr static Handle INVALID_HANDLE = INVALID_HANDLE_VALUE;
[build]       |                                 ^                ~~~~~~~~~~~~~~~~~~~~
[build] /code/src/remote\../remote\../common/ThreadStart.h:77:43: note: cast that performs the conversions of a reinterpret_cast is not allowed in a constant expression
[build]    77 |         constexpr static Handle INVALID_HANDLE = INVALID_HANDLE_VALUE;
[build]       |                                                  ^
[build] C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\handleapi.h:27:31: note: expanded from macro 'INVALID_HANDLE_VALUE'
[build]    27 | #define INVALID_HANDLE_VALUE ((HANDLE)(LONG_PTR)-1)
[build]       |                               ^
```
No excepton in MSVS compiler.  Clang has more hard control of a constant expression...
