### PR TITLE
Feature #2629 : Ability to specify length for index segments to be indexed on char-based columns

### DIFF
--- a/builds/win32/msvc15/engine_static.vcxproj
+++ b/builds/win32/msvc15/engine_static.vcxproj
@@ -297,6 +297,7 @@
     <ClInclude Include="..\..\..\src\jrd\ibsetjmp.h" />
     <ClInclude Include="..\..\..\src\jrd\idx.h" />
     <ClInclude Include="..\..\..\src\jrd\idx_proto.h" />
+    <ClInclude Include="..\..\..\src\jrd\IndexSegment.h" />
     <ClInclude Include="..\..\..\src\jrd\inf_proto.h" />
     <ClInclude Include="..\..\..\src\include\firebird\impl\inf_pub.h" />
     <ClInclude Include="..\..\..\src\jrd\ini.h" />

--- a/builds/win32/msvc15/engine_static.vcxproj.filters
+++ b/builds/win32/msvc15/engine_static.vcxproj.filters
@@ -564,6 +564,7 @@
     <ClCompile Include="..\..\..\src\jrd\Resources.cpp">
       <Filter>JRD files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\gen\jrd\Package.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\src\jrd\recsrc\RecordSource.h">
@@ -1162,6 +1163,9 @@
       <Filter>Header files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\jrd\os\pio_proto.h">
+      <Filter>Header files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\jrd\IndexSegment.h">
       <Filter>Header files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/burp/backup.epp
+++ b/src/burp/backup.epp
@@ -1726,6 +1726,9 @@ void put_index( burp_rel* relation)
 				SORTED BY Y.RDB$FIELD_POSITION
 			{
 				PUT_TEXT (att_index_field_name, Y.RDB$FIELD_NAME);
+
+				if (!Y.RDB$CHARACTER_LENGTH.NULL && Y.RDB$CHARACTER_LENGTH)
+					put_int32 (att_index_field_char_length, Y.RDB$CHARACTER_LENGTH);
 			}
 			END_FOR
 			ON_ERROR

--- a/src/burp/burp.h
+++ b/src/burp/burp.h
@@ -223,6 +223,9 @@ Version 12: FB6.0.
 			RDB$INDICES.RDB$PACKAGE_NAME and
 			RDB$INDEX_SEGMENTS.RDB$PACKAGE_NAME.
 
+			Optional length for index segments:
+			RDB$INDEX_SEGMENTS.RDB$CHARACTER_LENGTH
+
 			Custom aggregate function.
 */
 
@@ -382,6 +385,7 @@ enum att_type {
 	att_index_condition_source,
 	att_index_condition_blr,
 	att_index_foreign_key_schema_name,
+	att_index_field_char_length,	// length of segment in characters, optional
 
 	// Data record
 

--- a/src/burp/restore.epp
+++ b/src/burp/restore.epp
@@ -6777,6 +6777,19 @@ bool get_index(BurpGlobals* tdgbl, const burp_rel* relation)
 
 	SSHORT count = 0, segments = 0;
 
+	struct IndexSegment
+	{
+		IndexSegment(MemoryPool& pool) :
+			name(pool)
+		{
+		}
+
+		string name;
+		int length = 0;
+	};
+
+	ObjectsArray<IndexSegment> arrSegments(*getDefaultMemoryPool());
+
 	STORE (REQUEST_HANDLE tdgbl->handles_get_index_req_handle1)
 		X IN RDB$INDICES
 	{
@@ -6857,26 +6870,22 @@ bool get_index(BurpGlobals* tdgbl, const burp_rel* relation)
 				break;
 
 			case att_index_field_name:
-				STORE (REQUEST_HANDLE tdgbl->handles_get_index_req_handle2)
-					Y IN RDB$INDEX_SEGMENTS
-				{
-					GET_TEXT(Y.RDB$FIELD_NAME);
-					strcpy(Y.RDB$INDEX_NAME, X.RDB$INDEX_NAME);
-					Y.RDB$FIELD_POSITION = count++;
-
-					Y.RDB$SCHEMA_NAME.NULL = X.RDB$SCHEMA_NAME.NULL;
-					if (!X.RDB$SCHEMA_NAME.NULL)
-						strcpy(Y.RDB$SCHEMA_NAME, X.RDB$SCHEMA_NAME);
-
-					Y.RDB$PACKAGE_NAME.NULL = X.RDB$PACKAGE_NAME.NULL;
-					if (!X.RDB$PACKAGE_NAME.NULL)
-						strcpy(Y.RDB$PACKAGE_NAME, X.RDB$PACKAGE_NAME);
-				}
-				END_STORE
-				ON_ERROR
-					general_on_error ();
-				END_ERROR
+			{
+				BASED ON RDB$INDEX_SEGMENTS.RDB$FIELD_NAME segName;
+				GET_TEXT(segName);
+				auto& seg = arrSegments.add();
+				seg.name = segName;
 				break;
+			}
+
+			case att_index_field_char_length:
+			{
+				fb_assert(arrSegments.hasData());
+
+				auto& seg = arrSegments.back();
+				seg.length = get_int32(tdgbl);
+				break;
+			}
 
 			case att_index_description:
 				X.RDB$DESCRIPTION.NULL = FALSE;
@@ -6948,43 +6957,59 @@ bool get_index(BurpGlobals* tdgbl, const burp_rel* relation)
 		}
 
 		count = 0;
-		FOR (REQUEST_HANDLE tdgbl->handles_get_index_req_handle3)
-			RFR IN RDB$RELATION_FIELDS
-			CROSS IDS IN RDB$INDEX_SEGMENTS
-			WITH RFR.RDB$SCHEMA_NAME EQUIV NULLIF(relation->rel_name.schema.c_str(), '') AND
-				 RFR.RDB$PACKAGE_NAME EQUIV NULLIF(relation->rel_name.package.c_str(), '') AND
-				 RFR.RDB$RELATION_NAME = relation->rel_name.object.c_str() AND
-				 IDS.RDB$SCHEMA_NAME EQUIV RFR.RDB$SCHEMA_NAME AND
-				 IDS.RDB$PACKAGE_NAME EQUIV RFR.RDB$PACKAGE_NAME AND
-				 IDS.RDB$FIELD_NAME = RFR.RDB$FIELD_NAME AND
-				 IDS.RDB$INDEX_NAME = index_name
+		for (const auto& seg : arrSegments)
 		{
-			count++;
-		}
-		END_FOR
-		ON_ERROR
-			general_on_error ();
-		END_ERROR
-
-		if (count != segments)
-		{
-			FOR (REQUEST_HANDLE tdgbl->handles_get_index_req_handle4)
-				IDS IN RDB$INDEX_SEGMENTS
-				WITH IDS.RDB$SCHEMA_NAME EQUIV NULLIF(relation->rel_name.schema.c_str(), '') AND
-					 IDS.RDB$PACKAGE_NAME EQUIV NULLIF(relation->rel_name.package.c_str(), '') AND
-					 IDS.RDB$INDEX_NAME = index_name
+			FOR (REQUEST_HANDLE tdgbl->handles_get_index_req_handle3)
+				RFR IN RDB$RELATION_FIELDS
+				WITH RFR.RDB$SCHEMA_NAME EQUIV NULLIF(relation->rel_name.schema.c_str(), '') AND
+					 RFR.RDB$PACKAGE_NAME EQUIV NULLIF(relation->rel_name.package.c_str(), '') AND
+					 RFR.RDB$RELATION_NAME = relation->rel_name.object.c_str() AND
+					 RFR.RDB$FIELD_NAME	= seg.name.c_str()
 			{
-				ERASE IDS;
-				ON_ERROR
-					general_on_error ();
-				END_ERROR
+				count++;
 			}
 			END_FOR
 			ON_ERROR
 				general_on_error ();
-
 			END_ERROR
+		};
+
+		if (count != segments)
 			return false;
+
+		count = 0;
+		for (const auto& seg : arrSegments)
+		{
+			STORE (REQUEST_HANDLE tdgbl->handles_get_index_req_handle2)
+				Y IN RDB$INDEX_SEGMENTS
+			{
+				strcpy(Y.RDB$FIELD_NAME, seg.name.c_str());
+
+				strcpy(Y.RDB$INDEX_NAME, X.RDB$INDEX_NAME);
+				Y.RDB$FIELD_POSITION = count++;
+
+				Y.RDB$SCHEMA_NAME.NULL = X.RDB$SCHEMA_NAME.NULL;
+				if (!X.RDB$SCHEMA_NAME.NULL)
+					strcpy(Y.RDB$SCHEMA_NAME, X.RDB$SCHEMA_NAME);
+
+				Y.RDB$PACKAGE_NAME.NULL = X.RDB$PACKAGE_NAME.NULL;
+				if (!X.RDB$PACKAGE_NAME.NULL)
+					strcpy(Y.RDB$PACKAGE_NAME, X.RDB$PACKAGE_NAME);
+
+				if (seg.length == 0)
+				{
+					Y.RDB$CHARACTER_LENGTH.NULL = TRUE;
+				}
+				else
+				{
+					Y.RDB$CHARACTER_LENGTH.NULL = FALSE;
+					Y.RDB$CHARACTER_LENGTH = seg.length;
+				}
+			}
+			END_STORE
+			ON_ERROR
+				general_on_error ();
+			END_ERROR
 		}
 	}
 	END_STORE

--- a/src/dsql/DdlNodes.epp
+++ b/src/dsql/DdlNodes.epp
@@ -7861,7 +7861,10 @@ void RelationNode::defineConstraint(thread_db* tdbb, DsqlCompilerScratch* dsqlSc
 				if (constraint.index->descending)
 					definition.descending = true;
 				definition.inactive = false;
-				definition.columns = constraint.columns;
+
+				for (const auto& column : constraint.columns)
+					definition.segments.add().name = column;
+
 				definition.refRelation = constraint.refRelation;
 				definition.refColumns = constraint.refColumns;
 
@@ -9882,15 +9885,11 @@ void CreateRelationNode::execute(thread_db* tdbb, DsqlCompilerScratch* dsqlScrat
 					definition.descending = indexNode->descending;
 					definition.inactive = !indexNode->active;
 
-					fb_assert(indexNode->columns);
+					fb_assert(indexNode->segments && indexNode->segments->hasData());
 					fb_assert(!indexNode->computed);
 					fb_assert(!indexNode->partial);
 
-					for (const auto indexColumn : indexNode->columns->items)
-					{
-						MetaName& column = definition.columns.add();
-						column = nodeAs<FieldNode>(indexColumn)->dsqlName;
-					}
+					definition.segments = *indexNode->segments;
 
 					indexList.push(CreateIndexNode::store(tdbb, indexList.getPool(), transaction,
 						addPackagedTableIndexClause->indexNode->name, definition));
@@ -13355,6 +13354,8 @@ MetaId StoreIndexNode::create(thread_db* tdbb, jrd_tra* transaction)
 			idx.idx_rpt[SEG.RDB$FIELD_POSITION].idx_itype =
 				DFW_assign_index_type(tdbb, indexName, gds_cvt_blr_dtype[FLD.RDB$FIELD_TYPE], text_type);
 
+			idx.idx_rpt[SEG.RDB$FIELD_POSITION].idx_length = SEG.RDB$CHARACTER_LENGTH;
+
 			// Initialize selectivity to zero. Otherwise random rubbish makes its way into database
 			idx.idx_rpt[SEG.RDB$FIELD_POSITION].idx_selectivity = 0;
 		}
@@ -13572,6 +13573,7 @@ MetaId StoreIndexNode::createExpression(thread_db* tdbb, jrd_tra* transaction)
 				DFW_assign_index_type(tdbb, indexName,
 					idx.idx_expression_desc.dsc_dtype,
 					idx.idx_expression_desc.getTextType());
+			idx.idx_rpt[0].idx_length = 0;
 			idx.idx_rpt[0].idx_selectivity = 0;
 		}
 		catch (const Exception&)
@@ -13761,15 +13763,15 @@ ModifyIndexNode* CreateIndexNode::store(thread_db* tdbb, MemoryPool& p, jrd_tra*
 
 		request2.reset(tdbb, drq_l_lfield, DYN_REQUESTS);
 
-		for (FB_SIZE_T i = 0; i < definition.columns.getCount(); ++i)
+		for (FB_SIZE_T i = 0; i < definition.segments.getCount(); ++i)
 		{
 			for (FB_SIZE_T j = 0; j < i; ++j)
 			{
-				if (definition.columns[i] == definition.columns[j])
+				if (definition.segments[i].name == definition.segments[j].name)
 				{
 					// msg 240 "Field %s cannot be used twice in index %s"
 					status_exception::raise(
-						Arg::PrivateDyn(240) << definition.columns[i] << IDX.RDB$INDEX_NAME);
+						Arg::PrivateDyn(240) << definition.segments[i].name << IDX.RDB$INDEX_NAME);
 				}
 			}
 
@@ -13781,11 +13783,12 @@ ModifyIndexNode* CreateIndexNode::store(thread_db* tdbb, MemoryPool& p, jrd_tra*
 				WITH F.RDB$SCHEMA_NAME EQ IDX.RDB$SCHEMA_NAME AND
 					 F.RDB$PACKAGE_NAME EQUIV NULLIF(definition.relation.package.c_str(), '') AND
 					 F.RDB$RELATION_NAME EQ IDX.RDB$RELATION_NAME AND
-					 F.RDB$FIELD_NAME EQ definition.columns[i].c_str() AND
+					 F.RDB$FIELD_NAME EQ definition.segments[i].name.c_str() AND
 					 GF.RDB$SCHEMA_NAME EQ F.RDB$FIELD_SOURCE_SCHEMA_NAME AND
 					 GF.RDB$FIELD_NAME EQ F.RDB$FIELD_SOURCE
 			{
 				ULONG length = 0;
+				const SSHORT segmentLen = definition.segments[i].length;
 
 				if (GF.RDB$FIELD_TYPE == blr_blob)
 				{
@@ -13807,25 +13810,42 @@ ModifyIndexNode* CreateIndexNode::store(thread_db* tdbb, MemoryPool& p, jrd_tra*
 					// Compute the length of the key segment allowing for international
 					// information. Note that we we must convert a <character set, collation>
 					// type to an index type in order to compute the length.
+
+					if (!segmentLen)
+						length = GF.RDB$FIELD_LENGTH;
+					else if (segmentLen > GF.RDB$CHARACTER_LENGTH)
+						status_exception::raise(Arg::Gds(isc_random) << "segment length greater than field length ");
+					else
+						length = segmentLen * GF.RDB$FIELD_LENGTH / GF.RDB$CHARACTER_LENGTH;
+
 					if (!F.RDB$COLLATION_ID.NULL)
 					{
 						length = INTL_key_length(tdbb,
 							INTL_TEXT_TO_INDEX(TTypeId(CSetId(GF.RDB$CHARACTER_SET_ID),
 								CollId(F.RDB$COLLATION_ID))),
-							GF.RDB$FIELD_LENGTH);
+							length);
 					}
 					else if (!GF.RDB$COLLATION_ID.NULL)
 					{
 						length = INTL_key_length(tdbb,
 							INTL_TEXT_TO_INDEX(TTypeId(CSetId(GF.RDB$CHARACTER_SET_ID),
 								CollId(GF.RDB$COLLATION_ID))),
-							GF.RDB$FIELD_LENGTH);
+							length);
 					}
-					else
-						length = GF.RDB$FIELD_LENGTH;
 				}
 				else
+				{
+					if (segmentLen)
+					{
+						string msg;
+						msg.printf("attempt to specify a length for non-text field %s in index %s",
+							definition.segments[i].name.c_str(), idxName.toQuotedString().c_str());
+
+						status_exception::raise(Arg::Gds(isc_random) << msg);
+					}
+
 					length = sizeof(double);
+				}
 
 				if (keyLength)
 				{
@@ -13865,15 +13885,13 @@ ModifyIndexNode* CreateIndexNode::store(thread_db* tdbb, MemoryPool& p, jrd_tra*
 			status_exception::raise(Arg::PrivateDyn(118) << idxName.toQuotedString());
 		}
 
-		if (definition.columns.hasData())
+		if (definition.segments.hasData())
 		{
 			request2.reset(tdbb, drq_s_idx_segs, DYN_REQUESTS);
 
 			SSHORT position = 0;
 
-			for (ObjectsArray<MetaName>::const_iterator segment(definition.columns.begin());
-				 segment != definition.columns.end();
-				 ++segment)
+			for (const auto& segment : definition.segments)
 			{
 				STORE(REQUEST_HANDLE request2 TRANSACTION_HANDLE transaction)
 					X IN RDB$INDEX_SEGMENTS
@@ -13885,7 +13903,11 @@ ModifyIndexNode* CreateIndexNode::store(thread_db* tdbb, MemoryPool& p, jrd_tra*
 						strcpy(X.RDB$PACKAGE_NAME, IDX.RDB$PACKAGE_NAME);
 
 					strcpy(X.RDB$INDEX_NAME, IDX.RDB$INDEX_NAME);
-					strcpy(X.RDB$FIELD_NAME, segment->c_str());
+					strcpy(X.RDB$FIELD_NAME, segment.name.c_str());
+
+					X.RDB$CHARACTER_LENGTH.NULL = (segment.length > 0 ? FALSE : TRUE);
+					X.RDB$CHARACTER_LENGTH = segment.length;
+
 					X.RDB$FIELD_POSITION = position++;
 				}
 				END_STORE
@@ -13906,7 +13928,7 @@ ModifyIndexNode* CreateIndexNode::store(thread_db* tdbb, MemoryPool& p, jrd_tra*
 
 			// If referring columns count <> referred columns return error.
 
-			if (definition.columns.getCount() != definition.refColumns.getCount())
+			if (definition.segments.getCount() != definition.refColumns.getCount())
 			{
 				// msg 133: "Number of referencing columns do not equal number of
 				// referenced columns
@@ -14031,7 +14053,7 @@ ModifyIndexNode* CreateIndexNode::store(thread_db* tdbb, MemoryPool& p, jrd_tra*
 				// of columns in referring index.
 
 				fb_assert(IND.RDB$SEGMENT_COUNT >= 0);
-				if (definition.columns.getCount() != ULONG(IND.RDB$SEGMENT_COUNT))
+				if (definition.segments.getCount() != ULONG(IND.RDB$SEGMENT_COUNT))
 				{
 					// msg 133: "Number of referencing columns do not equal number of
 					// referenced columns"
@@ -14059,7 +14081,7 @@ ModifyIndexNode* CreateIndexNode::store(thread_db* tdbb, MemoryPool& p, jrd_tra*
 			}
 		}
 
-		IDX.RDB$SEGMENT_COUNT = SSHORT(definition.columns.getCount());
+		IDX.RDB$SEGMENT_COUNT = SSHORT(definition.segments.getCount());
 	}
 	END_STORE
 
@@ -14105,7 +14127,7 @@ string CreateIndexNode::internalPrint(NodePrinter& printer) const
 	NODE_PRINT(printer, active);
 	NODE_PRINT(printer, concurrently);
 	NODE_PRINT(printer, relation);
-	NODE_PRINT(printer, columns);
+	NODE_PRINT(printer, segments);
 	NODE_PRINT(printer, computed);
 	NODE_PRINT(printer, partial);
 	NODE_PRINT(printer, createIfNotExistsOnly);
@@ -14156,16 +14178,9 @@ void CreateIndexNode::execute(thread_db* tdbb, DsqlCompilerScratch* dsqlScratch,
 	definition.inactive = !active;
 	definition.concurrently = concurrently;
 
-	if (columns)
+	if (segments && segments->hasData())
 	{
-		const NestConst<ValueExprNode>* ptr = columns->items.begin();
-		const NestConst<ValueExprNode>* const end = columns->items.end();
-
-		for (; ptr != end; ++ptr)
-		{
-			MetaName& column = definition.columns.add();
-			column = nodeAs<FieldNode>(*ptr)->dsqlName;
-		}
+		definition.segments = *segments;
 	}
 	else if (computed)
 	{
@@ -14254,28 +14269,29 @@ void CreateIndexNode::defineLocalTempIndex(thread_db* tdbb, DsqlCompilerScratch*
 		status_exception::raise(Arg::Gds(isc_no_dup) << name.toQuotedString());
 	}
 
-	if (columns->items.getCount() > MAX_INDEX_SEGMENTS)
-		status_exception::raise(Arg::Gds(isc_idx_key_err) << name.toQuotedString());
-
 	const auto& fields = ltt->hasPendingChanges ? ltt->pendingFields : ltt->fields;
 
-	for (const auto& col : columns->items)
+	if (segments)
 	{
-		const auto& colName = nodeAs<FieldNode>(col)->dsqlName;
+		if (segments->getCount() > MAX_INDEX_SEGMENTS)
+			status_exception::raise(Arg::Gds(isc_idx_key_err) << name.toQuotedString());
 
-		auto fieldIt = std::find_if(fields.begin(), fields.end(),
-			[&colName](const auto& field) { return field.name == colName; });
-
-		if (fieldIt == fields.end())
+		for (const auto& seg : *segments)
 		{
-			// Column not found in LTT
-			status_exception::raise(
-				Arg::Gds(isc_dyn_column_does_not_exist) << colName.c_str() << ltt->name.toQuotedString());
-		}
+			auto fieldIt = std::find_if(fields.begin(), fields.end(),
+				[&seg](const auto& field) { return field.name == seg.name; });
 
-		// Check if field type is indexable (no blobs or arrays)
-		if (fieldIt->desc.dsc_dtype == dtype_blob)
-			status_exception::raise(Arg::Gds(isc_blob_idx_err) << colName.c_str());
+			if (fieldIt == fields.end())
+			{
+				// Column not found in LTT
+				status_exception::raise(
+					Arg::Gds(isc_dyn_column_does_not_exist) << seg.name.c_str() << ltt->name.toQuotedString());
+			}
+
+			// Check if field type is indexable (no blobs or arrays)
+			if (fieldIt->desc.dsc_dtype == dtype_blob)
+				status_exception::raise(Arg::Gds(isc_blob_idx_err) << seg.name.c_str());
+		}
 	}
 
 	// Register undo action with the savepoint
@@ -14307,8 +14323,11 @@ void CreateIndexNode::defineLocalTempIndex(thread_db* tdbb, DsqlCompilerScratch*
 	newIndex.inactive = !active;
 	newIndex.id = ltt->nextIndexId++;
 
-	for (const auto& col : columns->items)
-		newIndex.columns.add(nodeAs<FieldNode>(col)->dsqlName);
+	if (segments)
+	{
+		for (const auto& seg : *segments)
+			newIndex.segments.add(seg);
+	}
 
 	// Post deferred work to create the actual B-tree structure
 	DFW_post_work(transaction, dfw_create_ltt_index, string(name.object.c_str()), name.schema, 0);

--- a/src/dsql/DdlNodes.h
+++ b/src/dsql/DdlNodes.h
@@ -36,6 +36,7 @@
 #include "../common/classes/array.h"
 #include "../common/classes/ByteChunk.h"
 #include "../common/classes/TriState.h"
+#include "../jrd/IndexSegment.h"
 #include "../jrd/Relation.h"
 #include "../jrd/Savepoint.h"
 #include "../dsql/errd_proto.h"
@@ -2022,6 +2023,27 @@ protected:
 class CreateIndexNode final : public DdlNode
 {
 public:
+	struct Segment: Jrd::IndexSegment, Printable
+	{
+		Segment(MemoryPool& pool) : Jrd::IndexSegment(pool)
+		{}
+
+		Segment(MemoryPool& pool, const IndexSegment& other) :
+			Jrd::IndexSegment(pool, other)
+		{}
+
+		Firebird::string internalPrint(NodePrinter& printer) const override
+		{
+			NODE_PRINT(printer, name);
+			if (length)
+				NODE_PRINT(printer, length);
+			return "Segment";
+		}
+	};
+
+	typedef Firebird::ObjectsArray<Segment> Segments;
+
+
 	struct Definition
 	{
 		Definition()
@@ -2035,7 +2057,7 @@ public:
 
 		QualifiedName index;
 		QualifiedName relation;
-		Firebird::ObjectsArray<MetaName> columns;
+		Segments segments;
 		Firebird::TriState unique;
 		Firebird::TriState descending;
 		Firebird::TriState inactive;
@@ -2087,7 +2109,7 @@ public:
 	bool active = true;
 	bool concurrently = false;
 	NestConst<RelationSourceNode> relation;
-	NestConst<ValueListNode> columns;
+	NestConst<Segments> segments;
 	NestConst<ValueSourceClause> computed;
 	NestConst<BoolSourceClause> partial;
 	bool createIfNotExistsOnly = false;

--- a/src/dsql/StmtNodes.cpp
+++ b/src/dsql/StmtNodes.cpp
@@ -1827,7 +1827,19 @@ DmlNode* DeclareLocalTableNode::parse(thread_db* tdbb, MemoryPool& pool, Compile
 					PAR_error(csb, Arg::Gds(isc_random) << "Invalid local table index segment count");
 
 				for (USHORT i = 0; i < segmentCount; ++i)
-					index.fieldIds.add(blrReader.getWord());
+				{
+					const auto code = blrReader.getByte();
+					if (code == blr_dcl_local_table_index_segment)
+						index.segments.add({ blrReader.getWord(), 0 });
+					else
+						PAR_error(csb, Arg::Gds(isc_random) << "Invalid local table index segment subcode");
+
+					if (blrReader.peekByte() == blr_dcl_local_table_index_seg_length)
+					{
+						blrReader.getByte();
+						index.segments.back().length = blrReader.getWord();
+					}
+				}
 
 				break;
 			}
@@ -1902,13 +1914,23 @@ DmlNode* DeclareLocalTableNode::parse(thread_db* tdbb, MemoryPool& pool, Compile
 
 			indexNames.add(index.name);
 
-			for (const auto fieldId : index.fieldIds)
+			for (const auto& segment: index.segments)
 			{
-				if (fieldId >= fieldCount)
+				if (segment.fieldId >= fieldCount)
 					PAR_error(csb, Arg::Gds(isc_random) << "Invalid local table index field id");
 
-				if (node->format->fmt_desc[fieldId].dsc_dtype == dtype_blob)
+				const auto fieldType = node->format->fmt_desc[segment.fieldId].dsc_dtype;
+				if (fieldType == dtype_blob)
 					PAR_error(csb, Arg::Gds(isc_random) << "BLOB fields cannot be indexed in local tables");
+
+				if (segment.length && fieldType > dtype_any_text)
+				{
+					string msg;
+					msg.printf("Attempt to specify a length for non-text field %s in index %s",
+						node->fieldNames[segment.fieldId].c_str(), index.name.toQuotedString().c_str());
+
+					PAR_error(csb, Arg::Gds(isc_random) << msg);
+				}
 			}
 		}
 	}
@@ -2091,12 +2113,19 @@ DeclareLocalTableNode* DeclareLocalTableNode::dsqlPass(DsqlCompilerScratch* dsql
 					}
 
 					if (field->dtype == dtype_blob)
-						status_exception::raise(Arg::Gds(isc_blob_idx_err) << segment.name.c_str());
+						status_exception::raise(Arg::Gds(isc_blob_idx_err) << index.name.c_str());
 
-					if (std::find(index.fieldIds.begin(), index.fieldIds.end(), field->fld_id) != index.fieldIds.end())
-						status_exception::raise(Arg::Gds(isc_key_field_err) << indexNode->name.toQuotedString());
+					const auto foundSeg = std::find_if(index.segments.begin(), index.segments.end(),
+						[field](const auto& seg) { return seg.fieldId == field->fld_id; });
 
-					index.fieldIds.add(field->fld_id);
+					if (foundSeg != index.segments.end())
+					{
+						// msg 240 "Field %s cannot be used twice in index %s"
+						status_exception::raise(
+							Arg::PrivateDyn(240) << field->fld_name.c_str() << index.name.toQuotedString());
+					}
+
+					index.segments.add({field->fld_id, segment.length});
 				}
 
 				break;
@@ -2166,10 +2195,19 @@ void DeclareLocalTableNode::genBlr(DsqlCompilerScratch* dsqlScratch)
 				flags |= blr_dcl_local_table_index_descending;
 
 			dsqlScratch->appendUChar(flags);
-			dsqlScratch->appendUChar(index.fieldIds.getCount());
+			dsqlScratch->appendUChar(index.segments.getCount());
 
-			for (const auto fieldId : index.fieldIds)
-				dsqlScratch->appendUShort(fieldId);
+			for (const auto& segment : index.segments)
+			{
+				dsqlScratch->appendUChar(blr_dcl_local_table_index_segment);
+				dsqlScratch->appendUShort(segment.fieldId);
+
+				if (segment.length)
+				{
+					dsqlScratch->appendUChar(blr_dcl_local_table_index_seg_length);
+					dsqlScratch->appendUShort(segment.length);
+				}
+			}
 		}
 
 		dsqlScratch->appendUChar(blr_end);
@@ -2313,7 +2351,7 @@ jrd_rel* DeclareLocalTableNode::getRelation(thread_db* tdbb, Request* request) c
 		const auto& index = indexes[i];
 		auto* idp = permanent->rel_indices.ensurePermanent(tdbb, i);
 		AutoPtr<IndexVersion> idv(FB_NEW_POOL(pool) IndexVersion(pool, idp));
-		idv->setLtt(tdbb, QualifiedName(index.name), index.unique, index.descending, index.fieldIds.getCount());
+		idv->setLtt(tdbb, QualifiedName(index.name), index.unique, index.descending, index.segments.getCount());
 		idp->storeObject(tdbb, idv, 0);
 		idv.release();
 	}
@@ -2332,7 +2370,7 @@ void DeclareLocalTableNode::getIndexDescription(thread_db* tdbb, FB_SIZE_T index
 
 	const auto& index = indexes[indexId];
 	idx->idx_id = indexId;
-	idx->idx_count = index.fieldIds.getCount();
+	idx->idx_count = index.segments.getCount();
 
 	if (index.unique)
 		idx->idx_flags |= idx_unique;
@@ -2340,14 +2378,15 @@ void DeclareLocalTableNode::getIndexDescription(thread_db* tdbb, FB_SIZE_T index
 	if (index.descending)
 		idx->idx_flags |= idx_descending;
 
-	for (FB_SIZE_T i = 0; i < index.fieldIds.getCount(); ++i)
+	for (FB_SIZE_T i = 0; i < index.segments.getCount(); ++i)
 	{
-		const auto fieldId = index.fieldIds[i];
-		const auto& desc = format->fmt_desc[fieldId];
+		const auto& segment = index.segments[i];
+		const auto& desc = format->fmt_desc[segment.fieldId];
 
-		idx->idx_rpt[i].idx_field = fieldId;
+		idx->idx_rpt[i].idx_field = segment.fieldId;
 		idx->idx_rpt[i].idx_itype = DFW_assign_index_type(tdbb, QualifiedName(index.name), desc.dsc_dtype,
 			desc.isText() ? desc.getTextType() : ttype_none);
+		idx->idx_rpt[i].idx_length = segment.length;
 	}
 }
 

--- a/src/dsql/StmtNodes.cpp
+++ b/src/dsql/StmtNodes.cpp
@@ -2058,7 +2058,7 @@ DeclareLocalTableNode* DeclareLocalTableNode::dsqlPass(DsqlCompilerScratch* dsql
 						ERRD_post(Arg::Gds(isc_no_dup) << indexNode->name.toQuotedString());
 				}
 
-				fb_assert(indexNode->columns);
+				fb_assert(indexNode->segments && indexNode->segments->hasData());
 
 				if (indexNode->segments->getCount() == 0 ||
 					indexNode->segments->getCount() > MAX_INDEX_SEGMENTS)

--- a/src/dsql/StmtNodes.h
+++ b/src/dsql/StmtNodes.h
@@ -374,24 +374,30 @@ public:
 class DeclareLocalTableNode final : public TypedNode<StmtNode, StmtNode::TYPE_DECLARE_LOCAL_TABLE>
 {
 public:
+	struct Segment
+	{
+		USHORT fieldId;
+		SSHORT length;
+	};
+
 	struct Index
 	{
 		explicit Index(MemoryPool& pool)
 			: name(pool),
-			  fieldIds(pool)
+			  segments(pool)
 		{
 		}
 
 		Index(MemoryPool& pool, const Index& other)
 			: name(pool, other.name),
-			  fieldIds(pool, other.fieldIds),
+			  segments(pool, other.segments),
 			  unique(other.unique),
 			  descending(other.descending)
 		{
 		}
 
 		MetaName name;
-		Firebird::Array<USHORT> fieldIds;
+		Firebird::Array<Segment> segments;
 		bool unique = false;
 		bool descending = false;
 	};

--- a/src/dsql/parse-conflicts.txt
+++ b/src/dsql/parse-conflicts.txt
@@ -1,1 +1,1 @@
-153 shift/reduce conflicts, 8 reduce/reduce conflicts.
+153 shift/reduce conflicts, 9 reduce/reduce conflicts.

--- a/src/dsql/parse.y
+++ b/src/dsql/parse.y
@@ -902,6 +902,8 @@ using namespace Firebird;
 	Jrd::SessionResetNode* sessionResetNode;
 	Jrd::ForRangeNode::Direction forRangeDirection;
 	Jrd::CreatePackageConstantNode* createPackageConstantNode;
+	Jrd::CreateIndexNode::Segments* indexSegments;
+	Jrd::CreateIndexNode::Segment* indexSegment;
 }
 
 %include types.y
@@ -1931,10 +1933,10 @@ index_definition($createIndexNode)
 
 %type index_column_expr(<createIndexNode>)
 index_column_expr($createIndexNode)
-	: column_list
-		{ $createIndexNode->columns = $1; }
-	| column_parens
-		{ $createIndexNode->columns = $1; }
+	: segment_list
+		{ $createIndexNode->segments = $1; }
+	| segment_parens
+		{ $createIndexNode->segments = $1; }
 	| computed_by '(' value ')'
 		{
  			$createIndexNode->computed = newNode<ValueSourceClause>();
@@ -1942,6 +1944,45 @@ index_column_expr($createIndexNode)
 			$createIndexNode->computed->source = makeParseStr(YYPOSNARG(2), YYPOSNARG(4));
 		}
 	;
+
+
+%type <indexSegments> segment_parens
+segment_parens
+	: '(' segment_list ')'	{ $$ = $2; }
+	;
+
+%type <indexSegments> segment_list
+segment_list
+	: single_segment
+		{
+			$$ = newNode<CreateIndexNode::Segments>();
+			$$->add(*$1);
+		}
+	| segment_list ',' single_segment
+		{
+			$1->add(*$3);
+			$$ = $1;
+		}
+	;
+
+
+%type <indexSegment> single_segment
+single_segment
+	: symbol_column_name
+		{
+			auto* segment = newNode<CreateIndexNode::Segment>();
+			segment->name = *$1;
+			$$ = segment;
+		}
+	| symbol_column_name '(' pos_short_integer ')'
+		{
+			auto* segment = newNode<CreateIndexNode::Segment>();
+			segment->name = *$1;
+			segment->length = $3;
+			$$ = segment;
+		}
+	;
+
 
 %type <boolSourceClause> index_condition_opt
 index_condition_opt
@@ -2609,12 +2650,12 @@ packaged_table_indexes($createRelationNode)
 
 %type packaged_table_index(<createRelationNode>)
 packaged_table_index($createRelationNode)
-	: unique_opt order_direction INDEX valid_symbol_name [YYVALID;] column_parens
+	: unique_opt order_direction INDEX valid_symbol_name [YYVALID;] segment_parens
 		{
 			const auto node = newNode<CreateIndexNode>(QualifiedName(*$4));
 			node->unique = $1;
 			node->descending = $2;
-			node->columns = $6;
+			node->segments = $6;
 
 			auto clause = newNode<RelationNode::AddPackagedTableIndexClause>(node);
 			$createRelationNode->clauses.add(clause);

--- a/src/include/firebird/impl/blr.h
+++ b/src/include/firebird/impl/blr.h
@@ -467,6 +467,8 @@
 #define blr_dcl_local_table_index		(unsigned char) 4
 #define blr_dcl_local_table_index_unique		(unsigned char) 1
 #define blr_dcl_local_table_index_descending	(unsigned char) 2
+#define blr_dcl_local_table_index_segment		(unsigned char) 3
+#define blr_dcl_local_table_index_seg_length	(unsigned char) 4
 
 #define blr_local_table_truncate	(unsigned char) 219
 #define blr_local_table_id			(unsigned char) 220

--- a/src/isql/isql.epp
+++ b/src/isql/isql.epp
@@ -1779,6 +1779,13 @@ SLONG ISQL_get_index_segments(TEXT* segs,
 				segs += fieldNameStrLen + 2;
 			}
 		}
+
+		const auto ilen = SEG.RDB$CHARACTER_LENGTH;
+		if (ilen)
+		{
+			const auto l = snprintf(segs, segs_end - segs + 1, "(%d)", ilen);
+			segs += l;
+		}
 	}
 	END_FOR
 	ON_ERROR

--- a/src/isql/show.epp
+++ b/src/isql/show.epp
@@ -4733,11 +4733,12 @@ static void show_index(const QualifiedMetaString& relationName,
  **************************************/
 
 	isqlGlob.printf(
-		"%s%s%s INDEX ON %s",
+		"%s%s%s%s INDEX ON %s",
 		IUTILS_name_to_string(indexName).c_str(),
 		(unique_flag & IDX_UNIQUE ? " UNIQUE" : ""),
 		(unique_flag & IDX_NOT_VALIDATED ? " NOT VALIDATED" : ""),
-		(index_type == 1 ? " DESCENDING" : ""), IUTILS_name_to_string(relationName).c_str());
+		(index_type == 1 ? " DESCENDING" : ""),
+		IUTILS_name_to_string(relationName).c_str());
 
 	// Get column names
 

--- a/src/jrd/IndexSegment.h
+++ b/src/jrd/IndexSegment.h
@@ -1,0 +1,52 @@
+/*
+ *  The contents of this file are subject to the Initial
+ *  Developer's Public License Version 1.0 (the "License");
+ *  you may not use this file except in compliance with the
+ *  License. You may obtain a copy of the License at
+ *  http://www.ibphoenix.com/main.nfs?a=ibphoenix&page=ibp_idpl.
+ *
+ *  Software distributed under the License is distributed AS IS,
+ *  WITHOUT WARRANTY OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing rights
+ *  and limitations under the License.
+ *
+ *  The Original Code was created by Vladyslav Khorsun
+ *  for the Firebird Open Source RDBMS project.
+ *
+ *  Copyright (c) 2026 Vladyslav Khorsun <fbvlad@gmail.com>
+ *  and all contributors signed below.
+ *
+ *  All Rights Reserved.
+ *  Contributor(s): ______________________________________.
+ */
+
+#ifndef JRD_INDEX_SEGMENT_H
+#define JRD_INDEX_SEGMENT_H
+
+#include "firebird.h"
+#include "../jrd/MetaName.h"
+#include "../common/classes/alloc.h"
+
+namespace Jrd
+{
+
+struct IndexSegment
+{
+	IndexSegment(MemoryPool& pool) :
+		name(pool)
+	{
+	}
+
+	IndexSegment(MemoryPool& pool, const IndexSegment& other) :
+		name(pool, other.name),
+		length(other.length)
+	{
+	}
+
+	MetaName name;
+	SSHORT length = 0;		// Length in characters, if zero - equal to the field's length
+};
+
+} // namespace Jrd
+
+#endif // JRD_INDEX_SEGMENT_H

--- a/src/jrd/LocalTemporaryTable.h
+++ b/src/jrd/LocalTemporaryTable.h
@@ -25,6 +25,7 @@
 
 #include "firebird.h"
 #include "../jrd/constants.h"
+#include "../jrd/IndexSegment.h"
 #include "../jrd/MetaName.h"
 #include "../jrd/QualifiedName.h"
 #include "../common/dsc.h"
@@ -82,19 +83,19 @@ namespace Jrd
 		public:
 			explicit Index(MemoryPool& pool)
 				: name(pool),
-				  columns(pool)
+				  segments(pool)
 			{
 			}
 
 			Index(MemoryPool& pool, const QualifiedName& aName)
 				: name(pool, aName),
-				  columns(pool)
+				  segments(pool)
 			{
 			}
 
 			Index(MemoryPool& pool, const Index& other)
 				: name(pool, other.name),
-				  columns(pool, other.columns),
+				  segments(pool, other.segments),
 				  unique(other.unique),
 				  descending(other.descending),
 				  inactive(other.inactive),
@@ -104,7 +105,7 @@ namespace Jrd
 
 		public:
 			QualifiedName name;
-			Firebird::ObjectsArray<MetaName> columns;
+			Firebird::ObjectsArray<IndexSegment> segments;
 			bool unique = false;
 			bool descending = false;
 			bool inactive = false;

--- a/src/jrd/btr.cpp
+++ b/src/jrd/btr.cpp
@@ -225,7 +225,7 @@ namespace
 static ULONG add_node(thread_db*, WIN*, index_insertion*, temporary_key*, RecordNumber*,
 					  ULONG*, ULONG*);
 static void compress(thread_db*, const dsc*, const SSHORT scale, temporary_key*,
-					 USHORT, bool, USHORT, bool*);
+					 USHORT, SSHORT, bool, USHORT, bool*);
 static USHORT compress_root(thread_db*, index_root_page*);
 static void copy_key(const temporary_mini_key*, temporary_mini_key*);
 static contents delete_node(thread_db*, WIN*, UCHAR*);
@@ -756,7 +756,7 @@ idx_e IndexKey::compose(Record* record, bool skipNewFormat)
 
 			m_key.key_flags |= key_empty;
 
-			compress(m_tdbb, desc_ptr, 0, &m_key, tail->idx_itype, descending, m_keyType, nullptr);
+			compress(m_tdbb, desc_ptr, 0, &m_key, tail->idx_itype, tail->idx_length, descending, m_keyType, nullptr);
 		}
 		else
 		{
@@ -795,7 +795,7 @@ idx_e IndexKey::compose(Record* record, bool skipNewFormat)
 					m_key.key_nulls |= 1 << n;
 				}
 
-				compress(m_tdbb, desc_ptr, 0, &temp, tail->idx_itype, descending, m_keyType, nullptr);
+				compress(m_tdbb, desc_ptr, 0, &temp, tail->idx_itype, tail->idx_length, descending, m_keyType, nullptr);
 
 				const UCHAR* q = temp.key_data;
 				for (USHORT l = temp.key_length; l; --l, --stuff_count)
@@ -1703,6 +1703,7 @@ bool BTR_description(thread_db* tdbb, Cached::Relation* relation, const index_ro
 		const irtd* key_descriptor = (irtd*) ptr;
 		idx_desc->idx_field = key_descriptor->irtd_field;
 		idx_desc->idx_itype = key_descriptor->irtd_itype;
+		idx_desc->idx_length = key_descriptor->irtd_length;
 		idx_desc->idx_selectivity = key_descriptor->irtd_selectivity;
 		ptr += sizeof(irtd);
 	}
@@ -2388,9 +2389,22 @@ USHORT BTR_key_length(thread_db* tdbb, jrd_rel* relation, index_desc* idx)
 			}
 			else
 			{
-				length = format->fmt_desc[tail->idx_field].dsc_length;
-				if (format->fmt_desc[tail->idx_field].dsc_dtype == dtype_varying) {
-					length = length - sizeof(SSHORT);
+				if (!tail->idx_length)
+				{
+					length = format->fmt_desc[tail->idx_field].dsc_length;
+					if (format->fmt_desc[tail->idx_field].dsc_dtype == dtype_varying) {
+						length = length - sizeof(SSHORT);
+					}
+				}
+				else if (tail->idx_itype == idx_metadata)
+				{
+					const auto cs = INTL_charset_lookup(tdbb, CS_METADATA);
+					length = tail->idx_length * cs->maxBytesPerChar();
+				}
+				else if (tail->idx_itype >= idx_first_intl_string)
+				{
+					const auto tt = INTL_texttype_lookup(tdbb, INTL_INDEX_TO_TEXT(tail->idx_itype));
+					length = tail->idx_length * tt->getCharSet()->maxBytesPerChar();
 				}
 			}
 
@@ -2437,9 +2451,23 @@ USHORT BTR_key_length(thread_db* tdbb, jrd_rel* relation, index_desc* idx)
 			length = Int128::getIndexKeyLength();
 			break;
 		default:
-			length = format->fmt_desc[tail->idx_field].dsc_length;
-			if (format->fmt_desc[tail->idx_field].dsc_dtype == dtype_varying)
-				length -= sizeof(SSHORT);
+			if (!tail->idx_length)
+			{
+				length = format->fmt_desc[tail->idx_field].dsc_length;
+				if (format->fmt_desc[tail->idx_field].dsc_dtype == dtype_varying)
+					length -= sizeof(SSHORT);
+			}
+			else if (tail->idx_itype == idx_metadata)
+			{
+				const auto cs = INTL_charset_lookup(tdbb, CS_METADATA);
+				length = tail->idx_length * cs->maxBytesPerChar();
+			}
+			else if (tail->idx_itype >= idx_first_intl_string)
+			{
+				const auto tt = INTL_texttype_lookup(tdbb, INTL_INDEX_TO_TEXT(tail->idx_itype));
+				length = tail->idx_length * tt->getCharSet()->maxBytesPerChar();
+			}
+
 			if (tail->idx_itype >= idx_first_intl_string)
 				length = INTL_key_length(tdbb, tail->idx_itype, length);
 			break;
@@ -2620,7 +2648,7 @@ idx_e BTR_make_key(thread_db* tdbb,
 
 		key->key_flags |= key_empty;
 
-		compress(tdbb, desc, scale ? *scale : 0, key, tail->idx_itype, descending, keyType, forceInclude);
+		compress(tdbb, desc, scale ? *scale : 0, key, tail->idx_itype, tail->idx_length, descending, keyType, forceInclude);
 
 		if (fuzzy && (key->key_flags & key_empty))
 		{
@@ -2653,7 +2681,7 @@ idx_e BTR_make_key(thread_db* tdbb,
 
 			temp.key_flags |= key_empty;
 
-			compress(tdbb, desc, scale ? *scale++ : 0, &temp, tail->idx_itype, descending,
+			compress(tdbb, desc, scale ? *scale++ : 0, &temp, tail->idx_itype, tail->idx_length, descending,
 				(n == count - 1 ?
 					keyType : ((idx->idx_flags & idx_unique) ? INTL_KEY_UNIQUE : INTL_KEY_SORT)),
 				forceInclude);
@@ -2779,7 +2807,7 @@ void BTR_make_null_key(thread_db* tdbb, const index_desc* idx, temporary_key* ke
 	// If the index is a single segment index, don't sweat the compound stuff
 	if ((idx->idx_count == 1) || (idx->idx_flags & idx_expression))
 	{
-		compress(tdbb, nullptr, 0, key, tail->idx_itype, descending, INTL_KEY_SORT, nullptr);
+		compress(tdbb, nullptr, 0, key, tail->idx_itype, tail->idx_length, descending, INTL_KEY_SORT, nullptr);
 	}
 	else
 	{
@@ -2793,7 +2821,7 @@ void BTR_make_null_key(thread_db* tdbb, const index_desc* idx, temporary_key* ke
 			for (; stuff_count; --stuff_count)
 				*p++ = 0;
 
-			compress(tdbb, nullptr, 0, &temp, tail->idx_itype, descending, INTL_KEY_SORT, nullptr);
+			compress(tdbb, nullptr, 0, &temp, tail->idx_itype, tail->idx_length, descending, INTL_KEY_SORT, nullptr);
 
 			const UCHAR* q = temp.key_data;
 			for (USHORT l = temp.key_length; l; --l, --stuff_count)
@@ -3879,6 +3907,7 @@ static void compress(thread_db* tdbb,
 					 const SSHORT matchScale,
 					 temporary_key* key,
 					 USHORT itype,
+					 SSHORT ilength,
 					 bool descending, USHORT key_type,
 					 bool* forceInclude)
 {
@@ -3976,6 +4005,35 @@ static void compress(thread_db* tdbb,
 				}
 				else if (itype >= idx_first_intl_string || itype == idx_metadata)
 				{
+					MoveBuffer substr;
+					dsc subDesc;
+					const dsc* pDesc = desc;
+
+					if (ilength)
+					{
+						// Get first ilength characters from a full string value
+
+						const USHORT fromLen = desc->dsc_length - (desc->dsc_dtype == dtype_varying ? sizeof(USHORT) : 0);
+						const UCHAR* from = desc->dsc_address + (desc->dsc_dtype == dtype_varying ? sizeof(USHORT) : 0);
+
+						CharSet* cs = INTL_charset_lookup(tdbb, desc->getCharSet());
+						const auto fromChars = cs->length(fromLen, from, false);
+						if (fromChars > ilength)
+						{
+							const auto maxLen = ilength * cs->maxBytesPerChar();
+
+							subDesc.makeText(maxLen, desc->getTextType());
+							subDesc.dsc_address = substr.getBuffer(maxLen);
+
+							subDesc.dsc_length = cs->substring(fromLen, from, maxLen, subDesc.dsc_address, 0, ilength);
+
+							pDesc = &subDesc;
+						}
+
+						if (forceInclude && (ilength <= fromChars))
+							*forceInclude = true;
+					}
+
 					DSC to;
 
 					// convert to an international byte array
@@ -3986,10 +4044,20 @@ static void compress(thread_db* tdbb,
 					to.setTextType(ttype_sort_key);
 					to.dsc_length = MIN(MAX_COLUMN_SIZE, MAX_KEY * 4);
 					ptr = to.dsc_address = reinterpret_cast<UCHAR*>(buffer.vary_string);
-					multiKeyLength = length = INTL_string_to_key(tdbb, itype, desc, &to, key_type);
+					multiKeyLength = length = INTL_string_to_key(tdbb, itype, pDesc, &to, key_type);
 				}
 				else
+				{
 					length = MOV_get_string(tdbb, desc, &ptr, &buffer, MAX_KEY);
+
+					if (ilength && ilength <= length)
+					{
+						length = ilength;
+
+						if (forceInclude)
+							*forceInclude = true;
+					}
+				}
 			}
 
 			if (key_type == INTL_KEY_MULTI_STARTING && multiKeyLength != 0)

--- a/src/jrd/btr.h
+++ b/src/jrd/btr.h
@@ -107,6 +107,7 @@ struct index_desc
 	{
 		USHORT idx_field;					// field id
 		USHORT idx_itype;					// data of field in index
+		USHORT idx_length;					// data length in characters, if set (non zero)
 		float idx_selectivity;				// segment selectivity
 	} idx_rpt[MAX_INDEX_SEGMENTS];
 };

--- a/src/jrd/dfw.epp
+++ b/src/jrd/dfw.epp
@@ -4914,7 +4914,7 @@ static bool create_ltt_index(thread_db* tdbb, SSHORT phase, DeferredWork* work, 
 	memset(&idx, 0, sizeof(idx));
 
 	idx.idx_id = lttIndex->id;
-	idx.idx_count = lttIndex->columns.getCount();
+	idx.idx_count = lttIndex->segments.getCount();
 	idx.idx_flags = 0;
 
 	if (lttIndex->unique)
@@ -4925,14 +4925,14 @@ static bool create_ltt_index(thread_db* tdbb, SSHORT phase, DeferredWork* work, 
 	// Build the index key descriptors from LTT field info
 	int keyPos = 0;
 
-	for (const auto& colName : lttIndex->columns)
+	for (const auto& segment : lttIndex->segments)
 	{
 		// Find the field in the LTT
 		bool found = false;
 
 		for (const auto& field : ltt->fields)
 		{
-			if (field.name == colName)
+			if (field.name == segment.name)
 			{
 				idx.idx_rpt[keyPos].idx_field = field.id;
 
@@ -4942,7 +4942,9 @@ static bool create_ltt_index(thread_db* tdbb, SSHORT phase, DeferredWork* work, 
 					DTYPE_IS_TEXT(field.desc.dsc_dtype) ?
 						TTypeId(field.charSetId.value_or(CS_NONE), field.collationId.value_or(COLLATE_NONE)) :
 						ttype_none);
+
 				idx.idx_rpt[keyPos].idx_itype = idxType;
+				idx.idx_rpt[keyPos].idx_length = segment.length;
 
 				found = true;
 				break;

--- a/src/jrd/ini.epp
+++ b/src/jrd/ini.epp
@@ -1743,6 +1743,7 @@ static void store_indices(thread_db* tdbb, USHORT odsVersion)
 					PAD(field->fld_name, Y.RDB$FIELD_NAME);
 					tail->idx_field = segment->ini_idx_rfld_id;
 					tail->idx_itype = segment->ini_idx_type;
+					tail->idx_length = 0;
 				    tail->idx_selectivity = 0;
 				}
 				END_STORE

--- a/src/jrd/met.epp
+++ b/src/jrd/met.epp
@@ -5176,7 +5176,7 @@ void IndexVersion::setLtt(thread_db* tdbb, LocalTemporaryTable::Index* lttIndex)
 
 	idv_name = lttIndex->name;
 	idv_uniqFlag = lttIndex->unique;
-	idv_segmentCount = lttIndex->columns.getCount();
+	idv_segmentCount = lttIndex->segments.getCount();
 	idv_type = lttIndex->descending;
 	idv_active = lttIndex->inactive ? MET_index_inactive : MET_index_active;
 }

--- a/src/jrd/ods.h
+++ b/src/jrd/ods.h
@@ -458,13 +458,15 @@ struct irtd
 {
 	USHORT irtd_field;
 	USHORT irtd_itype;
+	USHORT irtd_length;				// length in characters, if not zero
 	float irtd_selectivity;
 };
 
-static_assert(sizeof(struct irtd) == 8, "struct irtd size mismatch");
+static_assert(sizeof(struct irtd) == 12, "struct irtd size mismatch");
 static_assert(offsetof(struct irtd, irtd_field) == 0, "irtd_field offset mismatch");
 static_assert(offsetof(struct irtd, irtd_itype) == 2, "irtd_itype offset mismatch");
-static_assert(offsetof(struct irtd, irtd_selectivity) == 4, "irtd_selectivity offset mismatch");
+static_assert(offsetof(struct irtd, irtd_length) == 4, "irtd_length offset mismatch");
+static_assert(offsetof(struct irtd, irtd_selectivity) == 8, "irtd_selectivity offset mismatch");
 
 // possible index states
 inline constexpr UCHAR irt_unused		= 0;	// empty slot

--- a/src/jrd/relations.h
+++ b/src/jrd/relations.h
@@ -86,6 +86,7 @@ RELATION(nam_i_segments, rel_segments, ODS_8_0, rel_persistent)
 	FIELD(f_seg_statistics, nam_statistics, fld_statistics, 1, ODS_11_0)
 	FIELD(f_seg_schema, nam_sch_name, fld_sch_name, 1, ODS_14_0)
 	FIELD(f_seg_pkg_name, nam_pkg_name, fld_pkg_name, 1, ODS_14_0)
+	FIELD(f_seg_char_length, nam_char_length, fld_f_length, 1, ODS_14_0)
 END_RELATION
 
 // Relation 4 (RDB$INDICES)


### PR DESCRIPTION
With this feature it is possible to create index on long text columns specifying max count of leading characters of string that is included into index key.

The syntax for index segment definition: `<column> [(<length>)]`, where `column` is table column name and `length` is optional maximum count of characters included into index key.

The `length` could be set for CHAR | VARCHAR | BINARY | VARBINARY types, blobs is not supported currently.


ODS changes:

1. The new column `RDB$INDEX_SEGMENTS.RDB$CHARACTER_LENGTH`  
2. The new field `irtd_length` in index key descriptor, see `struct Ods::irtd`
