### PR TITLE
Fix server crash when read a malformed replication segment

### DIFF
--- a/src/jrd/replication/Applier.cpp
+++ b/src/jrd/replication/Applier.cpp
@@ -127,13 +127,21 @@ namespace
 
 		const string& getAtomString()
 		{
-			const auto pos = getInt32();
+			const ULONG pos = static_cast<ULONG>(getInt32());
+
+			if (pos >= m_atoms.getCount())
+				malformed();
+
 			return m_atoms[pos];
 		}
 
 		const MetaString getAtomMetaName()
 		{
-			const auto pos = getInt32();
+			const ULONG pos = static_cast<ULONG>(getInt32());
+
+			if (pos >= m_atoms.getCount())
+				malformed();
+
 			return m_atoms[pos];
 		}
 
@@ -152,7 +160,7 @@ namespace
 
 		string getString()
 		{
-			const auto length = getInt32();
+			const ULONG length = static_cast<ULONG>(getInt32());
 
 			if (m_data + length > m_end)
 				malformed();

--- a/src/jrd/replication/Applier.cpp
+++ b/src/jrd/replication/Applier.cpp
@@ -127,9 +127,9 @@ namespace
 
 		const string& getAtomString()
 		{
-			const ULONG pos = static_cast<ULONG>(getInt32());
+			const auto pos = getInt32();
 
-			if (pos >= m_atoms.getCount())
+			if (pos < 0 || pos >= m_atoms.getCount())
 				malformed();
 
 			return m_atoms[pos];
@@ -137,9 +137,9 @@ namespace
 
 		const MetaString getAtomMetaName()
 		{
-			const ULONG pos = static_cast<ULONG>(getInt32());
+			const auto pos = getInt32();
 
-			if (pos >= m_atoms.getCount())
+			if (pos < 0 || pos >= m_atoms.getCount())
 				malformed();
 
 			return m_atoms[pos];
@@ -162,7 +162,7 @@ namespace
 		{
 			const auto length = getInt32();
 
-			if (length <= 0 || m_end - m_data < length)
+			if (length < 0 || m_end - m_data < length)
 				malformed();
 
 			const string str((const char*) m_data, length);
@@ -193,9 +193,6 @@ namespace
 		void defineAtom()
 		{
 			const auto length = getByte();
-			if (length <= 0)
-				malformed();
-
 			const auto ptr = getBinary(length);
 			const MetaString name((const char*) ptr, length);
 			m_atoms.add(name);

--- a/src/jrd/replication/Applier.cpp
+++ b/src/jrd/replication/Applier.cpp
@@ -160,9 +160,9 @@ namespace
 
 		string getString()
 		{
-			const ULONG length = static_cast<ULONG>(getInt32());
+			const auto length = getInt32();
 
-			if (m_data + length > m_end)
+			if (length <= 0 || m_end - m_data < length)
 				malformed();
 
 			const string str((const char*) m_data, length);
@@ -172,7 +172,7 @@ namespace
 
 		const UCHAR* getBinary(ULONG length)
 		{
-			if (m_data + length > m_end)
+			if (m_end - m_data < length)
 				malformed();
 
 			const auto ptr = m_data;
@@ -193,6 +193,9 @@ namespace
 		void defineAtom()
 		{
 			const auto length = getByte();
+			if (length <= 0)
+				malformed();
+
 			const auto ptr = getBinary(length);
 			const MetaString name((const char*) ptr, length);
 			m_atoms.add(name);


### PR DESCRIPTION
If a segment has some damage and it falls on the length of a string or the position of an atom, then the server crash with SIGSEGV, instead of output an correct error