### PR TITLE
Fix non-virtual destructor in TraceDescriptors

### DIFF
--- a/src/jrd/trace/TraceObjects.h
+++ b/src/jrd/trace/TraceObjects.h
@@ -545,7 +545,7 @@ public:
 	{}
 
 protected:
-	void fillParams();
+	void fillParams() override;
 
 private:
 	Request* const m_request;
@@ -563,7 +563,7 @@ public:
 	{}
 
 protected:
-	void fillParams();
+	void fillParams() override;
 
 private:
 	const Format* const m_format;
@@ -587,7 +587,7 @@ public:
 	}
 
 protected:
-	void fillParams() {}
+	void fillParams() override {}
 };
 
 

--- a/src/jrd/trace/TraceObjects.h
+++ b/src/jrd/trace/TraceObjects.h
@@ -503,6 +503,8 @@ public:
 	{
 	}
 
+	virtual ~TraceDescriptors() = default;
+
 	FB_SIZE_T getCount()
 	{
 		fillParams();


### PR DESCRIPTION
Problem

`TraceDescriptors` declares a pure virtual method (`fillParams()`) and
is inherited by several derived classes (`TraceDscFromValues`,
`TraceDscFromMsg`, `TraceDscFromDsc`), but its destructor was not
virtual. Deleting a derived object through a `TraceDescriptors*`
pointer would result in undefined behavior, since the derived class's
destructor would not be called.

Fix

Added an explicit `virtual ~TraceDescriptors() = default;` destructor.