### PR TITLE
Package Constant: Check missing dsc_address instead of dsc_dtype and restore impure after using existing request

### DIFF
--- a/src/dsql/PackageNodes.epp
+++ b/src/dsql/PackageNodes.epp
@@ -560,7 +560,7 @@ dsc* PackageReferenceNode::execute(thread_db* tdbb, Request* request) const
 			Package* package = m_package(request->getResources());
 			package->checkReload(tdbb);
 
-			dsc* constantDsc = package->findConstant(m_fullName)->makeValue(tdbb, request);
+			dsc* constantDsc = package->findConstant(m_fullName)->makeValue(tdbb);
 			if (constantDsc == nullptr || constantDsc->isNull())
 				return nullptr;
 

--- a/src/jrd/Package.epp
+++ b/src/jrd/Package.epp
@@ -195,10 +195,18 @@ dsc* ConstantValue::makeValue(thread_db* tdbb, Request* request)
 		bid constantBid = getBlobId(tdbb);
 
 		MET_parse_blob(tdbb, &name.schema, nullptr, &constantBid, &csb, nullptr, false, false);
+		if (request != nullptr)
+		{
+			// Allocate new impure data in a correct position
+			csb->csb_impure = request->impureArea.getCount();
+		}
+
 		fb_assert(csb->csb_node != nullptr);
 		csb->csb_node->pass1(tdbb, csb);
 		csb->csb_node->pass2(tdbb, csb);
 
+		// request is null when this function called inside Package::scan (without MINISCAN)
+		// request is not null when this function called in PackageReferenceNode::execute
 		if (request == nullptr)
 		{
 			// Came from Reload
@@ -219,25 +227,13 @@ dsc* ConstantValue::makeValue(thread_db* tdbb, Request* request)
 		}
 		else
 		{
-			// A csb->csb_node will use impureArea from the incoming request
-			// but it contains other data
-			// Backup the current data and restore it later
-
-			// Reusing a small chunk is faster instead of makeing a new request
-			// And using existing space for a temporally value is better instead of adding this to request->impureArea
-			// and carrying it for whole request live
-
-			const auto nodeImpureSize = csb->csb_impure;
-			if (request->impureArea.getCount() < nodeImpureSize)
-				request->impureArea.grow(nodeImpureSize - request->impureArea.getCount());
-
-			const Array<UCHAR> backup(request->impureArea.begin(), nodeImpureSize);
-
+			if (csb->csb_impure > request->impureArea.getCount())
+			{
+				// impureArea does not automatically extend. Do it manually
+				request->impureArea.grow(csb->csb_impure);
+			}
 			fb_assert(tdbb->getRequest() == request);
 			executeCsbNode(tdbb, csb);
-
-			// Restore
-			memcpy(request->impureArea.begin(), backup.begin(), nodeImpureSize);
 		}
 	}
 	catch (const Exception& ex)

--- a/src/jrd/Package.epp
+++ b/src/jrd/Package.epp
@@ -197,7 +197,6 @@ dsc* ConstantValue::makeValue(thread_db* tdbb)
 
 		MET_parse_blob(tdbb, &name.schema, nullptr, &constantBid, &csb, nullptr, false, false);
 
-		// Came from Reload
 		handmadeStmt = Statement::makeStatement(tdbb, csb, true);
 		request = handmadeStmt->makeRootRequest(tdbb);
 
@@ -342,7 +341,7 @@ ScanResult Package::scan(thread_db* tdbb, ObjectBase::Flag flags)
 				skipMakeValue);
 
 			if (skipMakeValue)
-				this->m_callReload = true; // Value is necessary for to calculate hash
+				this->m_callReload = true;
 		}
 		END_FOR
 	}

--- a/src/jrd/Package.epp
+++ b/src/jrd/Package.epp
@@ -168,7 +168,7 @@ bid ConstantValue::getBlobId(thread_db* tdbb)
 	return m_blrBlobId.isEmpty() ? getConstantBid(tdbb, name) : m_blrBlobId;
 }
 
-dsc* ConstantValue::makeValue(thread_db* tdbb, Request* request)
+dsc* ConstantValue::makeValue(thread_db* tdbb)
 {
 	{
 		ReadLockGuard guard(m_makeValueLock, FB_FUNCTION);
@@ -184,6 +184,7 @@ dsc* ConstantValue::makeValue(thread_db* tdbb, Request* request)
 
 	MemoryPool* csb_pool = attachment->att_database->createPool();
 	Statement* handmadeStmt = nullptr;
+	Request* request = nullptr;
 	try
 	{
 		ContextPoolHolder context(tdbb, csb_pool);
@@ -195,46 +196,22 @@ dsc* ConstantValue::makeValue(thread_db* tdbb, Request* request)
 		bid constantBid = getBlobId(tdbb);
 
 		MET_parse_blob(tdbb, &name.schema, nullptr, &constantBid, &csb, nullptr, false, false);
-		if (request != nullptr)
-		{
-			// Allocate new impure data in a correct position
-			csb->csb_impure = request->impureArea.getCount();
-		}
 
-		fb_assert(csb->csb_node != nullptr);
-		csb->csb_node->pass1(tdbb, csb);
-		csb->csb_node->pass2(tdbb, csb);
+		// Came from Reload
+		handmadeStmt = Statement::makeStatement(tdbb, csb, true);
+		request = handmadeStmt->makeRootRequest(tdbb);
 
-		// request is null when this function called inside Package::scan (without MINISCAN)
-		// request is not null when this function called in PackageReferenceNode::execute
-		if (request == nullptr)
-		{
-			// Came from Reload
-			handmadeStmt = Statement::makeStatement(tdbb, csb, true);
-			request = handmadeStmt->makeRootRequest(tdbb);
+		AutoSetRestore2<Request*, thread_db> autoSetRequest(
+			tdbb, &thread_db::getRequest, &thread_db::setRequest, request);
 
-			AutoSetRestore2<Request*, thread_db> autoSetRequest(
-				tdbb, &thread_db::getRequest, &thread_db::setRequest, request);
+		request->setUsed();
+		request->setAttachment(attachment);
+		attachment->att_requests.add(request);
 
-			request->setUsed();
-			request->setAttachment(attachment);
-			attachment->att_requests.add(request);
+		TRA_attach_request(tdbb->getTransaction(), request);
 
-			TRA_attach_request(tdbb->getTransaction(), request);
-
-			// Execute it here, while AutoSetRestore2 is active
-			executeCsbNode(tdbb, csb);
-		}
-		else
-		{
-			if (csb->csb_impure > request->impureArea.getCount())
-			{
-				// impureArea does not automatically extend. Do it manually
-				request->impureArea.grow(csb->csb_impure);
-			}
-			fb_assert(tdbb->getRequest() == request);
-			executeCsbNode(tdbb, csb);
-		}
+		// Execute it while AutoSetRestore2 is active
+		executeCsbNode(tdbb, csb);
 	}
 	catch (const Exception& ex)
 	{
@@ -444,7 +421,7 @@ ConstantValue& Package::addConstant(thread_db* tdbb,
 	auto& value = constants.add(constName, isPrivate);
 	value.updateValue(blrBlobId);
 	if (!skipMakeValue)
-		value.makeValue(tdbb, nullptr);
+		value.makeValue(tdbb);
 
 	return value;
 }

--- a/src/jrd/Package.epp
+++ b/src/jrd/Package.epp
@@ -172,12 +172,12 @@ dsc* ConstantValue::makeValue(thread_db* tdbb, Request* request)
 {
 	{
 		ReadLockGuard guard(m_makeValueLock, FB_FUNCTION);
-		if (m_value.vlu_desc.dsc_dtype != dtype_unknown)
+		if (m_value.vlu_desc.dsc_address != nullptr)
 			return &m_value.vlu_desc;
 	}
 
 	WriteLockGuard guard(m_makeValueLock, FB_FUNCTION);
-	if (m_value.vlu_desc.dsc_dtype != dtype_unknown) // Extra check in case of two callers waiting
+	if (m_value.vlu_desc.dsc_address != nullptr) // Extra check in case of two callers waiting
 		return &m_value.vlu_desc;
 
 	Attachment* attachment = tdbb->getAttachment();
@@ -196,6 +196,8 @@ dsc* ConstantValue::makeValue(thread_db* tdbb, Request* request)
 
 		MET_parse_blob(tdbb, &name.schema, nullptr, &constantBid, &csb, nullptr, false, false);
 		fb_assert(csb->csb_node != nullptr);
+		csb->csb_node->pass1(tdbb, csb);
+		csb->csb_node->pass2(tdbb, csb);
 
 		if (request == nullptr)
 		{
@@ -216,7 +218,27 @@ dsc* ConstantValue::makeValue(thread_db* tdbb, Request* request)
 			executeCsbNode(tdbb, csb);
 		}
 		else
+		{
+			// A csb->csb_node will use impureArea from the incoming request
+			// but it contains other data
+			// Backup the current data and restore it later
+
+			// Reusing a small chunk is faster instead of makeing a new request
+			// And using existing space for a temporally value is better instead of adding this to request->impureArea
+			// and carrying it for whole request live
+
+			const auto nodeImpureSize = csb->csb_impure;
+			if (request->impureArea.getCount() < nodeImpureSize)
+				request->impureArea.grow(nodeImpureSize - request->impureArea.getCount());
+
+			const Array<UCHAR> backup(request->impureArea.begin(), nodeImpureSize);
+
+			fb_assert(tdbb->getRequest() == request);
 			executeCsbNode(tdbb, csb);
+
+			// Restore
+			memcpy(request->impureArea.begin(), backup.begin(), nodeImpureSize);
+		}
 	}
 	catch (const Exception& ex)
 	{

--- a/src/jrd/Package.h
+++ b/src/jrd/Package.h
@@ -83,7 +83,7 @@ public:
 
 	bid getBlobId(thread_db* tdbb);
 
-	dsc* makeValue(thread_db* tdbb, Request* request);
+	dsc* makeValue(thread_db* tdbb);
 
 private:
 	void executeCsbNode(thread_db* tdbb, CompilerScratch* csb);

--- a/src/jrd/Package.h
+++ b/src/jrd/Package.h
@@ -73,6 +73,7 @@ public:
 		delete m_value.vlu_string;
 		m_value = {};
 		m_value.vlu_desc = typeDesc;
+		m_value.vlu_desc.dsc_address = nullptr; // Make sure to call makeValue
 	}
 
 	void updateValue(const bid blobId)


### PR DESCRIPTION
Original report: https://groups.google.com/g/firebird-devel/c/uPpRhaAKT0M

In the `makeValue` function, the value is compiled only once and then cached. Previously, the `dsc_address`  was always present, but now it is not required for calculating the hash, so it may be missing. This leads to null pointer read/write.

The second issue is related with `request impure space`. First, the calls to `pass1` and `pass2` were missing, leading to invalid addresses being used. Second, using an existing request, its impure will be corrupt. So, it should be restored after the node is executed.

SQL to reproduce:
```sql
shell rm -rf /tmp/test.fdb;
create database ' /tmp/test.fdb';

set bail on;
set list on;
set autoterm on;
set autoddl off;
set keep_tran on;


recreate package pg_test as
begin
    procedure sp_test() returns(o smallint);
end;

recreate package body pg_test as
begin
    constant PG_BODY_CONST smallint = -10;
    procedure sp_test() returns(o smallint) as
    begin
        o = pg_body_const;
        suspend;
    end
end
;
commit;

select p.o as get_pkg_head_const_1  from pg_test.sp_test as p rows 1; -- segfault
```