### PR TITLE
Reject embedded NUL characters in DSQL statements

### DIFF
--- a/src/dsql/Parser.cpp
+++ b/src/dsql/Parser.cpp
@@ -407,6 +407,10 @@ int Parser::yylexAux()
 	}
 
 	SSHORT c = lex.ptr[-1];
+
+	if (c == '\0')
+		yyabandon(yyposn, -104, isc_token_err);
+
 	UCHAR tok_class = classes(c);
 	char string[MAX_TOKEN_LEN];
 


### PR DESCRIPTION
Previously, an embedded NUL was treated as EOF, causing the remainder of the statement to be silently ignored. Report a lexer error instead.