### PR TITLE
fix(cast format): Correct behavior of `YEAR` pattern

### DIFF
--- a/doc/sql.extensions/README.cast.format.md
+++ b/doc/sql.extensions/README.cast.format.md
@@ -4,11 +4,11 @@ The following patterns are currently implemented for datetime to string conversi
 
 | Format Pattern | Description |
 | -------------- | ----------- |
-| YEAR | Year (1 - 9999) |
 | YYYY | Last 4 digits of Year (0001 - 9999) |
 | YYY | Last 3 digits of Year (000 - 999) |
 | YY | Last 2 digits of Year (00 - 99) |
 | Y | Last 1 digits of Year (0 - 9) |
+| YEAR | Spelled out Year (TWENTY TWENTY-SIX) |
 | Q | Quarter of the Year (1 - 4) |
 | MM | Month (01 - 12) |
 | MON | Short Month name (Apr) |
@@ -47,7 +47,7 @@ The separators are:
 
 Patterns can be used without any separators:
 ```
-SELECT CAST(CURRENT_TIMESTAMP AS VARCHAR(50) FORMAT 'YEARMMDD HH24MISS') FROM RDB$DATABASE;
+SELECT CAST(CURRENT_TIMESTAMP AS VARCHAR(50) FORMAT 'YYYYMMDD HH24MISS') FROM RDB$DATABASE;
 =========================
 20230719 161757
 ```
@@ -58,7 +58,7 @@ Also the format is case-insensitive, so `YYYY-MM` == `yyyy-mm`.
 
 Example:
 ```
-SELECT CAST(CURRENT_TIMESTAMP AS VARCHAR(45) FORMAT 'DD.MM.YEAR HH24:MI:SS "is" J "Julian day"') FROM RDB$DATABASE;
+SELECT CAST(CURRENT_TIMESTAMP AS VARCHAR(45) FORMAT 'DD.MM.YYYY HH24:MI:SS "is" J "Julian day"') FROM RDB$DATABASE;
 =========================
 14.06.2023 15:41:29 is 2460110 Julian day
 ```
@@ -69,7 +69,6 @@ The following patterns are currently implemented for string to datetime conversi
 
 | Format Pattern | Description |
 | ------------- | ------------- |
-| YEAR | Year |
 | YYYY | Last 4 digits of Year |
 | YYY | Last 3 digits of Year |
 | YY | Last 2 digits of Year |
@@ -109,7 +108,7 @@ Behavior of `RRRR`: Accepts either 4-digit or 2-digit input. If 2-digit, provide
 
 Example:
 ```
-SELECT CAST('2000.12.08 12:35:30.5000' AS TIMESTAMP FORMAT 'YEAR.MM.DD HH24:MI:SS.FF4') FROM RDB$DATABASE;
+SELECT CAST('2000.12.08 12:35:30.5000' AS TIMESTAMP FORMAT 'YYYY.MM.DD HH24:MI:SS.FF4') FROM RDB$DATABASE;
 =====================
 2000-12-08 12:35:30.5000
 ```

--- a/src/common/CvtFormat.cpp
+++ b/src/common/CvtFormat.cpp
@@ -173,7 +173,7 @@ namespace
 	#undef CVT_FORMAT_FLAG
 
 	constexpr const char* const TO_STRING_PATTERNS[] = {
-		FormatStr::YEAR, FormatStr::YYYY, FormatStr::YYY, FormatStr::YY, FormatStr::Y, FormatStr::Q, FormatStr::MM,
+		FormatStr::YYYY, FormatStr::YYY, FormatStr::YY, FormatStr::Y, FormatStr::YEAR, FormatStr::Q, FormatStr::MM,
 		FormatStr::MON, FormatStr::MONTH, FormatStr::RM, FormatStr::WW, FormatStr::W, FormatStr::D, FormatStr::DAY,
 		FormatStr::DD, FormatStr::DDD, FormatStr::DY, FormatStr::J, FormatStr::HH, FormatStr::HH12, FormatStr::HH24,
 		FormatStr::MI, FormatStr::SS, FormatStr::SSSSS, FormatStr::FF1, FormatStr::FF2, FormatStr::FF3, FormatStr::FF4,
@@ -182,7 +182,7 @@ namespace
 	};
 
 	constexpr const char* const TO_DATETIME_PATTERNS[] = {
-		FormatStr::YEAR, FormatStr::YYYY, FormatStr::YYY, FormatStr::YY, FormatStr::Y, FormatStr::RRRR, FormatStr::RR,
+		FormatStr::YYYY, FormatStr::YYY, FormatStr::YY, FormatStr::Y, FormatStr::RRRR, FormatStr::RR,
 		FormatStr::MM, FormatStr::MON, FormatStr::MONTH, FormatStr::RM, FormatStr::DD, FormatStr::J, FormatStr::HH,
 		FormatStr::HH12, FormatStr::HH24, FormatStr::MI, FormatStr::SS, FormatStr::SSSSS, FormatStr::FF1, FormatStr::FF2,
 		FormatStr::FF3, FormatStr::FF4, FormatStr::TZH, FormatStr::TZM, FormatStr::TZR, FormatStr::AM, FormatStr::PM
@@ -716,6 +716,122 @@ namespace
 		return string(timezoneBuffer, length);
 	}
 
+	string yearToWords(unsigned year, Callbacks* cb)
+	{
+		static constexpr const char* ZERO = "ZERO";
+		static constexpr const char* ONES[] = {
+			"", "ONE", "TWO", "THREE", "FOUR", "FIVE",
+			"SIX", "SEVEN", "EIGHT", "NINE", "TEN",
+			"ELEVEN", "TWELVE", "THIRTEEN", "FOURTEEN", "FIFTEEN",
+			"SIXTEEN", "SEVENTEEN", "EIGHTEEN", "NINETEEN"
+		};
+		static constexpr const char* TENS[] = {
+			"", "", "TWENTY", "THIRTY", "FORTY", "FIFTY",
+			"SIXTY", "SEVENTY", "EIGHTY", "NINETY"
+		};
+
+		auto twoDigits = [&](unsigned n, string& result) -> void
+		{
+			fb_assert(n < 100);
+
+			if (n == 0)
+			{
+				result += ZERO;
+				return;
+			}
+			if (n < 20)
+			{
+				result += ONES[n];
+				return;
+			}
+
+			result += TENS[n / 10];
+			if (n % 10)
+			{
+				result += "-";
+				result += ONES[n % 10];
+			}
+		};
+
+		// Not possible in our date implementation, but anyway handle 0 value just in case.
+		if (year == 0)
+			return ZERO;
+
+		string result;
+		result.reserve(30);
+
+		if (year < 100)
+		{
+			twoDigits(year, result);
+		}
+		else if (year < 1000)
+		{
+			const unsigned hi = year / 100;
+			const unsigned lo = year % 100;
+			result = ONES[hi];
+			if (lo < 10)
+			{
+				// 900 -> "nine hundred"
+				result += " HUNDRED";
+				if (lo != 0)
+				{
+					// 905 -> "nine hundred five"
+					result += " ";
+					result += ONES[lo];
+				}
+			}
+			else
+			{
+				// 925 -> "nine twenty-five"
+				result += " ";
+				twoDigits(lo, result);
+			}
+		}
+		else if (year < 10000)
+		{
+			const unsigned hi = year / 100;
+			const unsigned lo = year % 100;
+			if (lo < 10)
+			{
+				const unsigned hihi = hi / 10;
+				const unsigned hilo = hi % 10;
+				// 1000 -> "one thousand"
+				result += ONES[hihi];
+				result += " THOUSAND";
+				if (hilo != 0)
+				{
+					// 1900 -> "one thousand nine hundred"
+					result += " ";
+					result += ONES[hilo];
+					result += " HUNDRED";
+				}
+				if (lo != 0)
+				{
+					// 1905 -> "one thousand nine hundred five"
+					result += " ";
+					result += ONES[lo];
+				}
+			}
+			else
+			{
+				// 1985 -> "nineteen eighty-five"
+				// 2685 -> "twenty-six eighty-five"
+				twoDigits(hi, result);
+				result += " ";
+				twoDigits(lo, result);
+			}
+		}
+		else
+		{
+			// Currently we don't support dates >9999
+			fb_assert(false);
+			cb->err(Arg::Gds(isc_value_for_pattern_is_out_of_range)
+				<< FormatStr::YEAR << Arg::Num(1) << Arg::Num(9999));
+		}
+
+		return result;
+	}
+
 	string processDateTimeToStringTokens(const dsc* desc, const std::vector<Token>& tokens, const struct tm& times, int fractions, Callbacks* cb)
 	{
 		string result;
@@ -740,8 +856,11 @@ namespace
 					patternResult.printf("%04d", (times.tm_year + 1900) % 10000);
 					break;
 				case Format::YEAR:
-					patternResult.printf("%d", (times.tm_year + 1900));
+				{
+					const string year = yearToWords(times.tm_year + 1900, cb);
+					patternResult.printf("%s", year.data());
 					break;
+				}
 
 				case Format::Q:
 				{
@@ -1001,7 +1120,7 @@ namespace
 	constexpr void validateFormatFlags(Format::Patterns formatFlags, Callbacks* cb)
 	{
 		// CT shall contain at most one of each of the following: <datetime template year>
-		if (Format::Patterns value = formatFlags & (Format::Y | Format::YY | Format::YYY | Format::YYYY | Format::YEAR))
+		if (Format::Patterns value = formatFlags & (Format::Y | Format::YY | Format::YYY | Format::YYYY))
 		{
 			switch (value)
 			{
@@ -1009,10 +1128,9 @@ namespace
 				case Format::YY:
 				case Format::YYY:
 				case Format::YYYY:
-				case Format::YEAR:
 					break;
 				default:
-					cb->err(Arg::Gds(isc_only_one_pattern_can_be_used) << Arg::Str("Y/YY/YYY/YYYY/YEAR"));
+					cb->err(Arg::Gds(isc_only_one_pattern_can_be_used) << Arg::Str("Y/YY/YYY/YYYY"));
 			}
 		}
 
@@ -1021,8 +1139,8 @@ namespace
 			cb->err(Arg::Gds(isc_only_one_pattern_can_be_used) << Arg::Str("RR/RRRR"));
 
 		// CT shall not contain both <datetime template year> and <datetime template rounded year>
-		if ((formatFlags & (Format::Y | Format::YY | Format::YYY | Format::YYYY | Format::YEAR)) && (formatFlags & (Format::RR | Format::RRRR)))
-			cb->err(Arg::Gds(isc_incompatible_format_patterns) << Arg::Str("Y/YY/YYY/YYYY/YEAR") << Arg::Str("RR/RRRR"));
+		if ((formatFlags & (Format::Y | Format::YY | Format::YYY | Format::YYYY)) && (formatFlags & (Format::RR | Format::RRRR)))
+			cb->err(Arg::Gds(isc_incompatible_format_patterns) << Arg::Str("Y/YY/YYY/YYYY") << Arg::Str("RR/RRRR"));
 
 		// If CT contains <datetime template day of year>, then CT shall not contain <datetime template month>
 		// or <datetime template day of month>.
@@ -1389,19 +1507,6 @@ namespace
 					const std::optional<int> year = getIntFromString(str, strLength, strOffset, 4);
 					throwExceptionOnEmptyValue(year, patternStr, cb);
 
-					outTimes.tm_year = year.value() - 1900;
-					break;
-				}
-				case Format::YEAR:
-				{
-					const std::optional<int> year = getIntFromString(str, strLength, strOffset, strLength - strOffset);
-					throwExceptionOnEmptyValue(year, patternStr, cb);
-
-					if (year > 9999)
-					{
-						cb->err(Arg::Gds(isc_value_for_pattern_is_out_of_range) << patternStr <<
-							Arg::Num(0) << Arg::Num(9999));
-					}
 					outTimes.tm_year = year.value() - 1900;
 					break;
 				}

--- a/src/common/CvtFormat.cpp
+++ b/src/common/CvtFormat.cpp
@@ -172,7 +172,7 @@ namespace
 	#undef CVT_FORMAT2
 	#undef CVT_FORMAT_FLAG
 
-	constexpr const char* const TO_DATETIME_PATTERNS[] = {
+	constexpr const char* const TO_STRING_PATTERNS[] = {
 		FormatStr::YEAR, FormatStr::YYYY, FormatStr::YYY, FormatStr::YY, FormatStr::Y, FormatStr::Q, FormatStr::MM,
 		FormatStr::MON, FormatStr::MONTH, FormatStr::RM, FormatStr::WW, FormatStr::W, FormatStr::D, FormatStr::DAY,
 		FormatStr::DD, FormatStr::DDD, FormatStr::DY, FormatStr::J, FormatStr::HH, FormatStr::HH12, FormatStr::HH24,
@@ -181,7 +181,7 @@ namespace
 		FormatStr::TZR, FormatStr::AM, FormatStr::PM
 	};
 
-	constexpr const char* const TO_STRING_PATTERNS[] = {
+	constexpr const char* const TO_DATETIME_PATTERNS[] = {
 		FormatStr::YEAR, FormatStr::YYYY, FormatStr::YYY, FormatStr::YY, FormatStr::Y, FormatStr::RRRR, FormatStr::RR,
 		FormatStr::MM, FormatStr::MON, FormatStr::MONTH, FormatStr::RM, FormatStr::DD, FormatStr::J, FormatStr::HH,
 		FormatStr::HH12, FormatStr::HH24, FormatStr::MI, FormatStr::SS, FormatStr::SSSSS, FormatStr::FF1, FormatStr::FF2,
@@ -606,7 +606,7 @@ namespace
 				continue;
 			}
 
-			std::string_view patternStr = getPatternFromFormat(formatUpper.c_str(), TO_DATETIME_PATTERNS, formatLength,
+			std::string_view patternStr = getPatternFromFormat(formatUpper.c_str(), TO_STRING_PATTERNS, formatLength,
 				formatOffset, i);
 
 			const Format::Patterns pattern = mapFormatStrToFormatPattern(patternStr);
@@ -976,7 +976,7 @@ namespace
 			if (i == formatLength)
 				break;
 
-			std::string_view patternStr = getPatternFromFormat(formatUpper.c_str(), TO_STRING_PATTERNS, formatLength,
+			std::string_view patternStr = getPatternFromFormat(formatUpper.c_str(), TO_DATETIME_PATTERNS, formatLength,
 				formatOffset, i);
 
 			const Format::Patterns pattern = mapFormatStrToFormatPattern(patternStr);

--- a/src/common/tests/CvtTest.cpp
+++ b/src/common/tests/CvtTest.cpp
@@ -1,6 +1,7 @@
 #include "boost/test/unit_test.hpp"
 #include <cstddef>
 #include <cstring>
+#include <source_location>
 #include "../common/tests/CvtTestUtils.h"
 
 #include "../common/StatusArg.h"
@@ -26,7 +27,8 @@ MockCallback cb(errFunc, std::bind(mockGetLocalDate, 2023));
 BOOST_AUTO_TEST_SUITE(CVTDatetimeToFormatString)
 
 template<typename T>
-static void testCVTDatetimeToFormatString(T date, const string& format, const string& expected, Callbacks& cb)
+static void testCVTDatetimeToFormatString(T date, const string& format, const string& expected, Callbacks& cb,
+	std::source_location sl = std::source_location::current())
 {
 	try
 	{
@@ -36,7 +38,7 @@ static void testCVTDatetimeToFormatString(T date, const string& format, const st
 		desc.dsc_address = (UCHAR*) &date;
 		desc.dsc_scale = 0;
 
-		BOOST_TEST_INFO("FORMAT: " << "\"" << format.c_str() << "\"");
+		BOOST_TEST_INFO("FORMAT: " << "\"" << format.c_str() << "\"" << " at Line:" << sl.line() << " Column:" << sl.column());
 
 		string result = CVT_format_datetime_to_string(&desc, format, &cb);
 
@@ -53,13 +55,13 @@ BOOST_AUTO_TEST_SUITE(FunctionalTest)
 
 BOOST_AUTO_TEST_CASE(CVTDatetimeToFormatStringTest_DATE)
 {
-	testCVTDatetimeToFormatString(createDate(1, 1, 1), "YEAR.YYYY.YYY.YY.Y", "1.0001.001.01.1", cb);
-	testCVTDatetimeToFormatString(createDate(1234, 1, 1), "YEAR.YYYY.YYY.YY.Y", "1234.1234.234.34.4", cb);
-	testCVTDatetimeToFormatString(createDate(9999, 1, 1), "YEAR.YYYY.YYY.YY.Y", "9999.9999.999.99.9", cb);
+	testCVTDatetimeToFormatString(createDate(1, 1, 1), "YYYY.YYY.YY.Y", "0001.001.01.1", cb);
+	testCVTDatetimeToFormatString(createDate(1234, 1, 1), "YYYY.YYY.YY.Y", "1234.234.34.4", cb);
+	testCVTDatetimeToFormatString(createDate(9999, 1, 1), "YYYY.YYY.YY.Y", "9999.999.99.9", cb);
 
-	testCVTDatetimeToFormatString(createDate(1, 1, 1), "YEAR.YYYY.YYY.YY.Y", "1.0001.001.01.1", cb);
-	testCVTDatetimeToFormatString(createDate(1234, 1, 1), "YEAR.YYYY.YYY.YY.Y", "1234.1234.234.34.4", cb);
-	testCVTDatetimeToFormatString(createDate(9999, 1, 1), "YEAR.YYYY.YYY.YY.Y", "9999.9999.999.99.9", cb);
+	testCVTDatetimeToFormatString(createDate(1, 1, 1), "YYYY.YYY.YY.Y", "0001.001.01.1", cb);
+	testCVTDatetimeToFormatString(createDate(1234, 1, 1), "YYYY.YYY.YY.Y", "1234.234.34.4", cb);
+	testCVTDatetimeToFormatString(createDate(9999, 1, 1), "YYYY.YYY.YY.Y", "9999.999.99.9", cb);
 
 	testCVTDatetimeToFormatString(createDate(1, 1, 1), "Q", "1", cb);
 	testCVTDatetimeToFormatString(createDate(1, 2, 1), "Q", "1", cb);
@@ -73,6 +75,58 @@ BOOST_AUTO_TEST_CASE(CVTDatetimeToFormatStringTest_DATE)
 	testCVTDatetimeToFormatString(createDate(1, 10, 1), "Q", "4", cb);
 	testCVTDatetimeToFormatString(createDate(1, 11, 1), "Q", "4", cb);
 	testCVTDatetimeToFormatString(createDate(1, 12, 1), "Q", "4", cb);
+
+	testCVTDatetimeToFormatString(createDate(1, 1, 1),  "YEAR", "ONE", cb);
+	testCVTDatetimeToFormatString(createDate(2, 1, 1),  "YEAR", "TWO", cb);
+	testCVTDatetimeToFormatString(createDate(3, 1, 1),  "YEAR", "THREE", cb);
+	testCVTDatetimeToFormatString(createDate(4, 1, 1),  "YEAR", "FOUR", cb);
+	testCVTDatetimeToFormatString(createDate(5, 1, 1),  "YEAR", "FIVE", cb);
+	testCVTDatetimeToFormatString(createDate(6, 1, 1),  "YEAR", "SIX", cb);
+	testCVTDatetimeToFormatString(createDate(7, 1, 1),  "YEAR", "SEVEN", cb);
+	testCVTDatetimeToFormatString(createDate(8, 1, 1),  "YEAR", "EIGHT", cb);
+	testCVTDatetimeToFormatString(createDate(9, 1, 1),  "YEAR", "NINE", cb);
+	testCVTDatetimeToFormatString(createDate(10, 1, 1), "YEAR", "TEN", cb);
+	testCVTDatetimeToFormatString(createDate(11, 1, 1), "YEAR", "ELEVEN", cb);
+	testCVTDatetimeToFormatString(createDate(12, 1, 1), "YEAR", "TWELVE", cb);
+	testCVTDatetimeToFormatString(createDate(13, 1, 1), "YEAR", "THIRTEEN", cb);
+	testCVTDatetimeToFormatString(createDate(14, 1, 1), "YEAR", "FOURTEEN", cb);
+	testCVTDatetimeToFormatString(createDate(15, 1, 1), "YEAR", "FIFTEEN", cb);
+	testCVTDatetimeToFormatString(createDate(16, 1, 1), "YEAR", "SIXTEEN", cb);
+	testCVTDatetimeToFormatString(createDate(17, 1, 1), "YEAR", "SEVENTEEN", cb);
+	testCVTDatetimeToFormatString(createDate(18, 1, 1), "YEAR", "EIGHTEEN", cb);
+	testCVTDatetimeToFormatString(createDate(19, 1, 1), "YEAR", "NINETEEN", cb);
+	testCVTDatetimeToFormatString(createDate(20, 1, 1), "YEAR", "TWENTY", cb);
+	testCVTDatetimeToFormatString(createDate(30, 1, 1), "YEAR", "THIRTY", cb);
+	testCVTDatetimeToFormatString(createDate(40, 1, 1), "YEAR", "FORTY", cb);
+	testCVTDatetimeToFormatString(createDate(50, 1, 1), "YEAR", "FIFTY", cb);
+	testCVTDatetimeToFormatString(createDate(60, 1, 1), "YEAR", "SIXTY", cb);
+	testCVTDatetimeToFormatString(createDate(70, 1, 1), "YEAR", "SEVENTY", cb);
+	testCVTDatetimeToFormatString(createDate(80, 1, 1), "YEAR", "EIGHTY", cb);
+	testCVTDatetimeToFormatString(createDate(90, 1, 1), "YEAR", "NINETY", cb);
+	testCVTDatetimeToFormatString(createDate(100, 3, 1), "YEAR", "ONE HUNDRED", cb);
+	testCVTDatetimeToFormatString(createDate(500, 3, 1), "YEAR", "FIVE HUNDRED", cb);
+	testCVTDatetimeToFormatString(createDate(900, 3, 1), "YEAR", "NINE HUNDRED", cb);
+	testCVTDatetimeToFormatString(createDate(1000, 4, 1), "YEAR", "ONE THOUSAND", cb);
+	testCVTDatetimeToFormatString(createDate(5000, 4, 1), "YEAR", "FIVE THOUSAND", cb);
+	testCVTDatetimeToFormatString(createDate(9000, 4, 1), "YEAR", "NINE THOUSAND", cb);
+	testCVTDatetimeToFormatString(createDate(101, 1, 1), "YEAR", "ONE HUNDRED ONE", cb);
+	testCVTDatetimeToFormatString(createDate(105, 1, 1), "YEAR", "ONE HUNDRED FIVE", cb);
+	testCVTDatetimeToFormatString(createDate(109, 1, 1), "YEAR", "ONE HUNDRED NINE", cb);
+	testCVTDatetimeToFormatString(createDate(110, 1, 1), "YEAR", "ONE TEN", cb);
+	testCVTDatetimeToFormatString(createDate(115, 1, 1), "YEAR", "ONE FIFTEEN", cb);
+	testCVTDatetimeToFormatString(createDate(119, 1, 1), "YEAR", "ONE NINETEEN", cb);
+	testCVTDatetimeToFormatString(createDate(199, 1, 1), "YEAR", "ONE NINETY-NINE", cb);
+	testCVTDatetimeToFormatString(createDate(1001, 1, 1), "YEAR", "ONE THOUSAND ONE", cb);
+	testCVTDatetimeToFormatString(createDate(1009, 1, 1), "YEAR", "ONE THOUSAND NINE", cb);
+	testCVTDatetimeToFormatString(createDate(1010, 1, 1), "YEAR", "TEN TEN", cb);
+	testCVTDatetimeToFormatString(createDate(1019, 1, 1), "YEAR", "TEN NINETEEN", cb);
+	testCVTDatetimeToFormatString(createDate(1099, 1, 1), "YEAR", "TEN NINETY-NINE", cb);
+	testCVTDatetimeToFormatString(createDate(1100, 1, 1), "YEAR", "ONE THOUSAND ONE HUNDRED", cb);
+	testCVTDatetimeToFormatString(createDate(1101, 1, 1), "YEAR", "ONE THOUSAND ONE HUNDRED ONE", cb);
+	testCVTDatetimeToFormatString(createDate(1111, 1, 1), "YEAR", "ELEVEN ELEVEN", cb);
+	testCVTDatetimeToFormatString(createDate(3434, 1, 1), "YEAR", "THIRTY-FOUR THIRTY-FOUR", cb);
+	testCVTDatetimeToFormatString(createDate(3406, 1, 1), "YEAR", "THREE THOUSAND FOUR HUNDRED SIX", cb);
+	testCVTDatetimeToFormatString(createDate(2026, 1, 1), "YEAR", "TWENTY TWENTY-SIX", cb);
 
 	testCVTDatetimeToFormatString(createDate(1, 1, 1), "MON", "Jan", cb);
 	testCVTDatetimeToFormatString(createDate(1, 2, 1), "MON", "Feb", cb);
@@ -204,7 +258,7 @@ BOOST_AUTO_TEST_CASE(CVTDatetimeToFormatStringTest_TIMESTAMP)
 {
 	ISC_TIMESTAMP timestamp = createTimeStamp(1982, 4, 21, 1, 34, 15, 2500);
 
-	testCVTDatetimeToFormatString(timestamp, "YEAR.YYYY.YYY.YY.Y/J", "1982.1982.982.82.2/2445081", cb);
+	testCVTDatetimeToFormatString(timestamp, "YYYY.YYY.YY.Y/J", "1982.982.82.2/2445081", cb);
 	testCVTDatetimeToFormatString(timestamp, "Q-MM-RM-MON-MONTH", "2-04-IV-Apr-APRIL", cb);
 	testCVTDatetimeToFormatString(timestamp, "WW,W-D;DAY:DD DDD.DY", "16,3-4;WEDNESDAY:21 111.Wed", cb);
 	testCVTDatetimeToFormatString(timestamp, "HH-HH12 P.M.-HH24-MI-SS-SSSSS.FF2", "01-01 A.M.-01-34-15-5655.25", cb);
@@ -274,7 +328,7 @@ BOOST_AUTO_TEST_CASE(CVTDatetimeToFormatStringTest_TIMESTAMP_TZ)
 {
 	ISC_TIMESTAMP_TZ timestampTZ = createTimeStampTZ(1982, 4, 21, 1, 34, 15, 0, 500);
 
-	testCVTDatetimeToFormatString(timestampTZ, "YEAR.YYYY.YYY.YY.Y/J", "1982.1982.982.82.2/2445081", cb);
+	testCVTDatetimeToFormatString(timestampTZ, "YYYY.YYY.YY.Y/J", "1982.982.82.2/2445081", cb);
 	testCVTDatetimeToFormatString(timestampTZ, "Q-MM-RM-MON-MONTH", "2-04-IV-Apr-APRIL", cb);
 	testCVTDatetimeToFormatString(timestampTZ, "WW,W-D;DAY:DD DDD.DY", "16,3-4;WEDNESDAY:21 111.Wed", cb);
 	testCVTDatetimeToFormatString(timestampTZ, "HH A.M.-HH12-HH24-MI-SS-SSSSS.FF2/TZH/TZM", "01 A.M.-01-01-34-15-5655.50/+00/00", cb);
@@ -291,7 +345,7 @@ BOOST_AUTO_TEST_CASE(CVTDatetimeToFormatStringTest_SOLID_PATTERNS)
 {
 	ISC_TIMESTAMP_TZ timestampTZ = createTimeStampTZ(1982, 4, 21, 1, 34, 15, 0, 500);
 
-	testCVTDatetimeToFormatString(timestampTZ, "YEARYYYYYYYYYYJ", "198219821982822445081", cb);
+	testCVTDatetimeToFormatString(timestampTZ, "YYYYYYYYYYJ", "19821982822445081", cb);
 	testCVTDatetimeToFormatString(timestampTZ, "QMMRMMONMONTH", "204IVAprAPRIL", cb);
 	testCVTDatetimeToFormatString(timestampTZ, "WWWD/DAYDDDDDDY", "1634/WEDNESDAY1111112", cb);
 	testCVTDatetimeToFormatString(timestampTZ, "HHHH12A.M.HH24MISSSSSSSFF2TZHTZM", "0101A.M.013456551550+0000", cb);
@@ -401,11 +455,6 @@ BOOST_AUTO_TEST_SUITE(FunctionalTest)
 
 BOOST_AUTO_TEST_CASE(CVTStringToFormatDateTime_DATE)
 {
-	testCVTStringToFormatDateTimeExpectDate("1", "YEAR", createTimeStampTZ(1, 0, 0, 0, 0, 0, 0), cb);
-	testCVTStringToFormatDateTimeExpectDate("0001", "YEAR", createTimeStampTZ(1, 0, 0, 0, 0, 0, 0), cb);
-	testCVTStringToFormatDateTimeExpectDate("1234", "YEAR", createTimeStampTZ(1234, 0, 0, 0, 0, 0, 0), cb);
-	testCVTStringToFormatDateTimeExpectDate("9999", "YEAR", createTimeStampTZ(9999, 0, 0, 0, 0, 0, 0), cb);
-
 	testCVTStringToFormatDateTimeExpectDate("1", "YYYY", createTimeStampTZ(1, 0, 0, 0, 0, 0, 0), cb);
 	testCVTStringToFormatDateTimeExpectDate("0001", "YYYY", createTimeStampTZ(1, 0, 0, 0, 0, 0, 0), cb);
 	testCVTStringToFormatDateTimeExpectDate("1234", "YYYY", createTimeStampTZ(1234, 0, 0, 0, 0, 0, 0), cb);
@@ -519,16 +568,16 @@ BOOST_AUTO_TEST_CASE(CVTStringToFormatDateTime_DATE)
 	testCVTStringToFormatDateTimeExpectDate("1721426", "J", createTimeStampTZ(1, 1, 1, 0, 0, 0, 0), cb);
 	testCVTStringToFormatDateTimeExpectDate("5373484", "J", createTimeStampTZ(9999, 12, 31, 0, 0, 0, 0), cb);
 
-	testCVTStringToFormatDateTimeExpectDate("1:1,1", "YEAR.MM.DD", createTimeStampTZ(1, 1, 1, 0, 0, 0, 0), cb);
-	testCVTStringToFormatDateTimeExpectDate("1981-8/13", "YEAR.MM.DD", createTimeStampTZ(1981, 8, 13, 0, 0, 0, 0), cb);
-	testCVTStringToFormatDateTimeExpectDate("9999 12;31", "YEAR.MM.DD", createTimeStampTZ(9999, 12, 31, 0, 0, 0, 0), cb);
+	testCVTStringToFormatDateTimeExpectDate("1:1,1", "YYYY.MM.DD", createTimeStampTZ(1, 1, 1, 0, 0, 0, 0), cb);
+	testCVTStringToFormatDateTimeExpectDate("1981-8/13", "YYYY.MM.DD", createTimeStampTZ(1981, 8, 13, 0, 0, 0, 0), cb);
+	testCVTStringToFormatDateTimeExpectDate("9999 12;31", "YYYY.MM.DD", createTimeStampTZ(9999, 12, 31, 0, 0, 0, 0), cb);
 
-	testCVTStringToFormatDateTimeExpectDate("1981-Aug/13", "YEAR.MON.DD", createTimeStampTZ(1981, 8, 13, 0, 0, 0, 0), cb);
-	testCVTStringToFormatDateTimeExpectDate("1981-August/13", "YEAR.MONTH.DD", createTimeStampTZ(1981, 8, 13, 0, 0, 0, 0), cb);
-	testCVTStringToFormatDateTimeExpectDate("1981-VIII/13", "YEAR.RM.DD", createTimeStampTZ(1981, 8, 13, 0, 0, 0, 0), cb);
+	testCVTStringToFormatDateTimeExpectDate("1981-Aug/13", "YYYY.MON.DD", createTimeStampTZ(1981, 8, 13, 0, 0, 0, 0), cb);
+	testCVTStringToFormatDateTimeExpectDate("1981-August/13", "YYYY.MONTH.DD", createTimeStampTZ(1981, 8, 13, 0, 0, 0, 0), cb);
+	testCVTStringToFormatDateTimeExpectDate("1981-VIII/13", "YYYY.RM.DD", createTimeStampTZ(1981, 8, 13, 0, 0, 0, 0), cb);
 
 	testCVTStringToFormatDateTimeExpectDate("25.Jan.25", "YY;MON;DD", createTimeStampTZ(2025, 1, 25, 0, 0, 0, 0), cb);
-	testCVTStringToFormatDateTimeExpectDate("./.1981./''-8--/13-'-", "  YEAR.' -.MM.,',-.DD//", createTimeStampTZ(1981, 8, 13, 0, 0, 0, 0), cb);
+	testCVTStringToFormatDateTimeExpectDate("./.1981./''-8--/13-'-", "  YYYY.' -.MM.,',-.DD//", createTimeStampTZ(1981, 8, 13, 0, 0, 0, 0), cb);
 }
 
 BOOST_AUTO_TEST_CASE(CVTStringToFormatDateTime_TIME)
@@ -649,7 +698,7 @@ BOOST_AUTO_TEST_CASE(CVTStringToFormatDateTime_TZ)
 BOOST_AUTO_TEST_CASE(CVTStringToFormatDateTime_SOLID_PATTERNS)
 {
 	testCVTStringToFormatDateTimeExpectTime("1 P.M. - 25 - 45 ' 2", "HHA.M.MISSFF4", createTimeStampTZ(0, 0, 0, 13, 25, 45, 0, 2000), cb);
-	testCVTStringToFormatDateTimeExpectDate("1981-8/13", "YEARMMDD", createTimeStampTZ(1981, 8, 13, 0, 0, 0, 0), cb);
+	testCVTStringToFormatDateTimeExpectDate("1981-8/13", "YYYYMMDD", createTimeStampTZ(1981, 8, 13, 0, 0, 0, 0), cb);
 }
 
 BOOST_AUTO_TEST_CASE(CVTStringToFormatDateTime_EXCEPTION_CHECK)
@@ -659,7 +708,7 @@ BOOST_AUTO_TEST_CASE(CVTStringToFormatDateTime_EXCEPTION_CHECK)
 	testExceptionCvtStringToFormatDateTime("2000.12", "YYYY.MM.DD", cb);
 	testExceptionCvtStringToFormatDateTime("2000.12", "YYYY", cb);
 
-	testExceptionCvtStringToFormatDateTime("2 20 200 2000 2000", "Y YY YYY YYYY YEAR", cb);
+	testExceptionCvtStringToFormatDateTime("2 20 200 2000", "Y YY YYY YYYY", cb);
 	testExceptionCvtStringToFormatDateTime("20 2000", "RR RRRR", cb);
 
 	testExceptionCvtStringToFormatDateTime("2000 2000", "YYYY RRRR", cb);
@@ -692,7 +741,6 @@ BOOST_AUTO_TEST_CASE(CVTStringToFormatDateTime_EXCEPTION_CHECK)
 	testExceptionCvtStringToFormatDateTime("Apr", "YY    MON", cb);
 	testExceptionCvtStringToFormatDateTime("Apr", "YYY   MON", cb);
 	testExceptionCvtStringToFormatDateTime("Apr", "YYYY  MON", cb);
-	testExceptionCvtStringToFormatDateTime("Apr", "YEAR  MON", cb);
 	testExceptionCvtStringToFormatDateTime("Apr", "RR    MON", cb);
 	testExceptionCvtStringToFormatDateTime("Apr", "RRRR  MON", cb);
 	testExceptionCvtStringToFormatDateTime("Apr", "MM    MON", cb);


### PR DESCRIPTION
- This pattern was taken from Oracle and is supposed to display `spelled out year (TWENTY TWENTY-SIX)`. In the current implementation, it was equivalent to `YYYY` (i.e., the year as a number (2026)), which is incorrect;
- Update existing tests and add new ones for the reimplemented `YEAR` pattern;
- Fix incorrect variable names for `TO_STRING_PATTERNS` and `TO_DATETIME_PATTERNS` (usage was correct);