### PR TITLE
Add description for "local" trace flag

### DIFF
--- a/doc/README.services_extension
+++ b/doc/README.services_extension
@@ -146,6 +146,7 @@ List of existing trace sessions
 			if the session was created by the engine itself : "system"
 			kind of session : "audit" or "trace"
 			if user session log file is full : "log full"
+			if the user session is started on the same machine where the server is located: "local"
 		"plugins" is a set of plugins for use with trace session
 			Plugins can be specified via API/tracemgr.
 			By default, plugins form the firebird.conf (TracePlugin) are used


### PR DESCRIPTION
The flag "local" was added in  https://github.com/FirebirdSQL/firebird/commit/141db7610f5653afed791c6275621d75f2a7ed9b, but the description is missing
This PR should also be ported to the v5 branch.