### PR TITLE
First variant of depends tracking - works only for procedures

### DIFF
--- a/src/common/classes/array.h
+++ b/src/common/classes/array.h
@@ -169,7 +169,6 @@ public:
 		count = 0;
 	}
 
-protected:
 	const T& getElement(size_type index) const noexcept
 	{
   		fb_assert(index < count);
@@ -182,6 +181,7 @@ protected:
   		return data[index];
 	}
 
+protected:
 	void freeData() noexcept
 	{
 		// CVC: Warning, after this call, "data" is an invalid pointer, be sure to reassign it

--- a/src/dsql/DsqlRequests.cpp
+++ b/src/dsql/DsqlRequests.cpp
@@ -553,6 +553,8 @@ void DsqlDmlRequest::doExecute(thread_db* tdbb, jrd_tra** traHandle,
 	firstRowFetched = false;
 	const dsql_msg* message = dsqlStatement->getSendMsg();
 
+	req_transaction->processUpdates(tdbb);
+
 	if (!message)
 	{
 		JRD_start(tdbb, request, req_transaction);

--- a/src/jrd/CacheVector.h
+++ b/src/jrd/CacheVector.h
@@ -108,7 +108,7 @@ public:
 	}
 
 	// fill dependencies info
-	void fillDeps(thread_db* tdbb);
+	void fillDeps(thread_db* tdbb, bool forceRecompile);
 
 private:
 	Lock* lock = nullptr;
@@ -1018,7 +1018,7 @@ private:
 	void toUpdatedList(thread_db* tdbb, ObjectBase::Flag fl)
 	{
 		if (fl & CacheFlag::DEPENDS)
-			ElementBase::fillDeps(tdbb);
+			ElementBase::fillDeps(tdbb, true);
 	}
 
 private:

--- a/src/jrd/CacheVector.h
+++ b/src/jrd/CacheVector.h
@@ -40,6 +40,7 @@
 #include "../jrd/constants.h"
 #include "../jrd/tra_proto.h"
 #include "../jrd/QualifiedName.h"
+#include "../jrd/obj.h"
 
 namespace Jrd {
 
@@ -87,6 +88,13 @@ public:
 
 	virtual ~ElementBase();
 	virtual void cleanup(thread_db* tdbb) = 0;
+	virtual ObjectType getObjectType() = 0;
+	virtual void getObjectName(QualifiedName& name) = 0;
+	virtual void newVersion(thread_db* tdbb) = 0;
+	virtual bool ensureVersioned(thread_db* tdbb, ObjectBase::Flag fl) = 0;
+	virtual void makeRequests(thread_db* tdbb) = 0;
+	virtual void commit(thread_db* tdbb, TraNumber curNumber = 0) = 0;
+	virtual MdcVersion getVersion(thread_db* tdbb) = 0;
 
 public:
 	[[noreturn]] void busyError(thread_db* tdbb, MetaId id, const char* family);
@@ -98,6 +106,9 @@ public:
 	{
 		return locked;
 	}
+
+	// fill dependencies info
+	void fillDeps(thread_db* tdbb);
 
 private:
 	Lock* lock = nullptr;
@@ -163,11 +174,17 @@ class ListEntry : public HazardObject
 public:
 	enum State { INITIAL, RELOAD, MISSING, SCANNING, READY };
 
-	ListEntry(Versioned* object, TraNumber traNumber, ObjectBase::Flag fl, ListEntry* link = nullptr)
+	ListEntry(thread_db* tdbb, Versioned* object, TraNumber traNumber, ObjectBase::Flag fl, ListEntry* link = nullptr)
 		: object(object), traNumber(traNumber), cacheFlags(fl), state(INITIAL)
 	{
 		if (fl & CacheFlag::ERASED)
 			fb_assert(!object);
+
+		// Handle front & back versions of MDC
+		VersionIncr incr(tdbb);
+		version = incr.getVersion();
+
+		// Add to linked list
 		if (link)
 			next.store(link);
 	}
@@ -550,19 +567,9 @@ public:
 		return state == READY ? false : (thd == Thread::getCurrentThreadId()) && (state == SCANNING);
 	}
 
-	static bool upgradable(HazardPtr<ListEntry>& listEntry, const Versioned* from)
+	MdcVersion getVersion()
 	{
-		for (; listEntry; listEntry.set(listEntry->next))
-		{
-			if (listEntry->object == from)
-				return false;		// not found upgrade version
-
-			if (listEntry->getFlags() & CacheFlag::COMMITTED)
-				return true;		// already upgraded by someone else
-		}
-
-		fb_assert(false);
-		return false;				// miss from what to upgrade
+		return version;
 	}
 
 private:
@@ -582,7 +589,6 @@ private:
 	TraNumber traNumber;		// when COMMITTED not set - stores transaction that created this list element
 								// when COMMITTED is set - stores transaction after which older elements are not needed
 								// traNumber to be changed BEFORE setting COMMITTED
-
 	MdcVersion version = 0;		// version of metadata cache when object was added
 	ThreadId thd = 0;			// thread that performs object scan()
 	std::atomic<ObjectBase::Flag> cacheFlags;
@@ -677,6 +683,11 @@ public:
 		return getVersioned(tdbb, TransactionNumber::current(tdbb), fl);
 	}
 
+	bool ensureVersioned(thread_db* tdbb, ObjectBase::Flag fl) override
+	{
+		return getVersioned(tdbb, fl);
+	}
+
 	bool isReady(thread_db* tdbb)
 	{
 		auto entry = getEntry(tdbb, TransactionNumber::current(tdbb), CacheFlag::NOSCAN | CacheFlag::NOCOMMIT);
@@ -748,7 +759,7 @@ public:
 			ListEntry<Versioned>* newEntry = nullptr;
 			try
 			{
-				newEntry = FB_NEW ListEntry<Versioned>(obj, traNum, fl & ~CacheFlag::ERASED);
+				newEntry = FB_NEW ListEntry<Versioned>(tdbb, obj, traNum, fl & ~CacheFlag::ERASED);
 			}
 			catch (const Firebird::Exception&)
 			{
@@ -776,6 +787,7 @@ public:
 					return listEntry;	// nullptr
 				}
 
+				toUpdatedList(tdbb, fl);
 				return HazardPtr<ListEntry<Versioned>>(newEntry);
 			}
 
@@ -784,7 +796,9 @@ public:
 			fb_assert(list.load());
 			listEntry = list;
 		}
+
 		fl &= ~CacheFlag::AUTOCREATE;
+		toUpdatedList(tdbb, fl);
 		return ListEntry<Versioned>::getEntry(tdbb, listEntry, traNum, fl, this);
 	}
 
@@ -812,7 +826,7 @@ public:
 
 		if (!cur)
 			cur = TransactionNumber::current(tdbb);
-		ListEntry<Versioned>* newEntry = FB_NEW ListEntry<Versioned>(obj, cur, fl);
+		ListEntry<Versioned>* newEntry = FB_NEW ListEntry<Versioned>(tdbb, obj, cur, fl);
 		if (!ListEntry<Versioned>::add(tdbb, list, newEntry))
 		{
 			newEntry->cleanup(tdbb, false);
@@ -867,15 +881,15 @@ public:
 		return nullptr;
 	}
 
-	void commit(thread_db* tdbb, TraNumber cur = 0)
+	void commit(thread_db* tdbb, TraNumber curNumber = 0) override
 	{
 		HazardPtr<ListEntry<Versioned>> current(list);
 		if (current)
 		{
-			if (!cur)
-				cur = TransactionNumber::current(tdbb);
+			if (!curNumber)
+				curNumber = TransactionNumber::current(tdbb);
 
-			auto flags = current->commit(tdbb, cur, TransactionNumber::next(tdbb));
+			auto flags = current->commit(tdbb, curNumber, TransactionNumber::next(tdbb));
 
 			if (flags & CacheFlag::NOCOMMIT)	// Committed newly created version in cache
 				pingLock(tdbb, flags, this->getId(), Versioned::objectFamily(this));
@@ -938,12 +952,17 @@ public:
 		return listEntry->scanInProgress();
 	}
 
-	static int getObjectType()
+	ObjectType getObjectType() override
 	{
 		return Versioned::objectType();
 	}
 
-	void newVersion(thread_db* tdbb)
+	void getObjectName(QualifiedName& name) override
+	{
+		name = this->getName();
+	}
+
+	void newVersion(thread_db* tdbb) override
 	{
 		TraNumber traNum;
 
@@ -967,41 +986,25 @@ public:
 		}
 	}
 
-	bool upgrade(thread_db* tdbb, const Versioned* from)
-	{
-		HazardPtr<ListEntry<Versioned>> l(list);
-
-		// list of versions should be present
-		fb_assert(l);
-		if (!l)
-			return false;
-
-		// if there is another version at the top nothing to be added
-		if (l->getVersioned() != from)
-			return ListEntry<Versioned>::upgradable(l, from);
-
-		// we have candidate for upgrade - make sure it's not half-done
-		fb_assert(l->getFlags() & CacheFlag::COMMITTED);
-		if (!(l->getFlags() & CacheFlag::COMMITTED))
-			return false;
-
-		// Try to upgrade
-		ListEntry<Versioned>* newEntry = FB_NEW ListEntry<Versioned>(nullptr, TransactionNumber::current(tdbb),
-			CacheFlag::COMMITTED | CacheFlag::MINISCAN | CacheFlag::DB_VERSION, l.getPointer());
-		if (l.replace(list, newEntry))
-			return true;
-
-		// undo changes
-		delete newEntry;
-
-		// Someone already added entry - see is it OK for us
-		l.set(list);
-		return ListEntry<Versioned>::upgradable(l, from);
-	}
-
 	bool nameIs(const QualifiedName& name)
 	{
 		return this->getName() == name;
+	}
+
+	// This is needed to check correctness of statements present in current object's version
+	void makeRequests(thread_db* tdbb) override
+	{
+		Versioned* v = getVersioned(tdbb, CacheFlag::AUTOCREATE);
+		if (!v)
+			return;
+
+		v->makeRequests(tdbb);
+	}
+
+	MdcVersion getVersion(thread_db* tdbb) override
+	{
+		auto entry = getEntry(tdbb, TransactionNumber::current(tdbb), CacheFlag::NOSCAN | CacheFlag::NOCOMMIT);
+		return entry ? entry->getVersion() : 0;
 	}
 
 private:
@@ -1009,6 +1012,13 @@ private:
 	{
 		resetAt.compare_exchange_strong(oldVal, newVal,
 			atomics::memory_order_release, atomics::memory_order_relaxed);
+	}
+
+	// Check flags and may be fill dependencies info
+	void toUpdatedList(thread_db* tdbb, ObjectBase::Flag fl)
+	{
+		if (fl & CacheFlag::DEPENDS)
+			ElementBase::fillDeps(tdbb);
 	}
 
 private:
@@ -1209,28 +1219,6 @@ public:
 		StoredElement* data = ensurePermanent(tdbb, id);
 		data->newVersion(tdbb);
 		return data;
-	}
-
-	bool upgrade(thread_db* tdbb, MetaId id, const Versioned* from)
-	{
-		fb_assert(id < getCount());
-
-		if (id < getCount())
-		{
-			auto ptr = getDataPointer(id);
-			fb_assert(ptr);
-
-			if (ptr)
-			{
-				StoredElement* data = ptr->load(atomics::memory_order_acquire);
-				fb_assert(data);
-
-				if (data)
-					return data->upgrade(tdbb, from);
-			}
-		}
-
-		return false;
 	}
 
 	bool lookup(thread_db* tdbb, const QualifiedName& name, ObjectBase::Flag fl,

--- a/src/jrd/CharSetContainer.h
+++ b/src/jrd/CharSetContainer.h
@@ -134,6 +134,8 @@ public:
 
 	static ObjectType objectType() noexcept;
 
+	void makeRequests(thread_db* tdbb) { }
+
 	bool hash(thread_db*, Firebird::sha512&)
 	{
 		return true;

--- a/src/jrd/Function.h
+++ b/src/jrd/Function.h
@@ -71,7 +71,7 @@ namespace Jrd
 		}
 
 	public:
-		int getObjectType() const noexcept override
+		ObjectType getObjectType() const noexcept override
 		{
 			return objectType();
 		}

--- a/src/jrd/Package.h
+++ b/src/jrd/Package.h
@@ -214,7 +214,7 @@ public:
 		return getPermanent()->id;
 	}
 
-	int getObjectType() const noexcept
+	ObjectType getObjectType() const noexcept
 	{
 		return objectType();
 	}
@@ -225,6 +225,8 @@ public:
 	}
 
 	static ObjectType objectType() noexcept;
+
+	void makeRequests(thread_db* tdbb) {/*!!!!!!!!!!!!!!!*/}
 
 	bool hash(thread_db* tdbb, Firebird::sha512& digest);
 

--- a/src/jrd/Relation.h
+++ b/src/jrd/Relation.h
@@ -254,6 +254,8 @@ public:
 
 	static ObjectType objectType() noexcept;
 
+	void makeRequests(thread_db* tdbb) {/*!!!!!!!!!!!!!!!*/}
+
 private:
 	DbTriggersHeader* perm;
 
@@ -565,6 +567,8 @@ public:
 	static std::optional<MetaId> getIdByName(thread_db* tdbb, ExName<RelationPermanent*> name);
 	static ObjectType objectType() noexcept;
 
+	void makeRequests(thread_db* tdbb) {/*!!!!!!!!!!!!!!!*/}
+
 	ScanResult reload(thread_db* tdbb, ObjectBase::Flag flags)
 	{
 		return scan(tdbb, flags);
@@ -692,6 +696,8 @@ public:
 
 	static const char* objectFamily(RelationPermanent* perm);
 	static ObjectType objectType() noexcept;
+
+	void makeRequests(thread_db* tdbb) {/*!!!!!!!!!!!!!!!*/}
 
 	void releaseTriggers(thread_db* tdbb, bool destroy);
 	const Trigger* findTrigger(const QualifiedName& trig_name) const;

--- a/src/jrd/Routine.cpp
+++ b/src/jrd/Routine.cpp
@@ -233,6 +233,13 @@ void Routine::parseMessages(thread_db* tdbb, CompilerScratch* csb, BlrReader blr
 	}
 }
 
+void Routine::makeRequests(thread_db* tdbb)
+{
+	auto *req = statement->findRequest(tdbb);
+	if (req)
+		req->setUnused();
+}
+
 bool Routine::hash(thread_db* tdbb, Firebird::sha512& digest)
 {
 	if (inputFields.hasData())

--- a/src/jrd/Routine.h
+++ b/src/jrd/Routine.h
@@ -169,9 +169,11 @@ namespace Jrd
 
 		void sharedCheckUnlock(thread_db* tdbb);
 
+		void makeRequests(thread_db* tdbb);
+
 	public:
 		virtual RoutinePermanent* getPermanent() const noexcept = 0;	// Permanent part of data
-		virtual int getObjectType() const noexcept = 0;
+		virtual ObjectType getObjectType() const noexcept = 0;
 		virtual SLONG getSclType() const noexcept = 0;
 
 	private:

--- a/src/jrd/dfw.epp
+++ b/src/jrd/dfw.epp
@@ -421,6 +421,7 @@ static bool clear_cache(thread_db*, SSHORT, DeferredWork*, jrd_tra*);
 static bool change_repl_state(thread_db*, SSHORT, DeferredWork*, jrd_tra*);
 static bool set_statistics(thread_db*, SSHORT, DeferredWork*, jrd_tra*);
 static bool deps_to_disk(thread_db*, SSHORT, DeferredWork*, jrd_tra*);
+static bool update_dependencies(thread_db*, SSHORT, DeferredWork*, jrd_tra*);
 
 // ----------------------------------------------------------------
 
@@ -1228,6 +1229,7 @@ static inline constexpr deferred_task task_table[] =
 	{ dfw_modify_package_constant, createOrAlterConstant },
 	{ dfw_delete_package_constant, deleteConstant },
 	{ dfw_create_package, createPackage },
+	{ dfw_update_dependencies, update_dependencies },			// must be last
 
 	{ dfw_null, NULL }
 };
@@ -3473,6 +3475,46 @@ static bool delete_collation(thread_db* tdbb, SSHORT phase, DeferredWork* work, 
 }
 
 
+static bool update_dependencies(thread_db* tdbb, SSHORT phase, DeferredWork* work, jrd_tra* transaction)
+{
+/*******************************************
+ *
+ *	u p d a t e _ d e p e n d e n c i e s
+ *
+ *******************************************
+ *
+ * Functional description
+ *	Update dependent from changed in this transaction objects
+ *	and commit them at specific DFW phase.
+ *
+ **************************************/
+	SET_TDBB(tdbb);
+
+	switch (phase)
+	{
+	case 0:
+		return false;
+
+	case 1:
+	case 2:
+	case 3:
+	case 4:
+	case 5:
+		return true;
+
+	case 6:
+		transaction->processUpdates(tdbb);
+		return true;
+
+	case 7:
+		transaction->processCommits(tdbb);
+		break;
+	}
+
+	return false;
+}
+
+
 static bool delete_parameter(thread_db* tdbb, SSHORT phase, DeferredWork*, jrd_tra*)
 {
 /**************************************
@@ -3530,12 +3572,7 @@ static bool create_index(thread_db* tdbb, SSHORT phase, DeferredWork* work, jrd_
  *	Create a new index or change the state of an index between active/inactive.
  *
  **************************************/
-	jrd_rel* relation = nullptr;
-
 	SET_TDBB(tdbb);
-	Jrd::Attachment* attachment = tdbb->getAttachment();
-	Database* dbb = tdbb->getDatabase();
-	AutoRequest request;
 
 	switch (phase)
 	{

--- a/src/jrd/met.epp
+++ b/src/jrd/met.epp
@@ -5656,3 +5656,52 @@ jrd_rel* MetadataCache::getLtt(thread_db* tdbb, const QualifiedName& name)
 
 	return nullptr;
 }
+
+
+void ElementBase::fillDeps(thread_db* tdbb)
+{
+	auto* attachment = tdbb->getAttachment();
+	auto* metaTransaction = attachment->getMetaTransaction(tdbb);
+	auto* transaction = tdbb->getTransaction();
+
+	ObjectType objType = getObjectType();
+	QualifiedName name;
+	getObjectName(name);
+
+	MetaName object = name.object;
+	if (name.package.hasData())
+	{
+		objType = obj_package_header;
+		object = name.package;
+	}
+
+	AUTO_HANDLE(hndl);
+
+	FOR (REQUEST_HANDLE hndl TRANSACTION_HANDLE metaTransaction)
+		D IN RDB$DEPENDENCIES
+		WITH D.RDB$DEPENDED_ON_TYPE EQ objType
+		 AND D.RDB$DEPENDED_ON_SCHEMA_NAME EQ name.schema.c_str()
+		 AND D.RDB$DEPENDED_ON_NAME EQ object.c_str()
+		REDUCED TO D.RDB$DEPENDENT_TYPE, D.RDB$DEPENDENT_SCHEMA_NAME, D.RDB$PACKAGE_NAME, D.RDB$DEPENDENT_NAME
+	{
+		switch (D.RDB$DEPENDENT_TYPE)
+		{
+		case obj_procedure:
+			{
+				QualifiedName name;
+				name.schema = D.RDB$DEPENDENT_SCHEMA_NAME;
+				if (!D.RDB$PACKAGE_NAME.NULL)
+					name.package = D.RDB$PACKAGE_NAME;
+				name.object = D.RDB$DEPENDENT_NAME;
+
+				transaction->storeUpdate(MetadataCache::getPerm<Cached::Procedure>(tdbb, name, CacheFlag::AUTOCREATE));
+			}
+			break;
+
+		default:
+			break;
+		}
+	}
+	END_FOR
+}
+

--- a/src/jrd/met.epp
+++ b/src/jrd/met.epp
@@ -5658,7 +5658,7 @@ jrd_rel* MetadataCache::getLtt(thread_db* tdbb, const QualifiedName& name)
 }
 
 
-void ElementBase::fillDeps(thread_db* tdbb)
+void ElementBase::fillDeps(thread_db* tdbb, bool forceRecompile)
 {
 	auto* attachment = tdbb->getAttachment();
 	auto* metaTransaction = attachment->getMetaTransaction(tdbb);
@@ -5694,7 +5694,7 @@ void ElementBase::fillDeps(thread_db* tdbb)
 					name.package = D.RDB$PACKAGE_NAME;
 				name.object = D.RDB$DEPENDENT_NAME;
 
-				transaction->storeUpdate(MetadataCache::getPerm<Cached::Procedure>(tdbb, name, CacheFlag::AUTOCREATE));
+				transaction->storeUpdate(MetadataCache::getPerm<Cached::Procedure>(tdbb, name, CacheFlag::AUTOCREATE), forceRecompile);
 			}
 			break;
 

--- a/src/jrd/met.h
+++ b/src/jrd/met.h
@@ -141,7 +141,7 @@ public:
 	}
 
 public:
-	int getObjectType() const noexcept override
+	ObjectType getObjectType() const noexcept override
 	{
 		return obj_procedure;
 	}

--- a/src/jrd/tra.cpp
+++ b/src/jrd/tra.cpp
@@ -4454,7 +4454,7 @@ void jrd_tra::eraseSecDbContext() noexcept
 	tra_sec_db_context = NULL;
 }
 
-void jrd_tra::storeUpdate(ElementBase* obj)
+void jrd_tra::storeUpdate(ElementBase* obj, bool forceRecompile)
 {
 	if (!accumulatedDeps)
 	{
@@ -4462,8 +4462,14 @@ void jrd_tra::storeUpdate(ElementBase* obj)
 		DFW_post_work(this, dfw_update_dependencies, nullptr, nullptr, 0u);
 	}
 
-	if (!accumulatedDeps->locate(obj))
-		accumulatedDeps->add(obj);
+	bool* recompile = accumulatedDeps->get(obj);
+	if (recompile)
+		*recompile = forceRecompile || *recompile;
+	else
+	{
+		recompile = accumulatedDeps->put(obj);
+		*recompile = forceRecompile;
+	}
 }
 
 void jrd_tra::storeCommit(ElementBase* obj)
@@ -4492,29 +4498,37 @@ bool jrd_tra::processUpdates(thread_db* tdbb)
 			processingDeps = accumulatedDeps.release();
 
 		// process updates
-		for(auto run = processingDeps->getFirst(); run; run = processingDeps->getNext())
+		for(auto iter : *processingDeps)
 		{
-			auto* elem = processingDeps->current();
+			auto* elem = iter.first;
+			bool use = iter.second;
 
 			// may be this element was already processed in this update?
 			if (elem->getVersion(tdbb) >= startingVersion)
 				continue;
 
-			// now ask cache element to create all possible requests
-			try
+			if (!use)
 			{
-				elem->makeRequests(tdbb);
+				// now ask cache element to create all possible requests
+				try
+				{
+					elem->makeRequests(tdbb);
+				}
+
+				// handle specific for outdated element error
+				catch (const status_exception& ex)
+				{
+					if (ex.value()[1] != isc_old_format)
+						throw;
+					tdbb->tdbb_status_vector->init();
+					use = true;
+				}
 			}
 
-			// handle specific for outdated element error
-			catch (const status_exception& ex)
+			if (use)
 			{
-				if (ex.value()[1] != isc_old_format)
-					throw;
-				tdbb->tdbb_status_vector->init();
-
 				// get all existing currently dependencies
-				elem->fillDeps(tdbb);
+				elem->fillDeps(tdbb, false);
 
 				// make new version and compile it
 				elem->newVersion(tdbb);

--- a/src/jrd/tra.cpp
+++ b/src/jrd/tra.cpp
@@ -4453,3 +4453,103 @@ void jrd_tra::eraseSecDbContext() noexcept
 	delete tra_sec_db_context;
 	tra_sec_db_context = NULL;
 }
+
+void jrd_tra::storeUpdate(ElementBase* obj)
+{
+	if (!accumulatedDeps)
+	{
+		accumulatedDeps = FB_NEW_POOL(getPool()) Deps(getPool());
+		DFW_post_work(this, dfw_update_dependencies, nullptr, nullptr, 0u);
+	}
+
+	if (!accumulatedDeps->locate(obj))
+		accumulatedDeps->add(obj);
+}
+
+void jrd_tra::storeCommit(ElementBase* obj)
+{
+	if (!updateCommits)
+		updateCommits = FB_NEW_POOL(getPool()) UpdateCommits(getPool());
+
+	updateCommits->push(obj);
+}
+
+bool jrd_tra::processUpdates(thread_db* tdbb)
+{
+	if (!(accumulatedDeps || processingDeps))
+		return false;
+
+	MdcVersion startingVersion;
+	{
+		VersionIncr incr(tdbb);
+		startingVersion = incr.getVersion();
+	}
+
+	while (accumulatedDeps || processingDeps)
+	{
+		// switch deps
+		if (!processingDeps)
+			processingDeps = accumulatedDeps.release();
+
+		// process updates
+		for(auto run = processingDeps->getFirst(); run; run = processingDeps->getNext())
+		{
+			auto* elem = processingDeps->current();
+
+			// may be this element was already processed in this update?
+			if (elem->getVersion(tdbb) >= startingVersion)
+				continue;
+
+			// now ask cache element to create all possible requests
+			try
+			{
+				elem->makeRequests(tdbb);
+			}
+
+			// handle specific for outdated element error
+			catch (const status_exception& ex)
+			{
+				if (ex.value()[1] != isc_old_format)
+					throw;
+				tdbb->tdbb_status_vector->init();
+
+				// get all existing currently dependencies
+				elem->fillDeps(tdbb);
+
+				// make new version and compile it
+				elem->newVersion(tdbb);
+				auto rc = elem->ensureVersioned(tdbb, 0);
+				fb_assert(rc);
+
+				storeCommit(elem);
+			}
+		}
+
+		// This portion of update is ready
+		delete processingDeps.release();
+	}
+
+	return true;
+}
+
+void jrd_tra::processCommits(thread_db* tdbb)
+{
+	if (!updateCommits)
+		return;
+
+	unsigned pos = 0;
+	try
+	{
+		for (pos = 0; pos < updateCommits->getCount(); pos++)
+			updateCommits->getElement(pos)->commit(tdbb);
+	}
+	catch(const Exception&)
+	{
+		// We do not expect exceptions in metacache commits - but
+		// already committed elements should better go away
+		if (pos > 0)
+			updateCommits->removeRange(0, pos);
+
+		throw;
+	}
+}

--- a/src/jrd/tra.h
+++ b/src/jrd/tra.h
@@ -35,6 +35,8 @@
 #include "../include/fb_blk.h"
 #include "../common/classes/tree.h"
 #include "../common/classes/GenericMap.h"
+#include "../common/classes/auto.h"
+#include "../common/classes/array.h"
 #include "../jrd/exe.h"
 #include "../jrd/rpb_chain.h"
 #include "../jrd/blb.h" // For bid structure
@@ -430,6 +432,26 @@ public:
 
 	// Finish and delete BulkInsert that belongs to the request
 	void finiBulkInsert(thread_db* tdbb, Request* request);
+
+	// Store an object to be updated
+	void storeUpdate(ElementBase* obj);
+
+	// Store an object to be updated
+	void storeCommit(ElementBase* obj);
+
+	// Process updates/commits accumulated by transaction
+	bool processUpdates(thread_db* tdbb);
+	void processCommits(thread_db* tdbb);
+
+private:
+	// Under processing and accumulated sets of dependencies
+	typedef Firebird::BePlusTree<ElementBase*> Deps;
+	Firebird::AutoPtr<Deps> processingDeps;
+	Firebird::AutoPtr<Deps> accumulatedDeps;
+
+	// Set of updated objects to be committed
+	typedef Firebird::HalfStaticArray<ElementBase*, 64> UpdateCommits;
+	Firebird::AutoPtr<UpdateCommits> updateCommits;
 };
 
 // System transaction is always transaction 0.
@@ -574,7 +596,10 @@ enum dfw_t : int {
 	dfw_delete_package_constant,
 
 	// Package
-	dfw_create_package
+	dfw_create_package,
+
+	// Update various objects dependent from modified in this transaction
+	dfw_update_dependencies
 };
 
 } //namespace Jrd

--- a/src/jrd/tra.h
+++ b/src/jrd/tra.h
@@ -434,9 +434,9 @@ public:
 	void finiBulkInsert(thread_db* tdbb, Request* request);
 
 	// Store an object to be updated
-	void storeUpdate(ElementBase* obj);
+	void storeUpdate(ElementBase* obj, bool forceRecompile);
 
-	// Store an object to be updated
+	// Store updated object to be committed
 	void storeCommit(ElementBase* obj);
 
 	// Process updates/commits accumulated by transaction
@@ -445,7 +445,7 @@ public:
 
 private:
 	// Under processing and accumulated sets of dependencies
-	typedef Firebird::BePlusTree<ElementBase*> Deps;
+	typedef Firebird::GenericMap<Firebird::NonPooledPair<ElementBase*, bool>> Deps;
 	Firebird::AutoPtr<Deps> processingDeps;
 	Firebird::AutoPtr<Deps> accumulatedDeps;
 


### PR DESCRIPTION
I present for early review solution that should solve some "regressions" with new metadata cache. Word regressions is quoted cause pre-fb6 some specific changes in database (like changed number of output procedure parameters) under some circumstances kept dependent objects working correctly without recompile of that dependent objects. That was pure lucky cases among other failing - but people used that and do not get format outdated error instead. 

The overall idea is simple - if one needs to do some breaking changes in a set of objects (currently only procedures but others will work in same manner) this can be done in single transaction and everything needed will be recompiled on commit. Certainly that commit fails if compilation fails - but one can fix errors and repeat commit.

This PR is not ready for merge yet (all objects to be taken into an account) - but one who interested can play with procedures right now.