### PR TITLE
Improve database creation performance

### DIFF
--- a/src/jrd/dfw.epp
+++ b/src/jrd/dfw.epp
@@ -3412,7 +3412,12 @@ static bool commit_charset(thread_db* tdbb, SSHORT phase, DeferredWork* work, jr
 
 	case 7:
 		{
-			auto* cs = MetadataCache::getPerm<Cached::CharSet>(tdbb, id, 0);
+			// ASF: During database creation there is no need to force loading of
+			// all system collations - they are not used yet and will be loaded on
+			// demand later.
+			const bool creating = tdbb->getDatabase()->dbb_flags & DBB_creating;
+			auto* cs = MetadataCache::getPerm<Cached::CharSet>(tdbb, id,
+				(creating ? CacheFlag::NOSCAN : 0));
 			fb_assert(cs);
 			if (cs)
 				cs->commit(tdbb);


### PR DESCRIPTION
TCS (release build):
- Before shared metadata cache (5a65d481dab873ed61de057a9c95a6775984784e): 2m35
- Today master: 3m13 (24.5% increase time over 5a65d481dab873ed61de057a9c95a6775984784e)
- This PR: 2m58 (7.8% improvement over master)

20x database creation test (release build):
- Before shared metadata cache (5a65d481dab873ed61de057a9c95a6775984784e): 825ms
- Today master: 2339ms (183.5% increase time over 5a65d481dab873ed61de057a9c95a6775984784e)
- This PR: 1915ms (22.1% improvement over master)